### PR TITLE
Resetting Program Eligibility Each Term

### DIFF
--- a/app/controllers/admin/routes.py
+++ b/app/controllers/admin/routes.py
@@ -16,7 +16,6 @@ from app.models.eventTemplate import EventTemplate
 from app.models.outsideParticipant import OutsideParticipant
 from app.models.eventParticipant import EventParticipant
 from app.models.programEvent import ProgramEvent
-from app.logic.participants import trainedParticipants
 from app.logic.volunteers import getEventLengthInHours
 from app.logic.utils import selectSurroundingTerms
 from app.logic.events import deleteEvent, getAllFacilitators, attemptSaveEvent, preprocessEventData, calculateRecurringEventFrequency

--- a/app/controllers/admin/volunteers.py
+++ b/app/controllers/admin/volunteers.py
@@ -34,7 +34,7 @@ def trackVolunteersPage(eventID):
     if not program:
         return "TODO: What do we do for no programs or multiple programs?"
 
-    trainedParticipantsList = trainedParticipants(program)
+    trainedParticipantsList = trainedParticipants(program, g.current_term)
     eventParticipants = getEventParticipants(event)
 
     if not g.current_user.isCeltsAdmin:

--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -74,7 +74,7 @@ def viewVolunteersProfile(username):
 
               noteForDict = list(notes)[-1].banNote.noteContent if list(notes) else ""
               eligibilityTable.append({"program" : program,
-                                   "completedTraining" : (username in trainedParticipants(program)),
+                                   "completedTraining" : (username in trainedParticipants(program, g.current_term)),
                                    "isNotBanned" : isEligibleForProgram(program, username),
                                    "banNote": noteForDict})
          return render_template ("/main/volunteerProfile.html",

--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -13,6 +13,7 @@ from app.models.programBan import ProgramBan
 from app.models.programEvent import ProgramEvent
 from app.models.term import Term
 from app.models.eventRsvp import EventRsvp
+from app.models.note import Note
 from app.controllers.main import main_bp
 from app.logic.users import addUserInterest, removeUserInterest, banUser, unbanUser, isEligibleForProgram
 from app.logic.participants import userRsvpForEvent, unattendedRequiredEvents, trainedParticipants
@@ -67,13 +68,22 @@ def viewVolunteersProfile(username):
          completedBackgroundCheck = {entry.type.id: entry.passBackgroundCheck for entry in allUserEntries}
          backgroundTypes = list(BackgroundCheckType.select())
          eligibilityTable = []
-         for program in programs:
-              notes = ProgramBan.select().where(ProgramBan.user == username,
-                                                ProgramBan.program == program,
-                                                ProgramBan.endDate > datetime.datetime.now())
 
-              noteForDict = list(notes)[-1].banNote.noteContent if list(notes) else ""
-              eligibilityTable.append({"program" : program,
+         for program in programs:
+            notes = (ProgramBan.select(ProgramBan).where(
+                ProgramBan.user == username,
+                ProgramBan.program == program,
+                ProgramBan.endDate > datetime.datetime.now()))
+
+            # noteForDict = list(notes)[-1].banNote.noteContent
+
+            if list(notes):
+                if (list(notes)[-1].banNote):
+                    noteForDict = list(notes)[-1].banNote.noteContent
+            else:
+                 noteForDict = ""
+
+            eligibilityTable.append({"program" : program,
                                    "completedTraining" : (username in trainedParticipants(program, g.current_term)),
                                    "isNotBanned" : isEligibleForProgram(program, username),
                                    "banNote": noteForDict})

--- a/app/logic/participants.py
+++ b/app/logic/participants.py
@@ -15,39 +15,44 @@ def trainedParticipants(programID, currentTerm):
     This function tracks the users who have attended every Prerequisite
     event and adds them to a list that will not flag them when tracking hours.
     """
-    # Reset program eligibility each term, except for All Celts Training and All Volunteer Training events.
-    trainingEvents = (Event.select().join(ProgramEvent).where(
-        ProgramEvent.program==programID,
-        Event.isTraining==True,
-        Event.term==currentTerm,
-        (Event.term==getStartofCurrentAcademicYear(currentTerm) &
-        (Event.name == "All Celts Training" | Event.name == "All Volunteer Training"))
-        ))
 
-    print("\n\n ", programID,)
-    print("\n\n The training events are:", trainingEvents, "\n\n")
-    print("\n\n ", len(trainingEvents), "\n\n")
     # Reset program eligibility each AY when event is All Celts Training or All Volunteer Training
-    firstTermOfAcademicYear = getStartofCurrentAcademicYear(currentTerm)
-    print("\n\n Academic Year starts at:", firstTermOfAcademicYear, "\n current term is: ", currentTerm, "\n\n")
-
-    test = (Event.select().join(ProgramEvent).where(
+    allCeltsAndAllVolunteerTrainings = (Event.select(Event.id).join(ProgramEvent).where(
         ProgramEvent.program==programID,
         Event.term==getStartofCurrentAcademicYear(currentTerm),
         (Event.name == "All Celts Training" | Event.name == "All Volunteer Training")))
 
-    print("\n\n ", len(test), "\n\n")
+    # Reset program eligibility each term for all other trainings
+    otherTrainingEvents = (Event.select(Event.id).join(ProgramEvent).where(
+        ProgramEvent.program==programID,
+        Event.isTraining==True,
+        Event.term==currentTerm))
 
-    allTrainingEvents = (list(trainingEvents))
+    print("\n\n programID: ", programID, "\n\n")
+    print("\n\n currentTerm: ", currentTerm, "\n\n")
+    print("\n\n otherTrainingEvents: ", len(otherTrainingEvents), list(otherTrainingEvents), "\n\n")
+
+    allTraningEvents = allCeltsAndAllVolunteerTrainings + otherTrainingEvents
+    print("\n\n total number of trainings: ", len(allTraningEvents), "\n\n")
+
 
     eventTrainingDataList = [participant.user.username for participant in (
-        EventParticipant.select().where(EventParticipant.event.in_(allTrainingEvents) & EventParticipant.event.in_(test))
+        EventParticipant.select().where(EventParticipant.event.in_(allTraningEvents))
         )]
+    print("\n\n eventTrainingDataList: ", eventTrainingDataList, "\n\n")
+    # Find a way to check for all required trainings in EventParticipant table
 
-    # print("\n\n eventTrainingDataList: ", eventTrainingDataList)
-    attendedTraining = list(dict.fromkeys(filter(lambda user: eventTrainingDataList.count(user) == len(allTrainingEvents) + len(test), eventTrainingDataList)))
+    # program id = 3
+    # [3, 6, 10]
 
-    # print("\n\n\n attendedTraining: ", attendedTraining, "\n\n\n")
+    # term = spring 2021
+    # sreynit = 10
+    # allTraningEvents = [10]
+    # eventTrainingDataList = ["khatts"]
+
+
+    attendedTraining = list(dict.fromkeys(filter(lambda user: eventTrainingDataList.count(user) == len(allTraningEvents), eventTrainingDataList)))
+
     return attendedTraining
 
 def sendUserData(bnumber, eventId, programid):

--- a/app/logic/participants.py
+++ b/app/logic/participants.py
@@ -8,14 +8,14 @@ from app.models.eventParticipant import EventParticipant
 from app.logic.users import isEligibleForProgram
 from app.logic.volunteers import getEventLengthInHours
 
-def trainedParticipants(programID):
+def trainedParticipants(programID, currentTerm):
     """
     This function tracks the users who have attended every Prerequisite
     event and adds them to a list that will not flag them when tracking hours.
     """
     trainingEvents = list(Event.select()
                                .join(ProgramEvent)
-                               .where(ProgramEvent.program == programID,Event.isTraining==True))
+                               .where(ProgramEvent.program==programID, Event.isTraining==True, Event.term==currentTerm))
 
     eventTrainingDataList = [participant.user.username for participant in (
         EventParticipant.select().where(EventParticipant.event.in_(trainingEvents))

--- a/app/logic/participants.py
+++ b/app/logic/participants.py
@@ -19,11 +19,18 @@ def trainedParticipants(programID, currentTerm):
     trainingEvents = (Event.select().join(ProgramEvent).where(
         ProgramEvent.program==programID,
         Event.isTraining==True,
-        Event.term==currentTerm))
+        Event.term==currentTerm,
+        (Event.term==getStartofCurrentAcademicYear(currentTerm) &
+        (Event.name == "All Celts Training" | Event.name == "All Volunteer Training"))
+        ))
 
-    print("\n\n ", programID, "\n\n")
+    print("\n\n ", programID,)
+    print("\n\n The training events are:", trainingEvents, "\n\n")
     print("\n\n ", len(trainingEvents), "\n\n")
     # Reset program eligibility each AY when event is All Celts Training or All Volunteer Training
+    firstTermOfAcademicYear = getStartofCurrentAcademicYear(currentTerm)
+    print("\n\n Academic Year starts at:", firstTermOfAcademicYear, "\n current term is: ", currentTerm, "\n\n")
+
     test = (Event.select().join(ProgramEvent).where(
         ProgramEvent.program==programID,
         Event.term==getStartofCurrentAcademicYear(currentTerm),
@@ -31,13 +38,14 @@ def trainedParticipants(programID, currentTerm):
 
     print("\n\n ", len(test), "\n\n")
 
+    allTrainingEvents = (list(trainingEvents))
 
     eventTrainingDataList = [participant.user.username for participant in (
-        EventParticipant.select().where(EventParticipant.event.in_(trainingEvents) & EventParticipant.event.in_(test))
+        EventParticipant.select().where(EventParticipant.event.in_(allTrainingEvents) & EventParticipant.event.in_(test))
         )]
 
     # print("\n\n eventTrainingDataList: ", eventTrainingDataList)
-    attendedTraining = list(dict.fromkeys(filter(lambda user: eventTrainingDataList.count(user) == len(trainingEvents) + len(test), eventTrainingDataList)))
+    attendedTraining = list(dict.fromkeys(filter(lambda user: eventTrainingDataList.count(user) == len(allTrainingEvents) + len(test), eventTrainingDataList)))
 
     # print("\n\n\n attendedTraining: ", attendedTraining, "\n\n\n")
     return attendedTraining

--- a/app/logic/participants.py
+++ b/app/logic/participants.py
@@ -13,9 +13,27 @@ def trainedParticipants(programID, currentTerm):
     This function tracks the users who have attended every Prerequisite
     event and adds them to a list that will not flag them when tracking hours.
     """
+    # programId = 3
+    # events = 3, 6, 10, 12
+    # 10 - All celts training
+
+    #trainingEvents = [3, 6, 10]
+
+    # exclude events with name All celts training and All volunteer training
     trainingEvents = list(Event.select()
                                .join(ProgramEvent)
                                .where(ProgramEvent.program==programID, Event.isTraining==True, Event.term==currentTerm))
+
+
+    # Exception for All Celts training and All volunteer training
+    # if 10 in trainingEvents and (if user and 10 is in EventParticipant)
+    # [3, 6, 10] - [10]
+
+    #term term.academicYear "2021-2022"
+    # isInCurrentAcademicYear = if (fall in term.description and term.year in term.academicYear[everything-before-dash])   term.academicYear.split("-")[0]
+
+
+
 
     eventTrainingDataList = [participant.user.username for participant in (
         EventParticipant.select().where(EventParticipant.event.in_(trainingEvents))

--- a/app/logic/participants.py
+++ b/app/logic/participants.py
@@ -28,28 +28,11 @@ def trainedParticipants(programID, currentTerm):
         Event.isTraining==True,
         Event.term==currentTerm))
 
-    print("\n\n programID: ", programID, "\n\n")
-    print("\n\n currentTerm: ", currentTerm, "\n\n")
-    print("\n\n otherTrainingEvents: ", len(otherTrainingEvents), list(otherTrainingEvents), "\n\n")
-
-    allTraningEvents = allCeltsAndAllVolunteerTrainings + otherTrainingEvents
-    print("\n\n total number of trainings: ", len(allTraningEvents), "\n\n")
-
+    allTraningEvents = set(allCeltsAndAllVolunteerTrainings + otherTrainingEvents)
 
     eventTrainingDataList = [participant.user.username for participant in (
         EventParticipant.select().where(EventParticipant.event.in_(allTraningEvents))
         )]
-    print("\n\n eventTrainingDataList: ", eventTrainingDataList, "\n\n")
-    # Find a way to check for all required trainings in EventParticipant table
-
-    # program id = 3
-    # [3, 6, 10]
-
-    # term = spring 2021
-    # sreynit = 10
-    # allTraningEvents = [10]
-    # eventTrainingDataList = ["khatts"]
-
 
     attendedTraining = list(dict.fromkeys(filter(lambda user: eventTrainingDataList.count(user) == len(allTraningEvents), eventTrainingDataList)))
 

--- a/app/logic/participants.py
+++ b/app/logic/participants.py
@@ -21,27 +21,25 @@ def trainedParticipants(programID, currentTerm):
         Event.isTraining==True,
         Event.term==currentTerm))
 
-    print("\n\n training: ", len(trainingEvents))
+    print("\n\n ", programID, "\n\n")
+    print("\n\n ", len(trainingEvents), "\n\n")
     # Reset program eligibility each AY when event is All Celts Training or All Volunteer Training
     test = (Event.select().join(ProgramEvent).where(
         ProgramEvent.program==programID,
         Event.term==getStartofCurrentAcademicYear(currentTerm),
         (Event.name == "All Celts Training" | Event.name == "All Volunteer Training")))
 
-    print("\n\n test: ", len(test))
+    print("\n\n ", len(test), "\n\n")
 
-    final = trainingEvents.union_all(test)
-
-    print("\n\n final: ", len(final))
 
     eventTrainingDataList = [participant.user.username for participant in (
-        EventParticipant.select().where(EventParticipant.event.in_(final))
+        EventParticipant.select().where(EventParticipant.event.in_(trainingEvents) & EventParticipant.event.in_(test))
         )]
 
-    print("\n\n eventTrainingDataList: ", eventTrainingDataList)
-    attendedTraining = list(dict.fromkeys(filter(lambda user: eventTrainingDataList.count(user) == len(final), eventTrainingDataList)))
+    # print("\n\n eventTrainingDataList: ", eventTrainingDataList)
+    attendedTraining = list(dict.fromkeys(filter(lambda user: eventTrainingDataList.count(user) == len(trainingEvents) + len(test), eventTrainingDataList)))
 
-    print("\n\n\n attendedTraining: ", attendedTraining, "\n\n\n")
+    # print("\n\n\n attendedTraining: ", attendedTraining, "\n\n\n")
     return attendedTraining
 
 def sendUserData(bnumber, eventId, programid):

--- a/app/logic/users.py
+++ b/app/logic/users.py
@@ -57,8 +57,9 @@ def banUser(program_id, username, note, banEndDate, creator):
                              createdOn = datetime.datetime.now(),
                              noteContent = note,
                              isPrivate = 0)
+                             
     ProgramBan.create(program = program_id,
-                      user = "username",
+                      user = username,
                       endDate = banEndDate,
                       banNote = noteForDb)
 

--- a/app/logic/utils.py
+++ b/app/logic/utils.py
@@ -1,11 +1,12 @@
 import collections
+from peewee import DoesNotExist
 from app.models.term import Term
 
 def selectSurroundingTerms(currentTerm, prevTerms=2):
     """
-    Returns a list of term objects around the provided Term object for the current term. 
-    Chooses the previous terms according to the prevTerms parameter (defaulting to 2), 
-    and then chooses terms for the next two years after the current term. 
+    Returns a list of term objects around the provided Term object for the current term.
+    Chooses the previous terms according to the prevTerms parameter (defaulting to 2),
+    and then chooses terms for the next two years after the current term.
 
     To get only the current and future terms, pass prevTerms=0.
     """
@@ -35,3 +36,9 @@ def deep_update(d, u):
             d = {key: u[key]}
 
     return d
+
+def getStartofCurrentAcademicYear(currentTerm):
+    if ("Summer" in currentTerm.description) or ("Spring" in currentTerm.description):
+        fallTerm = Term.select().where(Term.year==currentTerm.year-1, Term.description == f"Fall {currentTerm.year-1}").get()
+        return fallTerm
+    return currentTerm

--- a/app/models/programBan.py
+++ b/app/models/programBan.py
@@ -7,5 +7,5 @@ class ProgramBan(baseModel):
     user = ForeignKeyField(User)
     program = ForeignKeyField(Program)
     endDate = DateField(null=True)
-    banNote = ForeignKeyField(Note, null=True)
+    banNote = ForeignKeyField(Note, null=False)
     unbanNote = ForeignKeyField(Note, null=True)

--- a/database/test_data.py
+++ b/database/test_data.py
@@ -133,6 +133,14 @@ User.insert_many(users).on_conflict_replace().execute()
 terms = [
     {
         "id": 1,
+        "description": "Fall 2020",
+        "year": 2020,
+        "academicYear": "2020-2021",
+        "isSummer": False,
+        "isCurrentTerm": False
+    },
+    {
+        "id": 2,
         "description": "Spring A 2021",
         "year": 2021,
         "academicYear": "2020-2021",
@@ -140,7 +148,7 @@ terms = [
         "isCurrentTerm": False
     },
     {
-        "id": 2,
+        "id": 3,
         "description": "Spring B 2021",
         "year": 2021,
         "academicYear": "2020-2021",
@@ -148,7 +156,7 @@ terms = [
         "isCurrentTerm": False
     },
     {
-        "id": 3,
+        "id": 4,
         "description": "Summer 2021",
         "year": 2021,
         "academicYear": "2020-2021",
@@ -156,7 +164,7 @@ terms = [
         "isCurrentTerm": True
     },
     {
-        "id": 4,
+        "id": 5,
         "description": "Fall 2021",
         "year": 2021,
         "academicYear": "2021-2022",
@@ -164,7 +172,7 @@ terms = [
         "isCurrentTerm": False
     },
     {
-        "id": 5,
+        "id": 6,
         "description": "Spring 2022",
         "year": 2022,
         "academicYear": "2021-2022",
@@ -242,7 +250,7 @@ Program.insert_many(programs).on_conflict_replace().execute()
 events = [
     {
         "id": 1,
-        "term": 1,
+        "term": 2,
         "name": "Empty Bowls Spring Event 1",
         "description": "Empty Bowls Spring 2021",
         "isTraining": True,
@@ -254,7 +262,7 @@ events = [
     },
     {
         "id": 2,
-        "term": 1,
+        "term": 2,
         "name": "Hunger Hurts",
         "description": "Will donate Food to Community",
         "isTraining": False,
@@ -266,7 +274,7 @@ events = [
     },
     {
         "id": 3,
-        "term": 3,
+        "term": 4,
         "name": "Adoption 101",
         "description": "Lecture on adoption",
         "isTraining": True,
@@ -278,7 +286,7 @@ events = [
     },
     {
         "id": 4,
-        "term": 3,
+        "term": 4,
         "name": "First Meetup",
         "description": "Berea Buddies First Meetup",
         "isTraining": False,
@@ -290,7 +298,7 @@ events = [
     },
     {
         "id": 5,
-        "term": 3,
+        "term": 4,
         "name": "Tutoring",
         "description": "Tutoring Training",
         "isTraining": False,
@@ -302,7 +310,7 @@ events = [
     },
     {
         "id": 6,
-        "term": 3,
+        "term": 4,
         "name": "Meet & Greet with Grandparent",
         "description": "Students meet with grandparent for the first time",
         "isTraining": True,
@@ -314,7 +322,7 @@ events = [
     },
     {
         "id": 7,
-        "term": 3,
+        "term": 4,
         "name": "Empty Bowl with Community",
         "description": "Open to Berea community",
         "isTraining": False,
@@ -326,7 +334,7 @@ events = [
     },
     {
         "id": 8,
-        "term": 1,
+        "term": 3,
         "name": "Berea Buddies Second Meeting",
         "description": "Play game to bond with buddy",
         "isTraining": True,
@@ -338,7 +346,7 @@ events = [
     },
     {
         "id": 9,
-        "term": 1,
+        "term": 3,
         "name": "Field Trip with Buddies",
         "description": "A small trip to Berea Farm",
         "isTraining": True,
@@ -351,7 +359,7 @@ events = [
     },
     {
         "id": 10,
-        "term": 3,
+        "term": 1,
         "name": "All Celts Training",
         "description": "Training event for all CELTS programs",
         "isTraining": True,
@@ -363,7 +371,7 @@ events = [
     },
     {
         "id": 11,
-        "term": 3,
+        "term": 4,
         "name": "Celts Admin Meeting",
         "description": "Not a required event",
         "isTraining": False,
@@ -375,7 +383,7 @@ events = [
     },
     {
         "id": 12,
-        "term": 3,
+        "term": 4,
         "name": "Dinner with Grandparent",
         "description": "Second event with grandparent",
         "isTraining": False,
@@ -387,7 +395,7 @@ events = [
     },
     {
         "id": 13,
-        "term": 2,
+        "term": 3,
         "name": "Community Clean Up",
         "description": "This event doesn't belong to any program",
         "isTraining": False,
@@ -399,7 +407,7 @@ events = [
     },
     {
         "id": 14,
-        "term": 2,
+        "term": 1,
         "name": "All Volunteer Training",
         "description": "testing multiple programs",
         "isTraining": True,
@@ -411,7 +419,7 @@ events = [
     },
     {
         "id": 15,
-        "term": 3,
+        "term": 4,
         "name": "Training Event",
         "description": "Test for training",
         "isTraining": True,
@@ -517,7 +525,7 @@ courses = [
     {
         "id": 1,
         "courseName": "Databases",
-        "term": 2,
+        "term": 3,
         "status": 1,
         "courseCredit": "",
         "createdBy": "",
@@ -528,7 +536,7 @@ courses = [
     {
         "id": 2,
         "courseName": "Spanish Help",
-        "term": 1,
+        "term": 2,
         "status": 2,
         "courseCredit": "",
         "createdBy": "",
@@ -539,7 +547,7 @@ courses = [
     {
         "id": 3,
         "courseName": "French Help",
-        "term": 3,
+        "term": 4,
         "status": 3,
         "courseCredit": "",
         "createdBy": "",

--- a/database/test_data.py
+++ b/database/test_data.py
@@ -2,7 +2,7 @@
 Chech phpmyadmin to see if your changes are reflected
 This file will need to be changed if the format of models changes (new fields, dropping fields, renaming...)'''
 
-from datetime import *
+from datetime import datetime, timedelta
 from app.models.eventRsvp import EventRsvp
 from app.models.user import User
 from app.models.term import Term
@@ -757,11 +757,13 @@ bannedUser = [
     {
         "user": "khatts",
         "program": 3,
+        "endDate": datetime.now() + timedelta(days=360),
     },
 
     {
         "user": "ayisie",
         "program": 1,
+        "endDate": datetime.now() + timedelta(days=150),
     }
 ]
 

--- a/database/test_data.py
+++ b/database/test_data.py
@@ -674,6 +674,16 @@ eventParticipants = [
         "user": "partont",
         "event": 2,
         "hoursEarned": 5
+    },
+    {
+        "user": "khatts",
+        "event": 6,
+        "hoursEarned": 3,
+    },
+    {
+        "user": "khatts",
+        "event": 10,
+        "hoursEarned": 3,
     }
 ]
 EventParticipant.insert_many(eventParticipants).on_conflict_replace().execute()

--- a/tests/code/test_emailHandler.py
+++ b/tests/code/test_emailHandler.py
@@ -104,7 +104,7 @@ def test_email_log():
             assert emailLog.subject == "Test Email"
             assert emailLog.templateUsed_id == 1
             assert emailLog.recipientsCategory == "RSVP'd"
-            time.sleep(.2) # Let's make sure that there is some separation in the times
+            time.sleep(.5) # Let's make sure that there is some separation in the times
             assert emailLog.dateSent <= datetime.now()
 
             rsvp_users = EventRsvp.select().where(EventRsvp.event_id==1)

--- a/tests/code/test_participants.py
+++ b/tests/code/test_participants.py
@@ -5,6 +5,7 @@ from peewee import IntegrityError, DoesNotExist
 from app.models import mainDB
 from app.models.user import User
 from app.models.event import Event
+from app.models.term import Term
 from app.models.eventParticipant import EventParticipant
 from app.logic.volunteers import addVolunteerToEventRsvp
 from app.logic.participants import trainedParticipants
@@ -102,15 +103,29 @@ def test_updateEventParticipants():
 
 @pytest.mark.integration
 def test_trainedParticipants():
-    attendedPreq = trainedParticipants(1)
-    assert "neillz" and "khatts" in attendedPreq
+    currentTerm = Term.get(Term.isCurrentTerm==1)
+    # Case1: test for an event in the current term
+    attendedPreq = trainedParticipants(3, currentTerm)
+    assert attendedPreq == ["khatts"]
 
-    #test for program with no prereq
-    attendedPreq = trainedParticipants(4)
+    # Case2: test for an event in a past term
+    attendedPreq = trainedParticipants(1, currentTerm)
     assert attendedPreq == []
 
-    #test for program that doesn't exist
-    attendedPreq = trainedParticipants(500)
+    # Case3: test for when user changes current term
+    currentTerm = Term.get(Term.id==1)
+    attendedPreq = trainedParticipants(1, currentTerm)
+    assert attendedPreq == ["neillz", "khatts", "ayisie"]
+
+    attendedPreq = trainedParticipants(3, currentTerm)
+    assert attendedPreq == []
+
+    # Case4: test for program with no prereq
+    attendedPreq = trainedParticipants(4, currentTerm)
+    assert attendedPreq == []
+
+    # Case5: test for program that doesn't exist
+    attendedPreq = trainedParticipants(500, currentTerm)
     assert attendedPreq == []
 
 @pytest.mark.integration

--- a/tests/code/test_participants.py
+++ b/tests/code/test_participants.py
@@ -113,7 +113,7 @@ def test_trainedParticipants():
     assert attendedPreq == []
 
     # Case3: test for when user changes current term
-    currentTerm = Term.get(Term.id==1)
+    currentTerm = Term.get_by_id(2)
     attendedPreq = trainedParticipants(1, currentTerm)
     assert attendedPreq == ["neillz", "khatts", "ayisie"]
 

--- a/tests/code/test_users.py
+++ b/tests/code/test_users.py
@@ -1,8 +1,11 @@
 import pytest
 from peewee import *
+from datetime import datetime
+from app.models import mainDB
 from app.models.program import Program
 from app.models.note import Note
 from app.models.user import User
+from app.models.programBan import ProgramBan
 from app.logic.users import addUserInterest, removeUserInterest, banUser, unbanUser, isEligibleForProgram
 from app.logic.users import isEligibleForProgram
 
@@ -108,56 +111,60 @@ def test_removeUserInterestt():
 
 @pytest.mark.integration
 def test_banUser():
+    with mainDB.atomic() as transaction:
+        #test for banning a user from a program
+        username = "khatts"
+        programId = 2
+        note = "Banning user test"
+        creator = "ramsayb2"
+        banEndDate = "2022-11-29"
+        banUser (programId, username, note, banEndDate, creator)
 
-    #test for banning a user from a program
-    username = "khatts"
-    program_id = 2
-    note = "Banning user test"
-    creator = "ramsayb2"
-    banEndDate = "2022-11-29"
-    status = banUser (program_id, username, note, banEndDate, creator)
-    assert status == "Successfully banned the user"
+        banned = ProgramBan.get(ProgramBan.program==programId)
+        assert banned.user.username == username
+        assert banned.endDate == datetime.strptime(banEndDate, '%Y-%m-%d').date()
+        assert banned.banNote.noteContent == note
+        assert banned.banNote.createdBy.username == creator
 
-    #test for banning a user from a program with different program is
-    program_id = 3
-    status = banUser (program_id, username, note, banEndDate, creator)
-    assert status == "Successfully banned the user"
+        #test for banning a user from a program with different program id
+        programId = 5
+        banUser (programId, username, note, banEndDate, creator)
+        banned = ProgramBan.get(ProgramBan.program==programId)
+        assert banned.user.username == username
+        assert banned.endDate == datetime.strptime(banEndDate, '%Y-%m-%d').date()
+        assert banned.banNote.noteContent == note
+        assert banned.banNote.createdBy.username == creator
 
-    #test for exceptions when banning the user
-    username = "khatts"
-    program_id = 100
-    note = "Banning user test"
-    creator = "ramsayb2"
-    banEndDate = "2022-11-29"
-    with pytest.raises(Exception):
-        status = banUser (program_id, username, note, banEndDate, creator)
-        assert status == False
-
-
-
+        transaction.rollback()
 
 @pytest.mark.integration
 def test_unbanUser():
+    with mainDB.atomic() as transaction:
+        #test for unbanning a user from a program
+        username = "khatts"
+        programId = 2
+        creator = "ramsayb2"
 
-    #test for unbanning a user from a program
-    username = "khatts"
-    program_id = 2
-    note = "unbanning user test"
-    creator = "ramsayb2"
-    status = unbanUser (program_id, username, note, creator)
-    assert status == "Successfully unbanned the user"
+        banNote = "Banning user test"
+        banEndDate = "2022-11-29"
+        banUser (programId, username, banNote, banEndDate, creator)
 
-    #test for unbanning a user from a program with different program
-    program_id = 3
-    status = unbanUser (program_id, username, note, creator)
-    assert status == "Successfully unbanned the user"
+        unbanNote = "unbanning user test"
+        unbanUser (programId, username, unbanNote, creator)
+        unbanned = ProgramBan.get(ProgramBan.program==programId)
+        assert unbanned.user.username == username
+        assert unbanned.endDate == datetime.now().date()
+        assert unbanned.unbanNote.noteContent == unbanNote
+        assert unbanned.unbanNote.createdBy.username == creator
 
-    #test for exceptions when unbanning the user
-    username = "ramsayb2"
-    program_id = 100
-    note = "Banning user test"
-    creator = "ramsayb2"
-    banEndDate = "2022-11-29"
-    with pytest.raises(Exception):
-        status = unbanUser (program_id, username, note, creator)
-        assert status == False
+        #test for unbanning a user from a program with different program
+        programId = 3
+        banUser (programId, username, banNote, banEndDate, creator)
+        unbanUser (programId, username, unbanNote, creator)
+        unbanned = ProgramBan.get(ProgramBan.program==programId)
+        assert unbanned.user.username == username
+        assert unbanned.endDate == datetime.now().date()
+        assert unbanned.unbanNote.noteContent == unbanNote
+        assert unbanned.unbanNote.createdBy.username == creator
+
+        transaction.rollback()

--- a/tests/code/test_utils.py
+++ b/tests/code/test_utils.py
@@ -3,22 +3,22 @@ import pytest
 from app.models import mainDB
 from app.models.user import User
 from app.models.term import Term
-from app.logic.utils import deep_update, selectSurroundingTerms
+from app.logic.utils import deep_update, selectSurroundingTerms, getStartofCurrentAcademicYear
 from app.logic.userManagement import addCeltsAdmin, removeCeltsAdmin,addCeltsStudentStaff, removeCeltsStudentStaff, changeCurrentTerm, addNextTerm
 
 @pytest.mark.integration
 def test_selectSurroundingTerms():
     listOfTerms = selectSurroundingTerms(Term.get_by_id(3))
-    assert [1,2,3,4,5] == [t.id for t in listOfTerms]
+    assert [1,2,3,4,5,6] == [t.id for t in listOfTerms]
 
     listOfTerms = selectSurroundingTerms(Term.get_by_id(3), prevTerms=0)
-    assert [3,4,5] == [t.id for t in listOfTerms]
+    assert [3,4,5,6] == [t.id for t in listOfTerms]
 
     listOfTerms = selectSurroundingTerms(Term.get_by_id(3), prevTerms=1)
-    assert [2,3,4,5] == [t.id for t in listOfTerms]
+    assert [2,3,4,5,6] == [t.id for t in listOfTerms]
 
     listOfTerms = selectSurroundingTerms(Term.get_by_id(3), prevTerms=-1)
-    assert [4,5] == [t.id for t in listOfTerms]
+    assert [4,5,6] == [t.id for t in listOfTerms]
 
 @pytest.mark.unit
 def test_deepUpdate_empty():
@@ -164,5 +164,32 @@ def test_addNextTerm():
         assert newTerm.academicYear == "2021-2022"
         assert newTerm.isSummer
         assert not newTerm.isCurrentTerm
+
+        transaction.rollback()
+
+@pytest.mark.integration
+def test_getStartofCurrentAcademicYear():
+    with mainDB.atomic() as transaction:
+        # Case1: current term is Fall 2020
+        currentTerm = Term.get_by_id(1)
+        fallTerm = getStartofCurrentAcademicYear(currentTerm)
+        assert fallTerm.year == 2020
+        assert fallTerm.description == "Fall 2020"
+        assert fallTerm.academicYear == "2020-2021"
+
+        # Case2: current term is Spring 2021
+        currentTerm = Term.get_by_id(2)
+        fallTerm = getStartofCurrentAcademicYear(currentTerm)
+        assert fallTerm.year == 2020
+        assert fallTerm.description == "Fall 2020"
+        assert fallTerm.academicYear == "2020-2021"
+
+        # Case3: current term is Summer 2021
+        currentTerm = Term.get_by_id(4)
+        fallTerm = getStartofCurrentAcademicYear(currentTerm)
+
+        assert fallTerm.year == 2020
+        assert fallTerm.description == "Fall 2020"
+        assert fallTerm.academicYear == "2020-2021"
 
         transaction.rollback()


### PR DESCRIPTION
- This PR builds on top of PR #169. 
- Fixes issue #195 
- The PR modifies the `trainedParticipants` function to take the current term. Then, we show volunteers' eligibility based on whether students finished the training in the current term or not. 
- 
- The PR also updates the tests for the mentioned function. There were other tests (from the original branch) that were failing, I fixed those as well. 