### PR TITLE
Fixes kiosk entry not showing up in track volunteer page

### DIFF
--- a/app/logic/participants.py
+++ b/app/logic/participants.py
@@ -20,23 +20,22 @@ def trainedParticipants(programID):
     attendedTraining = list(dict.fromkeys(filter(lambda user: eventTrainingDataList.count(user) == len(trlist), eventTrainingDataList)))
     return attendedTraining
 
-def sendUserData(bnumber, eventid, programid):
+def sendUserData(bnumber, eventId, programid):
     """Accepts scan input and signs in the user. If user exists or is already
     signed in will return user and login status"""
     signedInUser = User.get(User.bnumber == bnumber)
-    event = Event.get_by_id(eventid)
+    event = Event.get_by_id(eventId)
     if not isEligibleForProgram(programid, signedInUser):
         userStatus = "banned"
     elif ((EventParticipant.select(EventParticipant.user)
-       .where(EventParticipant.user == signedInUser, EventParticipant.event == eventid))
+       .where(EventParticipant.user==signedInUser, EventParticipant.event==eventId))
        .exists()):
         userStatus = "already in"
     else:
         userStatus = "success"
         totalHours = getEventLengthInHours(event.timeStart, event.timeEnd,  event.startDate)
-        EventParticipant.insert([{EventParticipant.user: signedInUser,
-          EventParticipant.event: eventid,
-          EventParticipant.hoursEarned: totalHours}]).execute()
+        EventRsvp.create(user=signedInUser, event=eventId)
+        EventParticipant.create (user=signedInUser, event=eventId, hoursEarned=totalHours)
     return signedInUser, userStatus
 
 def userRsvpForEvent(user,  event):

--- a/tests/code/test_participants.py
+++ b/tests/code/test_participants.py
@@ -217,20 +217,23 @@ def test_sendUserData():
     signedInUser, userStatus = sendUserData("B00751360", 2, 1)
     assert userStatus == "already in"
 
-    # user is eligible but the user is not in EventParticipant
-
+    # user is eligible but the user is not in EventParticipant and EventRsvp
     signedInUser = User.get(User.bnumber=="B00759117")
     with pytest.raises(DoesNotExist):
         EventParticipant.get(EventParticipant.user==signedInUser, EventParticipant.event==2)
+        EventRsvp.get(EventRsvp.user==signedInUser, EventRsvp.event==2)
+
         signedInUser, userStatus = sendUserData("B00759117", 2, 1)
         assert userStatus == "success"
 
-        usersAttended = EventParticipant.select().where(EventParticipant.event == 2)
-        listOfAttended = [users.user.username for users in usersAttended]
+        participant = EventParticipant.select().where(EventParticipant.event==2, EventParticipant.user==signedInUser)
+        assert "agliullovak" in participant
 
-        assert "agliullovak" in listOfAttended
+        userRsvp = EventRsvp.select().where(EventRsvp.event==2, EventRsvp.user==signedInUser)
+        assert "agliullovak" in userRsvp
 
         EventParticipant.delete(EventParticipant.user==signedInUser, EventParticipant.event==2).execute()
+        EventRsvp.delete(EventRsvp.user==signedInUser, EventRsvp.event==2).execute()
 
 @pytest.mark.integration
 def test_getEventParticipants():


### PR DESCRIPTION
**Issue:** The user entered through kiosk entry was not added to the track volunteer page. 

This PR fixes the issue by saving the student record in both Event Rsvp and Event Participant tables. 