### PR TITLE
Create Back button on Kiosk page

### DIFF
--- a/app/templates/events/eventKiosk.html
+++ b/app/templates/events/eventKiosk.html
@@ -22,7 +22,8 @@
     <input type="text" id="submitScannerData" name="bNumber" class="input-lg form-control" oninput="submitData()" style="font-size: 2rem;" placeholder="Scanner Kiosk Sign-in" aria-label="Enter scanner data" autofocus/>
   </div>
   <div class="form-check form-switch mt-5 mx-5 position-absolute end-0">
-    <input class="form-check-input" type="checkbox" id="fullscreenCheck" onclick="toggleFullscreen()">
+    <input class="form-check-input mt-2" type="checkbox" id="fullscreenCheck" onclick="toggleFullscreen()">
     <label class="form-check-label" id="fullscreenLabel" for="fullscreenCheck">Toggle Full Screen</label>
+    <a class="btn btn-secondary ms-3" href= "/event/{{event.id}}/track_volunteers" role="button">Back</a>
   </div>
   {% endblock %}

--- a/app/templates/events/eventKiosk.html
+++ b/app/templates/events/eventKiosk.html
@@ -16,14 +16,15 @@
     <h2 class="m-5" align="center">{{bNumberToUser}}</h2>
   </div>
   <div>
-    <input type="hidden" value="{{eventid}}" id="eventid"/>
+    <input type="hidden" value="{{eventid}}" id="eventid">
   </div>
   <div id="signinData" class="mx-auto px-5 mb-2">
-    <input type="text" id="submitScannerData" name="bNumber" class="input-lg form-control" oninput="submitData()" style="font-size: 2rem;" placeholder="Scanner Kiosk Sign-in" aria-label="Enter scanner data" autofocus/>
+    <input type="text" id="submitScannerData" name="bNumber" class="form-control input-lg" oninput="submitData()" style="font-size: 2rem;" placeholder="Scanner Kiosk Sign-in" aria-label="Enter scanner data" autofocus/>
   </div>
   <div class="form-check form-switch mt-5 mx-5 position-absolute end-0">
     <input class="form-check-input mt-2" type="checkbox" id="fullscreenCheck" onclick="toggleFullscreen()">
     <label class="form-check-label" id="fullscreenLabel" for="fullscreenCheck">Toggle Full Screen</label>
-    <a class="btn btn-secondary ms-3" href= "/event/{{event.id}}/track_volunteers" role="button">Back</a>
+    <a class="btn btn-secondary ms-3" href="/event/{{event.id}}/track_volunteers" role="button">Back</a>
   </div>
+
   {% endblock %}


### PR DESCRIPTION
This PR fixes issue #140, where there was no button to take the user back from the kiosk to the track volunteers screen. 

A Back button shows to the right of the toggle full screen button. It returns you to the track volunteers screen with the respective event ID. 

To test: 
Go to /event/<ID TO TEST>/kiosk 
Click the Back button 
You should now be on /event/<ID TO TEST>/track_volunteers
