### PR TITLE
Fixed test_participants.py Test Failure

### DIFF
--- a/tests/code/test_participants.py
+++ b/tests/code/test_participants.py
@@ -221,5 +221,5 @@ def test_sendKioskDataKiosk():
 
     assert "bryanta" in listOfAttended2
 
-    deleteInstance = EventParticipant.get(EventParticipant.user == "bryanta")
+    deleteInstance = EventParticipant.get(EventParticipant.user == "bryanta", EventParticipant.event_id == 2)
     deleteInstance.delete_instance()


### PR DESCRIPTION
I added an extra parameter to the .get() that was querying the EventParticipant table for the entry to delete that it just created.  It was getting the wrong entry since there was already an entry that appeared before it with the "bryanta" username, so I added the event_id that the correct entry that needed to be deleted was tied to.