### PR TITLE
Frontend Consistency to Main Titles

### DIFF
--- a/app/templates/admin/createSLProposalTable.html
+++ b/app/templates/admin/createSLProposalTable.html
@@ -8,7 +8,7 @@
   {{super()}}
 {% endblock %}
 {% block app_content %}
-<h1 class="text-center">{{g.current_user.firstName}} {{g.current_user.lastName}}</h1>
+<h1 class="text-center mt-5 mb-2">{{g.current_user.firstName}} {{g.current_user.lastName}}</h1>
 <div>
   <table class="table table-striped">
     <thead>

--- a/app/templates/admin/createSingleEvent.html
+++ b/app/templates/admin/createSingleEvent.html
@@ -16,7 +16,7 @@
   {% set isEditable = isAdmin %}
   {% set isNewEvent = 'create' in request.path %}
 
-  <div align="center" style="margin-bottom: 50px;">
+  <div class="text-center mt-5 mb-3">
       {% if isNewEvent %}
         {% if template.tag == 'single-program' %}
           {% set page_title = 'Create Event for ' + eventData["program"].programName %}
@@ -67,7 +67,7 @@
         {% if eventData.id %}
           <input type="hidden" name="id" value="{{eventData.id}}" >
         {% endif %}
-        
+
         <div class="d-grid gap-1.5">
           <div class="form-group">
             <label for='name'> <strong>Event Name</strong></label> <br>
@@ -134,7 +134,7 @@
             </div>
           </div>
         </div><br>
-        
+
         <!-- Start and End Datepickers -->
         <div class="flex-container">
           <div>
@@ -233,7 +233,7 @@
               <p>None</p>
             {%endif%}
 
-            {% for f in eventData.facilitators %} 
+            {% for f in eventData.facilitators %}
               <p>{{f.firstName}} {{f.lastName}}</p>
             {% endfor %}
         {% endif %}

--- a/app/templates/admin/userManagement.html
+++ b/app/templates/admin/userManagement.html
@@ -7,7 +7,7 @@
 {% endblock %}
 {% block app_content %}
 
-<h1 class="text-center">Admin Management</h1>
+<h1 class="text-center mt-5 mb-3">Admin Management</h1>
 
 {% macro createInputsButtons(inputId, buttonId, buttonName, buttonClass) %}
 <div class="input-group">
@@ -18,28 +18,29 @@
 </div>
 <div class="col-md-4"><button type="button" class="btn btn-{{buttonClass}} btn-sm" id="{{buttonId}}">{{buttonName}}</button></div>
 {% endmacro %}
-<div class="container">
-<div class="row g-3">
+
+<div class="container-fluid">
+  <div class="row offset-md-3">
     <div class="col-md-4">
-      <div class="col-md-12">Add Celts Admin</div>
-        {{createInputsButtons("searchCeltsAdminInput","addCeltsAdmin","Add","success")}}
+      <div class="text-nowrap">Add Celts Admin</div>
+      {{createInputsButtons("searchCeltsAdminInput","addCeltsAdmin","Add","success")}}
     </div>
-  <div class="col-md-4 offset-md-4">
-    <div class="col-md-12">Add Celts Student Staff</div>
-    {{createInputsButtons("searchCeltsStudentStaffInput","addCeltsStudentStaff","Add","success")}}
+    <div class="col-md-4">
+      <div class="text-nowrap">Add Celts Student Staff</div>
+      {{createInputsButtons("searchCeltsStudentStaffInput","addCeltsStudentStaff","Add","success")}}
+    </div>
   </div>
-</div>
- <br>
-  <div class="row g-3">
-  <div class="col-md-4">
-    <div class="col-md-12">Remove Celts Admin</div>
-    {{createInputsButtons("removeCeltsAdminInput","removeCeltsAdmin","Remove","danger")}}
+  <br>
+  <div class="row offset-md-3">
+    <div class="col-md-4">
+      <div class="text-nowrap">Remove Celts Admin</div>
+      {{createInputsButtons("removeCeltsAdminInput","removeCeltsAdmin","Remove","danger")}}
+    </div>
+    <div class="col-md-4">
+      <div class="text-nowrap">Remove Celts Student Staff</div>
+      {{createInputsButtons("removeCeltsStudentStaffInput","removeCeltsStudentStaff","Remove","danger")}}
+    </div>
   </div>
-  <div class="col-md-4 offset-md-4">
-    <div class="col-md-12">Remove Celts Student Staff</div>
-    {{createInputsButtons("removeCeltsStudentStaffInput","removeCeltsStudentStaff","Remove","danger")}}
-  </div>
-</div>
 </div>
 
 {% endblock %}

--- a/app/templates/events/eventKiosk.html
+++ b/app/templates/events/eventKiosk.html
@@ -12,7 +12,7 @@
 
   {% block app_content %}
   <div>
-    <h1 class="mb-5" align="center">{{event.name}}</h1>
+    <h1 class="my-5" align="center">{{event.name}}</h1>
     <h2 class="m-5" align="center">{{bNumberToUser}}</h2>
   </div>
   <div>

--- a/app/templates/events/event_list.html
+++ b/app/templates/events/event_list.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
 {% endblock %}
 {% block app_content %}
-<h1 class="text-center">Events List for {{selectedTerm.description}}</h1>
+<h1 class="text-center mt-5">Events List for {{selectedTerm.description}}</h1>
 <div class="container-fluid px-1 py-3">
   <div class="row d-flex align-items-baseline p-3">
     <div class="col-md-1 ps-1 ms-auto">

--- a/app/templates/events/template_selector.html
+++ b/app/templates/events/template_selector.html
@@ -18,17 +18,16 @@
     }
 </style>
 
-<h2>Choose Event Type</h2>
+<h2 class="text-center mt-5">Choose Event Type</h2>
+<div class="list-group m-auto">
+  <a href="#" class="list-group-item disabled" tabindex="-1" aria-disabled="true">Templated Events</a>
+  {% for template in templates %}
+  <a href="/event/{{template.id}}/create" class="list-group-item list-group-item-action list-group-indent">{{ template.name }}</a>
+  {% endfor %}
 
-<div class="list-group">
-    <a href="#" class="list-group-item disabled" tabindex="-1" aria-disabled="true">Templated Events</a>
-    {% for template in templates %}
-    <a href="/event/{{template.id}}/create" class="list-group-item list-group-item-action list-group-indent">{{ template.name }}</a>
-    {% endfor %}
-
-    <a href="#" class="list-group-item disabled" tabindex="-1" aria-disabled="true">Single Program Events</a>
-    {% for program in programs %}
-    <a href="/event/1/{{program.id}}/create" class="list-group-item list-group-item-action list-group-indent">{{ program.programName }}</a>
-    {% endfor %}
+  <a href="#" class="list-group-item disabled" tabindex="-1" aria-disabled="true">Single Program Events</a>
+  {% for program in programs %}
+  <a href="/event/1/{{program.id}}/create" class="list-group-item list-group-item-action list-group-indent">{{ program.programName }}</a>
+  {% endfor %}
 </div>
 {% endblock %}

--- a/app/templates/events/trackVolunteers.html
+++ b/app/templates/events/trackVolunteers.html
@@ -11,8 +11,8 @@
 
 {% block app_content %}
 
-<div align="center" style="margin-bottom: 50px;">
-    <h1 align="center">{{event.name}}</h1>
+<div class="text-center mt-5">
+    <h1 class="text-center">{{event.name}}</h1>
     {% if isPastEvent %}
       <div class="alert alert-danger" role="alert">This event is in the past.</div>
     {% endif %}
@@ -34,18 +34,18 @@
     <div class="form-group d-inline-flex">
       <div class="ui-widget input-group">
         <input id="trackVolunteersInput" type="input" placeholder="Search">
-        <span class="input-group-text" style="padding:0 0 0 0rem;"><i class="bi bi-search" style="margin-left:-35px;"></i></span>
+        <span class="input-group-text p-0 border-0 bg-transparent"><i class="bi bi-search" style="margin-left:-1.5rem;"></i></span>
         <div><button type="button" class="btn btn-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#addVolunteerModal">
           <i class="bi bi-plus-circle"></i>
         </button></div>
       </div>
     </div>
-    <div class='form-group d-inline-flex' style="padding: 0 0 0 2rem">
+    <div class='form-group d-inline-flex ps-2'>
       <a class="btn btn-info" href= "/event/{{event.id}}/kiosk" role="button">Kiosk Entry</a>
     </div>
   </div>
   <!-- Modal -->
-  <div class="modal fade" id="addVolunteerModal" tabindex="-1" aria-labelledby="addVolunteerModalLabel" aria-hidden="true" style="width:-60px;">
+  <div class="modal fade float-start" id="addVolunteerModal" tabindex="-1" aria-labelledby="addVolunteerModalLabel" aria-hidden="true">
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
@@ -57,7 +57,7 @@
             <div class="form-group input-group-x form-outline ui-widget" style="width:80%;">
               <input type="input" id="addVolunteerInput" class="form-control" placeholder="Search" autocomplete="off"/>
             </div>
-            <button type="button" class="btn btn-primary btn-sm"><i class="bi bi-search" style="margin-left:0px;"></i>
+            <button type="button" class="btn btn-primary btn-sm"><i class="bi bi-search ms-0"></i>
             </button>
           </div>
         </div>
@@ -90,7 +90,7 @@
           <td>
             {% if participant.username not in attendedTraining %}
               <span data-bs-toggle="tooltip" title="Did Not Complete All Trainings">
-              <span style="color:red" class="bi bi-exclamation-triangle"></span></span>
+              <span class="text-danger bi bi-exclamation-triangle-fill"></span></span>
             {% endif %}
           </td>
           <td><input class="form-control" type='hidden' name="username{{loop.index|string}}" id="{{participant.username}}"value="{{participant}}"> {{participant.firstName}} {{participant.lastName}}</td>
@@ -104,7 +104,7 @@
                      {% if participant.attended == 1 and participant.hoursEarned == None %} value="{{eventLength}}"
                      {% elif participant.attended == 1 %} value="{{participant.hoursEarned}}"
                      {%else%} readonly {%endif%}></td>
-          <td><span onclick = 'removeVolunteerFromEvent(this)' id="deleteIcon_{{participant.username}}" ><i class="bi bi-trash" style="font-size:20px"></i></span></td>
+          <td><span onclick = 'removeVolunteerFromEvent(this)' id="deleteIcon_{{participant.username}}"><i class="bi bi-trash h5 align-middle"></i></span></td>
         </tr>
         {%endfor%}
        </tbody>

--- a/app/templates/searchStudentPage.html
+++ b/app/templates/searchStudentPage.html
@@ -11,7 +11,7 @@
 
 {% block app_content %}
 <form id= "searchStudent" action="" method="post">
-  <h1 align="center">Student Search Page</h1><br>
+  <h1 class="text-center mt-5 mb-3">Student Search Page</h1><br>
   <div class="col-sm-6 col-sm-offset-3 m-auto">
     <div class="row">
       <div class="form-group ui-widget">


### PR DESCRIPTION
Original issue was #152 which called for removal of the big empty space in the admin management page. I changed the offset from the leftmost and rightmost columns to the 2 rows instead. I also added a mt-5 margin to improve the title's spacing. You can see the changes at /userManagement.

After talking with Alex, he recommended adding mt-5 to all the pages for frontend consistency. I did this to: 

- app/templates/admin/createSLProposalTable.html
- app/templates/admin/createSingleEvent.html
- app/templates/admin/userManagement.html
- app/templates/events/eventKiosk.html
- app/templates/events/event_list.html
- app/templates/events/template_selector.html
- app/templates/events/trackVolunteers.html
- app/templates/searchStudentPage.html

There were a couple cases like trackVolunteers and createSingleEvent where I just improved the frontend (e.g. removing styles for their bootstrap equivalent) 