### PR TITLE
Admins cannot create events in the past

### DIFF
--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -27,6 +27,7 @@ $(document).ready(function(){
     });
 
   $.datepicker.setDefaults({
+    minDate:  new Date($.now()),
     dateFormat:'mm-dd-yy'
   });
 
@@ -85,6 +86,7 @@ function updateDate(obj) { // updates max and min dates of the datepickers as th
   if(obj.id == "endDatePicker"){
     var newDay = dateToChange.getDate();
     $("#startDatePicker").datepicker({maxDate: new Date(  newYear, newMonth, newDay)});
+
     $("#startDatePicker").datepicker("option", "maxDate", new Date(  newYear, newMonth, newDay));
   }
   if(obj.id == "startDatePicker"){

--- a/app/templates/admin/createEvents.html
+++ b/app/templates/admin/createEvents.html
@@ -116,7 +116,7 @@
                 </div>
               </div>
 
-              <div class="d-inline-flex" id ="endDateStyle" style="width:51%;">
+              <div class="d-inline-flex d-none" id ="endDateStyle" style="width:51%;">
                 <!--datePicker for End date-->
                 <label for="endDatePicker" id="endDatePickerLabel" style="padding:0 0 0 2rem" ><span><strong>End Date *</strong></span></label>
                 <div class='input-group date' {{'id=endDate' if user.isCeltsAdmin or user.isCeltsStudentStaff }}>


### PR DESCRIPTION
Summary:
PR for  issue #71
Changed the start date of the create event page so that admins cannot create events in the past. Admins can only create events now or in the future. 

Test:
Go to http://IPAddress/1/create_event, and click on StartDate and you will see that the date picker starts from the current date and not from previous dates in the calendar.
