### PR TITLE
Warning about past event instead of disabling email button

### DIFF
--- a/app/static/js/emailModal.js
+++ b/app/static/js/emailModal.js
@@ -16,10 +16,16 @@ function retrieveEmailTemplateData() {
   });
 }
 
-function showEmailModal(eventID, programID, selectedTerm) {
+function showEmailModal(eventID, programID, selectedTerm, isPastEvent) {
   $(".modal-body #eventID").val(eventID);
   $(".modal-body #programID").val(programID);
   $(".modal-body #selectedTerm").val(selectedTerm);
+
+  if (isPastEvent) {
+    $(".pastEventWarning").prop("hidden", false);
+  } else {
+    $(".pastEventWarning").prop("hidden", true);
+  }
 
   for (let i=0; i < Object.keys(emailTemplateInfo).length; i++) {
     let option = `<option value='${emailTemplateInfo[i]['purpose']}'>${emailTemplateInfo[i]['subject']}</option>`;

--- a/app/templates/emailModal.html
+++ b/app/templates/emailModal.html
@@ -9,6 +9,14 @@
         <button type="button" class="btn-close position-absolute end-0 me-3" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
+        <div class="pastEventWarning" hidden>
+          <div class="alert alert-danger d-flex justify-content-center" role="alert">
+            <span class="bi bi-exclamation-triangle-fill me-2"></span>
+            <div>
+              This event is in the past
+            </div>
+          </div>
+        </div>
         <h6 id="emailLastSent" class="text-center"></h6>
         <form role="form" method="post" id="modal-form" action="/email">
           <div>

--- a/app/templates/events/event_list.html
+++ b/app/templates/events/event_list.html
@@ -71,9 +71,12 @@
             <td>{{event.location}}</td>
             {% if user.isAdmin %}
               <td>
-                  <button class="btn btn-primary" onclick="showEmailModal({{event.id}}, 'Unknown', {{selectedTerm}})"{{ 'disabled' if event.isPast }}>
-                    <span class="bi bi-envelope-fill"> Email</span>
-                  </button>
+                {% if event.isPast %}
+                  {% set isPastEvent = "true" %}
+                {% endif %}
+                <button class="btn btn-primary" onclick="showEmailModal({{event.id}}, 'Unknown', {{selectedTerm}}, {{isPastEvent}})">
+                  <span class="bi bi-envelope-fill"> Email</span>
+                </button>
               </td>
             {% else %}
               {% if (event.isPast) %}
@@ -132,10 +135,13 @@
                         <td>{{event.location}}</td>
                         {% if user.isAdmin %}
                           <td>
-                              <button class="btn btn-primary"
-                              onclick="showEmailModal({{event.id}}, {{program.id}}, {{selectedTerm}})" {{ 'disabled' if event.isPast }}>
-                                <span class="bi bi-envelope-fill"> Email</span>
-                              </button>
+                            {% if event.isPast %}
+                              {% set isPastEvent = "true" %}
+                            {% endif %}
+                            <button class="btn btn-primary"
+                            onclick="showEmailModal({{event.id}}, {{program.id}}, {{selectedTerm}}, {{isPastEvent}})">
+                              <span class="bi bi-envelope-fill"> Email</span>
+                            </button>
                           </td>
                         {% else %}
                           {% if event.isPast%}


### PR DESCRIPTION
- This PR fixes issue #200 
- Removes disabling of email button and adds a warning in the email model to let the user know that event has passed. 
- Branches off of PR #210 