### PR TITLE
fixed issue about adding the user as admin twice

### DIFF
--- a/app/controllers/admin/userManagement.py
+++ b/app/controllers/admin/userManagement.py
@@ -16,17 +16,29 @@ def manageUsers():
     user = User.get_by_id(username)
 
     if method == "addCeltsAdmin":
-        addCeltsAdmin(user)
-        flash(username+ " has been added as a Celts Admin", 'success')
+        if user.isCeltsAdmin:
+            flash(username+ " is already a Celts Admin", 'danger')
+        else:
+            addCeltsAdmin(user)
+            flash(username+ " has been added as a Celts Admin", 'success')
     elif method == "addCeltsStudentStaff":
-        addCeltsStudentStaff(user)
-        flash(username+ " has been added as a Celts Student Staff", 'success')
+        if user.isCeltsStudentStaff:
+            flash(username+ " is already a Celts Student Staff", 'danger')
+        else:
+            addCeltsStudentStaff(user)
+            flash(username+ " has been added as a Celts Student Staff", 'success')
     elif method == "removeCeltsAdmin":
-        removeCeltsAdmin(user)
-        flash(username+ " is no longer a Celts Admin ", 'success')
+        if not user.isCeltsAdmin:
+            flash(username+ " is not a Celts Admin ", 'danger')
+        else:
+            removeCeltsAdmin(user)
+            flash(username+ " is no longer a Celts Admin ", 'success')
     elif method == "removeCeltsStudentStaff":
-        removeCeltsStudentStaff(user)
-        flash(username+ " is no longer a Celts Student Staff", 'success')
+        if not user.isCeltsStudentStaff:
+            flash(username+ " is not a Celts Student Staff ", 'danger')
+        else:
+            removeCeltsStudentStaff(user)
+            flash(username+ " is no longer a Celts Student Staff", 'success')
 
     return ("success")
 


### PR DESCRIPTION

Issue from the small board: _There seems to be no handling on Admin Management. You can remove people who are not admins and add the same user twice_

This PR handles Admin Management actions. Previously, there was no indication that a user is already an admin and they could be added or removed multiple times. 

Test: Make a user a celts admin and try to add them as admin again. You should get a flash message which says they are already a celts admin. 