### PR TITLE
Extend and Restrict Sidebar to Bottom of Page

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -34,64 +34,64 @@
 {% block content %}
 
 <div>
-    <div class="row g-0">
-      <div class="col-md-auto d-none d-lg-block">
-        <div style="margin-right: 280px">
-          <nav class="position-fixed float-start">
-            {% block sidebar %}
-            {% include 'sidebar.html' %}
-            {% endblock %}
-          </nav>
-        </div>
-      </div>
-        <nav class="col-md-auto d-lg-none">
-            <div class="offcanvas offcanvas-start w-auto" tabindex="-1" id="offcanvasSidebar" aria-labelledby="sidebar">
-                <div class="offcanvas-body p-0">
-                    <button type="button" class="btn btn-dark position-absolute top-0 start-100 rounded-0 rounded-end" data-bs-dismiss="offcanvas" aria-label="Close">
-                        <i class="bi bi-x"></i>
-                    </button>
-                    {% include 'sidebar.html' %}
-                </div>
-            </div>
-        </nav>
-        <div class='col-12 col-md scroll-container overflow-visible'>
-        <div>
-            <div class="main-content container">
-                <div class="flash_container">
-                    {% with messages = get_flashed_messages(with_categories=true) %}
-                        {% if messages %}
-                            {% for category, message in messages %}
-                                <div class="alert  alert-{{category}} alert-dismissible" role="alert">{{ message }}
-                                  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-                                </div>
-                            {% endfor %}
-                        {% endif %}
-                    {% endwith %}
-                </div>
-
-                <div class="d-lg-none position-fixed top-0 start-0 d-print-none">
-                    <button class="btn btn-dark rounded-0 rounded-end" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasSidebar" aria-controls="sidebar">
-                        <i class="bi bi-list" role="button" aria-label="Sidebar"></i>
-                    </button>
-                </div>
-
-                {% block app_content %}
-                    {# application content needs to be provided in the app_content block #}
-                {% endblock %}
-                <div class="spacer my-0"></div>
-            </div>
-        </div>
-
-        {% block footer %}
-        <footer class="footer mt-auto bg-light d-print-none" style="font-size:small; vertical-align: middle;">
-          <div class="container" style="margin-bottom: 0; line-height:normal;"><br>
-            <span><strong>Issues? Contact: </strong><a href="mailto:support@bereacollege.onmicrosoft.com" class="footerlink">Systems Support </a><br class="d-lg-none">
-              <strong>Created & Designed by the </strong><a href="/contributors" id = "contribLink" class="footerlink">Student Software Development Team</a></span>
-            </div>
-          </footer>
+  <div class="row g-0">
+    <div class="col-md-auto d-none d-lg-block">
+      <div style="margin-right: 280px">
+        <nav class="position-fixed float-start">
+          {% block sidebar %}
+          {% include 'sidebar.html' %}
           {% endblock %}
-        </div>
+        </nav>
+      </div>
     </div>
+      <nav class="col-md-auto d-lg-none">
+        <div class="offcanvas offcanvas-start w-auto" tabindex="-1" id="offcanvasSidebar" aria-labelledby="sidebar">
+          <div class="offcanvas-body p-0">
+            <button type="button" class="btn btn-dark position-absolute top-0 start-100 rounded-0 rounded-end" data-bs-dismiss="offcanvas" aria-label="Close">
+              <span class="bi bi-x"></span>
+            </button>
+            {% include 'sidebar.html' %}
+          </div>
+        </div>
+      </nav>
+      <div class='col-12 col-md scroll-container overflow-visible'>
+        <div>
+          <div class="main-content container">
+            <div class="flash_container">
+              {% with messages = get_flashed_messages(with_categories=true) %}
+                {% if messages %}
+                  {% for category, message in messages %}
+                    <div class="alert  alert-{{category}} alert-dismissible" role="alert">{{ message }}
+                      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                    </div>
+                  {% endfor %}
+                {% endif %}
+              {% endwith %}
+            </div>
+
+            <div class="d-lg-none position-fixed top-0 start-0 d-print-none">
+              <button class="btn btn-dark rounded-0 rounded-end" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasSidebar" aria-controls="sidebar">
+                <span class="bi bi-list" role="button" aria-label="Sidebar"></span>
+              </button>
+            </div>
+
+            {% block app_content %}
+              {# application content needs to be provided in the app_content block #}
+            {% endblock %}
+            <div class="spacer my-0"></div>
+          </div>
+        </div>
+
+      {% block footer %}
+      <footer class="footer mt-auto bg-light d-print-none" style="font-size:small; vertical-align: middle;">
+        <div class="container" style="margin-bottom: 0; line-height:normal;"><br>
+          <span><strong>Issues? Contact: </strong><a href="mailto:support@bereacollege.onmicrosoft.com" class="footerlink">Systems Support </a><br class="d-lg-none">
+          <strong>Created & Designed by the </strong><a href="/contributors" id = "contribLink" class="footerlink">Student Software Development Team</a></span>
+        </div>
+      </footer>
+      {% endblock %}
+    </div>
+  </div>
 </div>
 
 {% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -35,11 +35,15 @@
 
 <div>
     <div class="row g-0">
-        <nav class="position-fixed col-md-auto d-none d-lg-block">
+      <div class="col-md-auto d-none d-lg-block">
+        <div style="margin-right: 280px">
+          <nav class="position-fixed float-start">
             {% block sidebar %}
-                {% include 'sidebar.html' %}
+            {% include 'sidebar.html' %}
             {% endblock %}
-        </nav>
+          </nav>
+        </div>
+      </div>
         <nav class="col-md-auto d-lg-none">
             <div class="offcanvas offcanvas-start w-auto" tabindex="-1" id="offcanvasSidebar" aria-labelledby="sidebar">
                 <div class="offcanvas-body p-0">
@@ -50,7 +54,7 @@
                 </div>
             </div>
         </nav>
-        <div class='col-12 col-md scroll-container overflow-visible' style="margin-left: 280px">
+        <div class='col-12 col-md scroll-container overflow-visible'>
         <div>
             <div class="main-content container">
                 <div class="flash_container">

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -39,7 +39,7 @@
       <div style="margin-right: 280px">
         <nav class="position-fixed float-start">
           {% block sidebar %}
-          {% include 'sidebar.html' %}
+            {% include 'sidebar.html' %}
           {% endblock %}
         </nav>
       </div>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -2,37 +2,32 @@
 <html lang="en">
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-    {% block styles %}
-        <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
-        <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
-        <link rel="stylesheet" href="{{url_for('static', filename ='css/bootstrap.min.css') }}?u={{lastStaticUpdate}}">
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css">
-        <link rel="stylesheet" href="{{url_for('static', filename ='css/base.css') }}?u={{lastStaticUpdate}}">
-        <link rel="stylesheet" href="{{url_for('static', filename ='css/sidebar.css') }}?u={{lastStaticUpdate}}">
+  {% block styles %}
+    <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
+    <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
+    <link rel="stylesheet" href="{{url_for('static', filename ='css/bootstrap.min.css') }}?u={{lastStaticUpdate}}">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css">
+    <link rel="stylesheet" href="{{url_for('static', filename ='css/base.css') }}?u={{lastStaticUpdate}}">
+    <link rel="stylesheet" href="{{url_for('static', filename ='css/sidebar.css') }}?u={{lastStaticUpdate}}">
+  {% endblock %}
 
+  {% block scripts %}
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+    <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
+    <script src="{{url_for('static', filename='js/bootstrap.bundle.min.js') }}?u={{lastStaticUpdate}}" type="text/javascript"></script>
+    <script src="{{url_for('static', filename='js/base.js') }}?u={{lastStaticUpdate}}" type="text/javascript"></script>
+  {% endblock %}
+
+  <title>
+    {% block title %}
+      {% if title %}{{ title }} - CELTS{% else %}Welcome to CELTS{% endif %}
     {% endblock %}
-
-    {% block scripts %}
-        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-        <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
-        <script src="{{url_for('static', filename='js/bootstrap.bundle.min.js') }}?u={{lastStaticUpdate}}" type="text/javascript"></script>
-        <script src="{{url_for('static', filename='js/base.js') }}?u={{lastStaticUpdate}}" type="text/javascript"></script>
-
-
-    {% endblock %}
-
-    <title>
-        {% block title %}
-            {% if title %}{{ title }} - CELTS{% else %}Welcome to CELTS{% endif %}
-        {% endblock %}
-    </title>
-
+  </title>
 </head>
 
 <body class="mb-n4">
 
 {% block content %}
-
 <div>
   <div class="row g-0">
     <div class="col-md-auto d-none d-lg-block">
@@ -44,43 +39,43 @@
         </nav>
       </div>
     </div>
-      <nav class="col-md-auto d-lg-none">
-        <div class="offcanvas offcanvas-start w-auto" tabindex="-1" id="offcanvasSidebar" aria-labelledby="sidebar">
-          <div class="offcanvas-body p-0">
-            <button type="button" class="btn btn-dark position-absolute top-0 start-100 rounded-0 rounded-end" data-bs-dismiss="offcanvas" aria-label="Close">
-              <span class="bi bi-x"></span>
+    <nav class="col-md-auto d-lg-none">
+      <div class="offcanvas offcanvas-start w-auto" tabindex="-1" id="offcanvasSidebar" aria-labelledby="sidebar">
+        <div class="offcanvas-body p-0">
+          <button type="button" class="btn btn-dark position-absolute top-0 start-100 rounded-0 rounded-end" data-bs-dismiss="offcanvas" aria-label="Close">
+            <span class="bi bi-x"></span>
+          </button>
+          {% include 'sidebar.html' %}
+        </div>
+      </div>
+    </nav>
+    <div class='col-12 col-md scroll-container overflow-visible'>
+      <div>
+        <div class="main-content container">
+          <div class="flash_container">
+            {% with messages = get_flashed_messages(with_categories=true) %}
+              {% if messages %}
+                {% for category, message in messages %}
+                  <div class="alert  alert-{{category}} alert-dismissible" role="alert">{{ message }}
+                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                  </div>
+                {% endfor %}
+              {% endif %}
+            {% endwith %}
+          </div>
+
+          <div class="d-lg-none position-fixed top-0 start-0 d-print-none">
+            <button class="btn btn-dark rounded-0 rounded-end" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasSidebar" aria-controls="sidebar">
+              <span class="bi bi-list" role="button" aria-label="Sidebar"></span>
             </button>
-            {% include 'sidebar.html' %}
           </div>
-        </div>
-      </nav>
-      <div class='col-12 col-md scroll-container overflow-visible'>
-        <div>
-          <div class="main-content container">
-            <div class="flash_container">
-              {% with messages = get_flashed_messages(with_categories=true) %}
-                {% if messages %}
-                  {% for category, message in messages %}
-                    <div class="alert  alert-{{category}} alert-dismissible" role="alert">{{ message }}
-                      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-                    </div>
-                  {% endfor %}
-                {% endif %}
-              {% endwith %}
-            </div>
 
-            <div class="d-lg-none position-fixed top-0 start-0 d-print-none">
-              <button class="btn btn-dark rounded-0 rounded-end" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasSidebar" aria-controls="sidebar">
-                <span class="bi bi-list" role="button" aria-label="Sidebar"></span>
-              </button>
-            </div>
-
-            {% block app_content %}
-              {# application content needs to be provided in the app_content block #}
-            {% endblock %}
-            <div class="spacer my-0"></div>
-          </div>
+          {% block app_content %}
+            {# application content needs to be provided in the app_content block #}
+          {% endblock %}
+          <div class="spacer my-0"></div>
         </div>
+      </div>
 
       {% block footer %}
       <footer class="footer mt-auto bg-light d-print-none" style="font-size:small; vertical-align: middle;">

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -35,7 +35,7 @@
 
 <div>
     <div class="row g-0">
-        <nav class="col-md-auto d-none d-lg-block">
+        <nav class="position-fixed col-md-auto d-none d-lg-block">
             {% block sidebar %}
                 {% include 'sidebar.html' %}
             {% endblock %}
@@ -50,7 +50,7 @@
                 </div>
             </div>
         </nav>
-        <div class='col-12 col-md scroll-container overflow-visible'>
+        <div class='col-12 col-md scroll-container overflow-visible' style="margin-left: 280px">
         <div>
             <div class="main-content container">
                 <div class="flash_container">

--- a/app/templates/sidebar.html
+++ b/app/templates/sidebar.html
@@ -1,6 +1,5 @@
 <div id="sidebar">
   <h1 class="visually-hidden">Admin sidebar</h1>
-
   <div class="d-flex flex-column flex-shrink-0 p-3 text-white bg-dark" style="width: 280px">
     <a href="/" class="d-flex align-items-center mb-3 mb-md-0 me-md-auto text-white text-decoration-none">
       <span class="fs-4">CELTS</span>
@@ -15,11 +14,11 @@
         </a>
       </li>
     {% endif %}
-      <li class="nav-item">
-        <a href="/" class="nav-link text-white {{ 'active' if request.path =='/' }}" aria-current="page">
-          Events List
-        </a>
-      </li>
+    <li class="nav-item">
+      <a href="/" class="nav-link text-white {{ 'active' if request.path =='/' }}" aria-current="page">
+        Events List
+      </a>
+    </li>
     {% if g.current_user.isAdmin %}
       <li>
         <a href="/template_select" class="nav-link text-white {{ 'active' if request.path =='/template_select' }}">
@@ -37,7 +36,6 @@
         </a>
       </li>
     {% endif %}
-
     </ul>
     <hr>
     {% if env != 'production' %}

--- a/app/templates/sidebar.html
+++ b/app/templates/sidebar.html
@@ -15,7 +15,6 @@
         </a>
       </li>
     {% endif %}
-
       <li class="nav-item">
         <a href="/" class="nav-link text-white {{ 'active' if request.path =='/' }}" aria-current="page">
           Events List
@@ -44,15 +43,13 @@
     {% if env != 'production' %}
       <h6>Current User: {{g.current_user.username}}</h6>
       <form action="/switch_user" method="POST" id="userSelectForm">
-          <select name="newuser" class="form-select" style="margin-bottom: 10px" id="userSelect">
-              <option {{"selected" if g.current_user == config.default_user }} value="{{config.default_user}}">Default User: {{config.default_user}}</option>
-              <option {{"selected" if g.current_user == "ramsayb2"}} value="ramsayb2">Admin: ramsayb2</option>
-              <option {{"selected" if g.current_user == "neillz"}} value="neillz">Student: neillz</option>
-          </select>
+        <select name="newuser" class="form-select" style="margin-bottom: 10px" id="userSelect">
+          <option {{"selected" if g.current_user == config.default_user }} value="{{config.default_user}}">Default User: {{config.default_user}}</option>
+          <option {{"selected" if g.current_user == "ramsayb2"}} value="ramsayb2">Admin: ramsayb2</option>
+          <option {{"selected" if g.current_user == "neillz"}} value="neillz">Student: neillz</option>
+        </select>
       </form>
     {% endif %}
     <button type="button" class="btn btn-secondary btn-secondary">Log out</button>
   </div>
-
-  <div class="b-example-divider d-none d-xxl-block"></div>
-  </div>
+</div>

--- a/app/templates/sidebar.html
+++ b/app/templates/sidebar.html
@@ -1,7 +1,7 @@
 <div id="sidebar">
   <h1 class="visually-hidden">Admin sidebar</h1>
 
-  <div class="d-flex flex-column flex-shrink-0 p-3 text-white bg-dark" style="width: 280px;">
+  <div class="d-flex flex-column flex-shrink-0 p-3 text-white bg-dark" style="width: 280px">
     <a href="/" class="d-flex align-items-center mb-3 mb-md-0 me-md-auto text-white text-decoration-none">
       <span class="fs-4">CELTS</span>
     </a>
@@ -55,5 +55,4 @@
   </div>
 
   <div class="b-example-divider d-none d-xxl-block"></div>
-
   </div>


### PR DESCRIPTION
This PR is a solution to issue #171. The sidebar did not extend to the end of the page. I couldn't find a viable solution where the sidebar stays put, so it is now a fixed sidebar. 

I added position-fixed to the nav in base.html. I also added a margin-right: 280px, which is the width of the sidebar in sidebar.html. This pushes everything back to the center. Otherwise, the sidebar's position is ignored, and the content goes under the bar. Printing is unaffected, and because of col-md-auto, mobile view is also unaffected. 

TO TEST:
Go to the CELTS website, and the sidebar should be fixed on all pages. 