### PR TITLE
Connected edit events and track volunteers page.

### DIFF
--- a/app/templates/admin/createEvents.html
+++ b/app/templates/admin/createEvents.html
@@ -20,7 +20,7 @@
     <h2> New Event Form</h2>
   </div>
 
-  {% if 'edit_event' in request.path %}
+  {% if 'edit_event' in request.path and g.current_user.isCeltsAdmin or g.current_user.isCeltsStudentStaff %}
   <div class="btn-group">
     <ul class="nav nav-pills nav-fill mx-3 mb-3" id="pills-tab" role="tablist">
       <li class="nav-item" role="presentation">

--- a/app/templates/admin/createEvents.html
+++ b/app/templates/admin/createEvents.html
@@ -20,7 +20,7 @@
     <h2> New Event Form</h2>
   </div>
 
-  {% if 'edit_event' in request.path and g.current_user.isCeltsAdmin or g.current_user.isCeltsStudentStaff %}
+  {% if 'edit_event' in request.path and (g.current_user.isCeltsAdmin or g.current_user.isCeltsStudentStaff) %}
   <div class="btn-group">
     <ul class="nav nav-pills nav-fill mx-3 mb-3" id="pills-tab" role="tablist">
       <li class="nav-item" role="presentation">

--- a/app/templates/admin/createEvents.html
+++ b/app/templates/admin/createEvents.html
@@ -21,16 +21,16 @@
   </div>
 
   {% if 'edit_event' in request.path and (g.current_user.isCeltsAdmin or g.current_user.isCeltsStudentStaff) %}
-  <div class="btn-group">
-    <ul class="nav nav-pills nav-fill mx-3 mb-3" id="pills-tab" role="tablist">
-      <li class="nav-item" role="presentation">
-        <a class="nav-link active" href="#">Edit Event</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" aria-current="page" href="/{{program.id}}/{{eventInfo.id}}/track_volunteers">Track Volunteers</a>
-      </li>
-    </ul>
-  </div>
+    <div class="btn-group">
+      <ul class="nav nav-pills nav-fill mx-3 mb-3" id="pills-tab" role="tablist">
+        <li class="nav-item" role="presentation">
+          <a class="nav-link active" href="#">Edit Event</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" aria-current="page" href="/{{program.id}}/{{eventInfo.id}}/track_volunteers">Track Volunteers</a>
+        </li>
+      </ul>
+    </div>
   {% endif %}
 
   <form action="/{{program.id}}/{{eventId}}/deleteEvent" method='post'>

--- a/app/templates/admin/createEvents.html
+++ b/app/templates/admin/createEvents.html
@@ -19,6 +19,20 @@
     <h1 id ="title">{{program.programName}}</h1>
     <h2> New Event Form</h2>
   </div>
+
+  {% if 'edit_event' in request.path %}
+  <div class="btn-group">
+    <ul class="nav nav-pills nav-fill mx-3 mb-3" id="pills-tab" role="tablist">
+      <li class="nav-item" role="presentation">
+        <a class="nav-link active" href="#">Edit Event</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" aria-current="page" href="/{{program.id}}/{{eventInfo.id}}/track_volunteers">Track Volunteers</a>
+      </li>
+    </ul>
+  </div>
+  {% endif %}
+
   <form action="/{{program.id}}/{{eventId}}/deleteEvent" method='post'>
     <input type="{{deleteButton}}" class="btn btn-danger float-end" value="Cancel Event"/>
     <div>

--- a/app/templates/events/trackVolunteers.html
+++ b/app/templates/events/trackVolunteers.html
@@ -15,9 +15,9 @@
   <h3 align="center">{{event.eventName}}</h3><br>
 
   <div class="btn-group">
-    <ul class="nav nav-tabs">
-      <li class="nav-item">
-        <a class="nav-link" href="https://google.com">Event Form</a> <!--FIXME: link to event page-->
+    <ul class="nav nav-pills nav-fill mx-3 mb-3" id="pills-tab" role="tablist">
+      <li class="nav-item" role="presentation">
+        <a class="nav-link" href="/{{program.id}}/{{event.id}}/edit_event">Edit Event</a>
       </li>
       <li class="nav-item">
         <a class="nav-link active" aria-current="page" href="#">Track Volunteers</a>
@@ -25,86 +25,87 @@
     </ul>
   </div>
 
-  <form action="#" method="post"><br>
+  <form action="#" method="post">
 
-    <label class='d-none' id="eventLength">{{eventLength}}</label>
-    <input  class="form-control" id="eventID" name="event" value="{{event}}" type='hidden'>
+    <div class='row p-4'>
+      <label class='d-none' id="eventLength">{{eventLength}}</label>
+      <input  class="form-control" id="eventID" name="event" value="{{event}}" type='hidden'>
 
 
-    <div class="ui-widget input-group">
-      <input id="trackVolunteersInput" type="input" placeholder="Search">
-      <span class="input-group-text" style="padding:0 0 0 0rem;"><i class="bi bi-search" style="margin-left:-35px;"></i></span>
-      <div><button type="button" class="btn btn-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#addVolunteerModal">
-          <i class="bi bi-plus-circle"></i>
-      </button></div>
-    </div>
+      <div class="ui-widget input-group">
+        <input id="trackVolunteersInput" type="input" placeholder="Search">
+        <span class="input-group-text" style="padding:0 0 0 0rem;"><i class="bi bi-search" style="margin-left:-35px;"></i></span>
+        <div><button type="button" class="btn btn-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#addVolunteerModal">
+            <i class="bi bi-plus-circle"></i>
+        </button></div>
+      </div>
 
-  <!-- Modal -->
-  <div class="modal fade" id="addVolunteerModal" tabindex="-1" aria-labelledby="addVolunteerModalLabel" aria-hidden="true" style="width:-60px;">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title" id="exampleModalLabel">Add a volunteer</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-        </div>
-        <div class="modal-body">
-          <div class="input-group">
-            <div class="form-group input-group-x form-outline ui-widget" style="width:80%;">
-              <input type="input" id="addVolunteerInput" class="form-control" placeholder="Search" oninput="searchVolunteers()" autocomplete="off"/>
-            </div>
-            <button type="button" class="btn btn-primary btn-sm"><i class="bi bi-search" style="margin-left:0px;"></i>
-            </button>
+    <!-- Modal -->
+    <div class="modal fade" id="addVolunteerModal" tabindex="-1" aria-labelledby="addVolunteerModalLabel" aria-hidden="true" style="width:-60px;">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="exampleModalLabel">Add a volunteer</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-          <button id="selectVolunteerButton" type="button" class="btn btn-primary" disabled>Add participant</button>
+          <div class="modal-body">
+            <div class="input-group">
+              <div class="form-group input-group-x form-outline ui-widget" style="width:80%;">
+                <input type="input" id="addVolunteerInput" class="form-control" placeholder="Search" oninput="searchVolunteers()" autocomplete="off"/>
+              </div>
+              <button type="button" class="btn btn-primary btn-sm"><i class="bi bi-search" style="margin-left:0px;"></i>
+              </button>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            <button id="selectVolunteerButton" type="button" class="btn btn-primary" disabled>Add participant</button>
+          </div>
         </div>
       </div>
     </div>
-  </div>
 
 
-    <div>
-      <table class="table">
-        <thead>
-          <tr>
-            <th>Present</th>
-            <th>Name</th>
-            <th>Email</th>
-            <th>Phone Number</th>
-            <th>RSVP</th>
-            <th>Total Hours</th>
-            <th></th>
-          </tr>
-        </thead>
-      <tbody id="volunteerTable">
-      {% for participant in eventParticipantsData%}
-      <tr>
-        <td><input type="checkbox" id='checkbox_{{participant.user.username}}' name="checkbox_{{participant.user.username}}"
-                   onChange='toggleVolunteersInputBox(this)' {% if participant.attended == 1 %} checked  {%endif%}></td>
+      <div>
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Present</th>
+              <th>Name</th>
+              <th>Email</th>
+              <th>Phone Number</th>
+              <th>RSVP</th>
+              <th>Total Hours</th>
+              <th></th>
+            </tr>
+          </thead>
+        <tbody id="volunteerTable">
+        {% for participant in eventParticipantsData%}
+        <tr>
+          <td><input type="checkbox" id='checkbox_{{participant.user.username}}' name="checkbox_{{participant.user.username}}"
+                     onChange='toggleVolunteersInputBox(this)' {% if participant.attended == 1 %} checked  {%endif%}></td>
 
-        <td><input class="form-control" type='hidden' name="username{{loop.index|string}}" id="{{participant.user.username}}"value="{{participant.user}}"> {{participant.user.firstName}} {{participant.user.lastName}}</td>
-        <td>{{participant.user.email}}</td>
-        <td>{{participant.user.phoneNumber}}</td>
+          <td><input class="form-control" type='hidden' name="username{{loop.index|string}}" id="{{participant.user.username}}"value="{{participant.user}}"> {{participant.user.firstName}} {{participant.user.lastName}}</td>
+          <td>{{participant.user.email}}</td>
+          <td>{{participant.user.phoneNumber}}</td>
 
-        <td>{% if participant.rsvp == 1 %} Yes {% else %} No {% endif %}</td>
+          <td>{% if participant.rsvp == 1 %} Yes {% else %} No {% endif %}</td>
 
-        <td><input class="form-control number-only form-control input-sm" id="inputHours_{{participant.user.username}}"
-                   name="inputHours_{{participant.user.username}}" style="max-width: 90px;" type ="number" min="0" step="0.01"
-                   {% if participant.attended == 1 and participant.hoursEarned == None %} value="{{eventLength}}"
-                   {% elif participant.attended == 1 %} value="{{participant.hoursEarned}}"
-                   {%else%} readonly {%endif%}></td>
-        <td><span onclick = 'removeVolunteerFromEvent(this)' id="deleteIcon_{{participant.user.username}}" ><i class="bi bi-trash" style="font-size:20px"></i></span></td>
-      </tr>
-      {%endfor%}
-     </tbody>
-      </table>
+          <td><input class="form-control number-only form-control input-sm" id="inputHours_{{participant.user.username}}"
+                     name="inputHours_{{participant.user.username}}" style="max-width: 90px;" type ="number" min="0" step="0.01"
+                     {% if participant.attended == 1 and participant.hoursEarned == None %} value="{{eventLength}}"
+                     {% elif participant.attended == 1 %} value="{{participant.hoursEarned}}"
+                     {%else%} readonly {%endif%}></td>
+          <td><span onclick = 'removeVolunteerFromEvent(this)' id="deleteIcon_{{participant.user.username}}" ><i class="bi bi-trash" style="font-size:20px"></i></span></td>
+        </tr>
+        {%endfor%}
+       </tbody>
+        </table>
+      </div>
+
+      <div>
+        <button type="submit" class="btn btn-primary float-end">Save</button>
+      </div>
     </div>
-
-    <div>
-      <button type="submit" class="btn btn-primary float-end">Save</button>
-    </div>
-
   </form>
 {% endblock %}


### PR DESCRIPTION
This PR resolves issue #69 
Summary:
Changed nav-tabs in the track volunteer page to be nav-pill instead. Added nav pills to edit_event page. There are now two nav-pills in the track volunteer page and the edit event page. One called 'Edit Event' and another called 'Track Volunteers'. Clicking on one will lead to its respective page.

To test:
go to `HTTP://<yourIp>:8080/<programID>/<eventID>/track_volunteers` or `HTTP://<yourIp>:8080/<programID>/<eventID>/edit_event` make sure that the current user is either a celtsStudentStaff or celtsAdmin.
Click on the nav pills and it should take you to the appropriate page.