### PR TITLE
Add term dropdown event management

### DIFF
--- a/app/controllers/events/routes.py
+++ b/app/controllers/events/routes.py
@@ -9,13 +9,11 @@ from app.logic.getUpcomingEvents import getUpcomingEventsForUser
 def events(term):
 
     eventsDict = groupEventsByCategory(term)
-    print(eventsDict)
     listOfTerms = Term.select()
-    termName = Term.get_by_id(term).description
 
     return render_template("/events/event_list.html",
+        selectedTerm = Term.get_by_id(term),
         eventDict = eventsDict,
-        termName = termName,
         listOfTerms = listOfTerms,
         user = g.current_user)
 

--- a/app/templates/events/event_list.html
+++ b/app/templates/events/event_list.html
@@ -12,15 +12,21 @@
 {% endblock %}
 {% block app_content %}
 
-
 <h1 class="text-center">Events List for {{selectedTerm.description}}</h1>
-<div class="d-inline-flex container justify-content-center">
-  <div class="form-group d-inline"><strong>Term *</strong>
-    <select class="form-control" name='eventTerm' id='inputTerm' onchange="location = this.value;">
-      {% for term in listOfTerms %}
-        <option value='/events/{{term}}/' {{ "selected" if selectedTerm.id == term.id }}>{{term.description}} </option>
-      {% endfor %}
-    </select>
+<div class="container-fluid px-1 py-3">
+  <div class="row d-flex align-items-baseline p-3">
+    <div class="col-md-1 ps-1 ms-auto">
+      <h4><strong>Term</strong></h4>
+    </div>
+    <div class="col-md-3 me-auto">
+      <div class="form-group">
+        <select class="form-control" name='eventTerm' id='inputTerm' onchange="location = this.value;">
+          {% for term in listOfTerms %}
+            <option value='/events/{{term}}/' {{ "selected" if selectedTerm.id == term.id }}>{{term.description}} </option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/app/templates/events/event_list.html
+++ b/app/templates/events/event_list.html
@@ -13,9 +13,19 @@
 {% block app_content %}
 
 
-<h1 class="text-center">Event List for {{termName}}</h1>
+<h1 class="text-center">Events List for {{selectedTerm.description}}</h1>
+<div class="d-inline-flex container justify-content-center">
+  <div class="form-group d-inline"><strong>Term *</strong>
+    <select class="form-control" name='eventTerm' id='inputTerm' onchange="location = this.value;">
+      {% for term in listOfTerms %}
+        <option value='/events/{{term}}/' {{ "selected" if selectedTerm.id == term.id }}>{{term.description}} </option>
+      {% endfor %}
+    </select>
+  </div>
+</div>
+
 <div>
-  <ul class="nav nav-pills nav-fill mb-3" id="pills-tab" role="tablist">
+  <ul class="nav nav-pills nav-fill mx-3 mb-3" id="pills-tab" role="tablist">
   <li class="nav-item" role="presentation">
     <button class="nav-link active" id="studentLedEvents"
     data-bs-toggle="pill" data-bs-target="#pills-student-led" type="button" role="tab" aria-controls="pills-student-led" aria-selected="true">Student Led Service</button>

--- a/tests/code/test_eventList.py
+++ b/tests/code/test_eventList.py
@@ -11,6 +11,7 @@ def test_termDoesNotExist():
     with pytest.raises(DoesNotExist):
         groupedEvents = groupEventsByCategory(7)
         groupedEvents2 = groupEventsByCategory("khatts")
+        groupedEvents3 = groupedEventsByCategory("")
 
 @pytest.mark.integration
 def test_groupEventsByProgram():

--- a/tests/code/test_eventList.py
+++ b/tests/code/test_eventList.py
@@ -10,7 +10,11 @@ from app.models.term import Term
 def test_termDoesNotExist():
     with pytest.raises(DoesNotExist):
         groupedEvents = groupEventsByCategory(7)
+
+    with pytest.raises(DoesNotExist):
         groupedEvents2 = groupEventsByCategory("khatts")
+
+    with pytest.raises(DoesNotExist):
         groupedEvents3 = groupedEventsByCategory("")
 
 @pytest.mark.integration


### PR DESCRIPTION
**Note:** Review this PR after PR #58 - Volunteer event management all event page

**Problem:** The user should be able to select a term from a term dropdown on the All events page. The selected term should match the programs that are in that term. Also, by selecting the term, the term name in the heading should be changed to the term selected by the user.

**Solution:** In the event_list.html file, we implemented a dropdown for the term selection. Once the term is selected, it will be passed to the controller to get the correct events that belong to that term. The page will load those events that are included in that term. 

**Testing:** Navigate to /events/<programid> and select any term, and the page should load the events that are in that term and display that term's name in the heading.
