### PR TITLE
fixed the interest switches

### DIFF
--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -16,7 +16,7 @@ def home():
 def volunteerIndicateInterest():
     programs = Program.select()
     interests = Interest.select().where(Interest.user == g.current_user)
-    interests_ids = [interest.program for interest in interests]
+    interests_ids = [interest.program.id for interest in interests]
     return render_template('volunteerIndicateInterest.html',
                            title="Volunteer Interest",
                            user = g.current_user,


### PR DESCRIPTION
Fixes issue #101: Volunteer Interest switches not updating on the page.

Solution: We found out that the data type of the interests_ids was a model instead of integers. We added `.id` to `interest.program` so that the interest id is an integer.

Test:
navigate to /volunteerIndicateInterest, the toggle of the programs Berea Buddies and Adopt A Grandparent should be blue. Then switch the toggle of Berea Buddies program and refresh the page. Only Adopt A Grandparent should be blue. 