### PR TITLE
Add test and make surroundingTerms use the term object

### DIFF
--- a/app/logic/utils.py
+++ b/app/logic/utils.py
@@ -2,9 +2,17 @@ import collections
 from app.models.term import Term
 
 def selectSurroundingTerms(currentTerm, prevTerms=2):
+    """
+    Returns a list of term objects around the provided Term object for the current term. 
+    Chooses the previous terms according to the prevTerms parameter (defaulting to 2), 
+    and then chooses terms for the next two years after the current term. 
+
+    To get only the current and future terms, pass prevTerms=0.
+    """
     startTerm = max(1, currentTerm.id - prevTerms)
-    surroundingTerms = (Term.select().where(Term.id >= startTerm)
-                                .where((Term.year <= currentTerm.year + 2)))
+    surroundingTerms = (Term.select()
+                            .where(Term.id >= startTerm)
+                            .where((Term.year <= currentTerm.year + 2)))
 
     return surroundingTerms
 

--- a/app/logic/utils.py
+++ b/app/logic/utils.py
@@ -1,10 +1,10 @@
 import collections
 from app.models.term import Term
 
-def selectSurroundingTerms(currentTermid, prevTerms=2):
-    startTerm = max(1,currentTermid-prevTerms)
+def selectSurroundingTerms(currentTerm, prevTerms=2):
+    startTerm = max(1, currentTerm.id - prevTerms)
     surroundingTerms = (Term.select().where(Term.id >= startTerm)
-                                .where((Term.year <= (Term.get_by_id(currentTermid)).year + 2)))
+                                .where((Term.year <= currentTerm.year + 2)))
 
     return surroundingTerms
 

--- a/database/test_data.py
+++ b/database/test_data.py
@@ -175,6 +175,15 @@ terms = [
         "isSummer": False,
         "isCurrentTerm": False
     },
+    {
+        "id": 6,
+        "description": "Spring 2024",
+        "year": 2024,
+        "academicYear": "2023-2024",
+        "isBreak": False,
+        "isSummer": False,
+        "isCurrentTerm": False
+    },
 
 
 ]

--- a/tests/code/test_utils.py
+++ b/tests/code/test_utils.py
@@ -1,14 +1,21 @@
 import pytest
 
 from app.models.term import Term
-from app.logic.utils import deep_update, selectFutureTerms
+from app.logic.utils import deep_update, selectSurroundingTerms
 
 @pytest.mark.integration
-def test_validateListOfTerms():
-    currentTermid = 3
-    listOfTerms = selectFutureTerms(currentTermid)
+def test_selectSurroundingTerms():
+    listOfTerms = selectSurroundingTerms(Term.get_by_id(3))
+    assert [1,2,3,4,5] == [t.id for t in listOfTerms]
 
-    assert Term.get_by_id(3) in listOfTerms and "2024" not in listOfTerms
+    listOfTerms = selectSurroundingTerms(Term.get_by_id(3), prevTerms=0)
+    assert [3,4,5] == [t.id for t in listOfTerms]
+
+    listOfTerms = selectSurroundingTerms(Term.get_by_id(3), prevTerms=1)
+    assert [2,3,4,5] == [t.id for t in listOfTerms]
+
+    listOfTerms = selectSurroundingTerms(Term.get_by_id(3), prevTerms=-1)
+    assert [4,5] == [t.id for t in listOfTerms]
 
 @pytest.mark.unit
 def test_deepUpdate_empty():


### PR DESCRIPTION
Fix `selectSurroundingTerms` to use a Term object and not a term id and create a test for the function