### PR TITLE
Fixes Sidebar Breaking on Smaller Screens

### DIFF
--- a/app/static/css/sidebar.css
+++ b/app/static/css/sidebar.css
@@ -16,7 +16,6 @@
     display: flex;
     flex-wrap: nowrap;
     height: 100vh;
-    height: -webkit-fill-available;
     max-height: 100vh;
     overflow-x: auto;
     overflow-y: hidden;


### PR DESCRIPTION
* Fixes issue #108 
* **Summary**: The sidebar css had `-webkit-fill-available` the `fill-available` part is apparently changed to `stretch`, which in the documentation says is experimental for now and the behavior might change in the future. To fix the issue we took out that whole code because we already have `height: 100vh;` which will fill the whole sidebar area, regardless of browser. 