### PR TITLE
Adding user to event participant when added through add volunteer

### DIFF
--- a/app/controllers/admin/volunteers.py
+++ b/app/controllers/admin/volunteers.py
@@ -84,6 +84,7 @@ def addVolunteer(volunteer, eventId):
     username = volunteer.strip("()").split('(')[-1]
     user = User.get(User.username==username)
     successfullyAddedVolunteer = addVolunteerToEventRsvp(user, eventId)
+    EventParticipant.create(user=user, event=eventId) # user is present
     if successfullyAddedVolunteer:
         flash("Volunteer successfully added!", "success")
     else:


### PR DESCRIPTION
Whenever a user is added through Add Volunteer button on the Track Volunteers page (by an admin), then they have to be also added to the EventParticipant table (which means they are marked as present). 