### PR TITLE
Adds Tabs to Link Service Transcript and Upcoming Events

### DIFF
--- a/app/templates/main/serviceTranscript.html
+++ b/app/templates/main/serviceTranscript.html
@@ -2,8 +2,18 @@
 
 {% block app_content %}
 
-<h1 class="text-center pb-5">{{userData.firstName}} {{userData.lastName}}</h1>
-<button type="button" class="btn btn-primary float-end d-print-none" onClick="window.print()"><i class="bi bi-printer d-print-none"></i> Print</button>
+<h1 class="text-center mt-5 mb-3">{{userData.firstName}} {{userData.lastName}}</h1>
+<div class="btn-group">
+  <ul class="nav nav-tabs" role="tab-list">
+    <li class="nav-item" role="presentation">
+      <a class="nav-link" href="/profile/{{userData.username}}">Upcoming Events</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link active" aria-current="page" href="#">Service Transcript</a>
+    </li>
+  </ul>
+</div>
+<button type="button" class="btn btn-primary float-end d-print-none" onclick="window.print()"><span class="bi bi-printer d-print-none"></span> Print</button>
 {% if programs.exists() %}
   <h2>Programs</h2>
   <table class="table table-bordered table-striped">
@@ -16,7 +26,7 @@
     <tr>
       <td> {{program.program.programName}}</td>
       <td> {{program.event.term.description}}</td>
-      <td class= "w-25"> {{program.hoursEarned}}</td>
+      <td class="w-25"> {{program.hoursEarned}}</td>
     </tr>
     {% endfor %}
   </table>
@@ -33,9 +43,9 @@
 
     {% for programEvent in bonnerData %}
     <tr>
-      <td> {{programEvent.event.name}}</td>
-      <td> {{programEvent.event.term.description}}</td>
-      <td class= "w-25"> {{programEvent.hoursEarned}}</td>
+      <td>{{ programEvent.event.name }}</td>
+      <td>{{ programEvent.event.term.description}} </td>
+      <td class="w-25"> {{programEvent.hoursEarned}} </td>
     </tr>
     {% endfor %}
   </table>
@@ -48,19 +58,19 @@
       <th>Course Name</th>
       <th>Semester</th>
       <th>Instructor</th>
-      <th class= "w-25">Accrued Hours</th>
+      <th class="w-25">Accrued Hours</th>
     </tr>
     {% for slcourse in slCourses %}
     <tr>
-      <td> {{slcourse.courseName}}</td>
-      <td> {{slcourse.term.description}}</td>
+      <td> {{ slcourse.courseName }}</td>
+      <td> {{ slcourse.term.description }}</td>
 
       <td>
         {% for instructor in slcourse.courseInstructors %}
-          {{instructor.user.firstName}} {{instructor.user.lastName}} <br>
+          {{ instructor.user.firstName }} {{ instructor.user.lastName }} <br>
         {% endfor %}
       </td>
-      <td class= "w-25"> {{slcourse.hoursEarned}}</td>
+      <td class="w-25">{{ slcourse.hoursEarned }}</td>
     </tr>
     {% endfor %}
   </table>
@@ -76,9 +86,9 @@
     </tr>
     {% for data in trainingData %}
     <tr>
-      <td> {{data.event.name}}</td>
-      <td> {{data.event.term.description}}</td>
-      <td class= "w-25"> {{data.hoursEarned}}</td>
+      <td>{{ data.event.name }}</td>
+      <td>{{ data.event.term.description }}</td>
+      <td class= "w-25"> {{ data.hoursEarned }}</td>
     </tr>
     {% endfor %}
   </table>
@@ -88,12 +98,12 @@
     {% if startDate == "N/A" %}
       <p>No Volunteer Record</p>
     {% else %}
-      <p>*Volunteering since {{startDate}}</p>
+      <p>*Volunteering since {{ startDate }}</p>
     {% endif %}
   </div>
-  <div class="float-end "  >
+  <div class="float-end">
     <p class="fw-bold pb-3 d-inline">Total Hours:</p>
-    <p class="d-inline bg-light ps-2 pe-5 border-bottom" id="hourTotal" > {{totalHours}} </p>
+    <p class="d-inline bg-light ps-2 pe-5 border-bottom" id="hourTotal">{{ totalHours }}</p>
   </div>
   <div class="pt-5">
     <p>If there are any corrections that need to be made, contact <a href="mailto:cochranea@berea.edu">Ashley Cochrane</a></p>

--- a/app/templates/main/serviceTranscript.html
+++ b/app/templates/main/serviceTranscript.html
@@ -3,7 +3,7 @@
 {% block app_content %}
 
 <h1 class="text-center mt-5 mb-3">{{userData.firstName}} {{userData.lastName}}</h1>
-<div class="btn-group">
+<div class="btn-group d-print-none">
   <ul class="nav nav-tabs" role="tab-list">
     <li class="nav-item" role="presentation">
       <a class="nav-link" href="/profile/{{userData.username}}">Upcoming Events</a>
@@ -15,7 +15,7 @@
 </div>
 <button type="button" class="btn btn-primary float-end d-print-none" onclick="window.print()"><span class="bi bi-printer d-print-none"></span> Print</button>
 {% if programs.exists() %}
-  <h2>Programs</h2>
+  <h2 class="m-1">Programs</h2>
   <table class="table table-bordered table-striped">
     <tr>
       <th>Program</th>
@@ -33,7 +33,7 @@
 {% endif %}
 
 {% if bonnerData.exists() %}
-  <h2>Bonner Scholar Events</h2>
+  <h2 class="m-1">Bonner Scholar Events</h2>
   <table class="table table-bordered table-striped">
     <tr>
       <th>Event Name</th>
@@ -52,7 +52,7 @@
 {% endif %}
 
 {% if slCourses.exists() %}
-  <h2>Service Learning Courses</h2>
+  <h2 class="m-1">Service Learning Courses</h2>
   <table class="table table-bordered table-striped">
     <tr>
       <th>Course Name</th>
@@ -77,7 +77,7 @@
 {% endif %}
 
 {% if trainingData.exists() %}
-  <h2>Trainings</h2>
+  <h2 class="m-1">Trainings</h2>
   <table class="table table-bordered table-striped">
     <tr>
       <th>Training Name</th>
@@ -94,19 +94,19 @@
   </table>
 {% endif %}
 
-  <div class="pt-4">
-    {% if startDate == "N/A" %}
-      <p>No Volunteer Record</p>
-    {% else %}
-      <p>*Volunteering since {{ startDate }}</p>
-    {% endif %}
-  </div>
-  <div class="float-end">
-    <p class="fw-bold pb-3 d-inline">Total Hours:</p>
-    <p class="d-inline bg-light ps-2 pe-5 border-bottom" id="hourTotal">{{ totalHours }}</p>
-  </div>
-  <div class="pt-5">
-    <p>If there are any corrections that need to be made, contact <a href="mailto:cochranea@berea.edu">Ashley Cochrane</a></p>
-  </div>
+<div class="pt-4">
+  {% if startDate == "N/A" %}
+    <p>No Volunteer Record</p>
+  {% else %}
+    <p>*Volunteering since {{ startDate }}</p>
+  {% endif %}
+</div>
+<div class="float-end">
+  <p class="fw-bold pb-3 d-inline">Total Hours:</p>
+  <p class="d-inline bg-light ps-2 pe-5 border-bottom" id="hourTotal">{{ totalHours }}</p>
+</div>
+<div class="d-print-none pt-5">
+  <p>If there are any corrections that need to be made, contact <a href="mailto:cochranea@berea.edu">Ashley Cochrane</a></p>
+</div>
 
 {% endblock %}

--- a/app/templates/volunteer/volunteerProfile.html
+++ b/app/templates/volunteer/volunteerProfile.html
@@ -8,19 +8,20 @@
 
 {% block app_content %}
 <div class="container">
+  <h1 class="mt-5 mb-3 text-center">{{ user.firstName }} {{ user.lastName }}</h1>
   <div class="btn-group">
-    <ul class="nav nav-tabs nav-fill mx-3 mb-3" id="profile-tab" role="tablist">
+    <ul class="nav nav-tabs" role="tab-list">
       <li class="nav-item" role="presentation">
-        <a class="nav-link active" href="#">Upcoming Events</a>
+        <a class="nav-link active" aria-current="page" href="#">Upcoming Events</a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" aria-current="page" href="/{{ user.username }}/serviceTranscript">Service Transcript</a>
+        <a class="nav-link" href="/{{user.username}}/serviceTranscript">Service Transcript</a>
       </li>
     </ul>
   </div>
+
   <div class="row">
     <table class="table">
-
       {% if upcomingEvents|length > 0 %}
         <thead class="tableHeader">
           <th scope="col"><h4><strong>Program</strong></h4>

--- a/app/templates/volunteer/volunteerProfile.html
+++ b/app/templates/volunteer/volunteerProfile.html
@@ -8,6 +8,16 @@
 
 {% block app_content %}
 <div class="container">
+  <div class="btn-group">
+    <ul class="nav nav-tabs nav-fill mx-3 mb-3" id="profile-tab" role="tablist">
+      <li class="nav-item" role="presentation">
+        <a class="nav-link active" href="#">Upcoming Events</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" aria-current="page" href="/{{ user.username }}/serviceTranscript">Service Transcript</a>
+      </li>
+    </ul>
+  </div>
   <div class="row">
     <table class="table">
 


### PR DESCRIPTION
This PR fixes issue #167 where there was no link to the volunteer service transcript page.

There is now a nav-tab in both serviceTranscript.html and volunteerProfile.html. I also added and reformatted their names to better reflect the wireframe.

TO TEST:
Go to /profile/
There should be a nav-tab that takes the user to the username's transcript.
Click on "Service Transcript"
It sends the user to //serviceTranscript