### PR TITLE
Create Edit SLC Proposals Page

### DIFF
--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -1,5 +1,6 @@
 from flask import request, render_template, g, abort, flash, redirect, url_for
 import datetime
+import json
 
 from app import app
 from app.models.program import Program
@@ -19,7 +20,6 @@ from app.logic.participants import userRsvpForEvent, unattendedRequiredEvents
 from app.logic.searchUsers import searchUsers
 from app.logic.transcript import *
 from app.logic.manageSLFaculty import getCourseDict
-
 @main_bp.route('/', methods=['GET'])
 def redirectToEventsList():
     return redirect(url_for("main.events", selectedTerm=g.current_term))
@@ -167,14 +167,14 @@ def serviceTranscript(username):
                             startDate = startDate,
                             userData = user)
 
-@main_bp.route('/searchUser/<query>/<object>', methods = ['GET'])
-def searchUser(query, object):
+@main_bp.route('/searchUser/<query>', methods = ['GET'])
+def searchUser(query):
     '''Accepts user input and queries the database returning results that matches user search'''
     try:
         query = query.strip()
         search = query.upper()
         splitSearch = search.split()
-        searchResults = searchUsers(query, object)
+        searchResults = searchUsers(query)
         return searchResults
     except Exception as e:
         print(e)

--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -166,14 +166,14 @@ def serviceTranscript(username):
                             startDate = startDate,
                             userData = user)
 
-@main_bp.route('/searchUser/<query>', methods = ['GET'])
-def searchUser(query):
+@main_bp.route('/searchUser/<query>/<object>', methods = ['GET'])
+def searchUser(query, object):
     '''Accepts user input and queries the database returning results that matches user search'''
     try:
         query = query.strip()
         search = query.upper()
         splitSearch = search.split()
-        searchResults = searchUsers(query)
+        searchResults = searchUsers(query, object)
         return searchResults
     except Exception as e:
         print(e)

--- a/app/controllers/serviceLearning/routes.py
+++ b/app/controllers/serviceLearning/routes.py
@@ -11,7 +11,7 @@ from app.models.courseParticipant import CourseParticipant
 from app.controllers.serviceLearning import serviceLearning_bp
 from app.logic.searchUsers import searchUsers
 from app.logic.serviceLearningCoursesData import getServiceLearningCoursesData, withdrawProposal
-from app.logic.courseManagement import updatecourse
+from app.logic.courseManagement import updateCourse
 
 @serviceLearning_bp.route('/serviceLearning/courseManagement', methods = ['GET'])
 @serviceLearning_bp.route('/serviceLearning/courseManagement/<username>', methods = ['GET'])
@@ -65,7 +65,6 @@ def slcNewProposal():
         term = Term.get(Term.id==request.form.get("term"))
         status = CourseStatus.get(CourseStatus.status == "Pending")
         coursecheck = Course.get_or_none(Course.courseName == request.form.get("courseName"))
-        print("OVERHEREEEEEE", coursecheck)
         if coursecheck == None:
             course = Course.create(
                 courseName=request.form.get("courseName"),
@@ -89,7 +88,7 @@ def slcNewProposal():
                 CourseInstructor.create(course=course, user=instructor.username)
             return redirect('/serviceLearning/courseManagement')
         else:
-            updatecourse(request.form.copy())
+            updateCourse(request.form.copy())
 
     terms = Term.select().where(Term.year >= g.current_term.year)
     courseData = None
@@ -118,4 +117,4 @@ def withdrawCourse(courseID):
             flash("Unauthorized to perform this action", 'warning')
     except Exception as e:
         flash("Withdrawal Unsuccessful", 'warning')
-    return "" 
+    return ""

--- a/app/controllers/serviceLearning/routes.py
+++ b/app/controllers/serviceLearning/routes.py
@@ -89,7 +89,7 @@ def slcNewProposal():
                 CourseInstructor.create(course=course, user=instructor.username)
             return redirect('/serviceLearning/courseManagement')
         else:
-            updateCourse(request.form.copy())
+            updateCourse(request.form.copy(), instructorsDict)
             return redirect('/serviceLearning/courseManagement')
     terms = Term.select().where(Term.year >= g.current_term.year)
     courseData = None
@@ -112,14 +112,12 @@ def getInstructors():
 def updateInstructorPhone():
     try:
         instructorData = request.get_json()
-        print(instructorData)
         updateInstructorPhone = User.update(phoneNumber=instructorData[1]).where(User.username == instructorData[0]).execute()
-        flash("Instructor's phone number updated", 'success')
-        return ""
+        return "success"
     except Exception as e:
         print(e)
-        flash("Failed to update phone number", 'warning')
         return e
+        
 @serviceLearning_bp.route('/serviceLearning/withdraw/<courseID>', methods = ['POST'])
 def withdrawCourse(courseID):
     try:

--- a/app/controllers/serviceLearning/routes.py
+++ b/app/controllers/serviceLearning/routes.py
@@ -30,10 +30,13 @@ def serviceCourseManagement(username=None):
 @serviceLearning_bp.route('/serviceLearning/editProposal/<courseID>', methods=['GET', 'POST'])
 def slcEditProposal(courseID):
     courseData = CourseQuestion.get(CourseQuestion.course == courseID)
-    print(courseData.course.id)
-    print(courseData.course.courseName)
-    print(courseData.course.isRegularlyOccuring)
-    print(courseData.course.serviceLearningDesignatedSections)
+    courseInstructor = CourseInstructor.select().where(CourseInstructor.course == courseID)
+
+    for inst in courseInstructor:
+        print(inst.user.firstName)
+    isRegularlyOccuring = ""
+    isAllSectionsServiceLearning = ""
+    isPermanentlyDesignated = ""
 
     if courseData.course.isRegularlyOccuring:
         isRegularlyOccuring = "checked"
@@ -43,9 +46,17 @@ def slcEditProposal(courseID):
         isPermanentlyDesignated = "checked"
 
     terms = Term.select().where(Term.year >= g.current_term.year)
+
+    print(type(courseData.course.term))
+
+    for term in terms:
+        print(type(term))
+        if courseData.course.term == term.id:
+            print("Hello")
     return render_template('serviceLearning/slcNewProposal.html',
                                 courseData = courseData,
                                 terms = terms,
+                                courseInstructor = courseInstructor,
                                 isRegularlyOccuring = isRegularlyOccuring,
                                 isAllSectionsServiceLearning = isAllSectionsServiceLearning,
                                 isPermanentlyDesignated = isPermanentlyDesignated)

--- a/app/controllers/serviceLearning/routes.py
+++ b/app/controllers/serviceLearning/routes.py
@@ -108,6 +108,18 @@ def getInstructors():
     instructorsDict["instructors"] = instructorObjectList
     return jsonify({"Success": True}), 200
 
+@serviceLearning_bp.route('/updateInstructorPhone', methods=['POST'])
+def updateInstructorPhone():
+    try:
+        instructorData = request.get_json()
+        print(instructorData)
+        updateInstructorPhone = User.update(phoneNumber=instructorData[1]).where(User.username == instructorData[0]).execute()
+        flash("Instructor's phone number updated", 'success')
+        return ""
+    except Exception as e:
+        print(e)
+        flash("Failed to update phone number", 'warning')
+        return e
 @serviceLearning_bp.route('/serviceLearning/withdraw/<courseID>', methods = ['POST'])
 def withdrawCourse(courseID):
     try:

--- a/app/controllers/serviceLearning/routes.py
+++ b/app/controllers/serviceLearning/routes.py
@@ -26,13 +26,29 @@ def serviceCourseManagement(username=None):
     else:
         flash("Unauthorized to view page", 'warning')
         return redirect(url_for('main.events'))
+
 @serviceLearning_bp.route('/serviceLearning/editProposal/<courseID>', methods=['GET', 'POST'])
 def slcEditProposal(courseID):
     courseData = CourseQuestion.get(CourseQuestion.course == courseID)
     print(courseData.course.id)
     print(courseData.course.courseName)
+    print(courseData.course.isRegularlyOccuring)
+    print(courseData.course.serviceLearningDesignatedSections)
+
+    if courseData.course.isRegularlyOccuring:
+        isRegularlyOccuring = "checked"
+    if courseData.course.isAllSectionsServiceLearning:
+        isAllSectionsServiceLearning = "checked"
+    if courseData.course.isPermanentlyDesignated:
+        isPermanentlyDesignated = "checked"
+
     terms = Term.select().where(Term.year >= g.current_term.year)
-    return render_template('serviceLearning/slcNewProposal.html', courseData = courseData, terms = terms)
+    return render_template('serviceLearning/slcNewProposal.html',
+                                courseData = courseData,
+                                terms = terms,
+                                isRegularlyOccuring = isRegularlyOccuring,
+                                isAllSectionsServiceLearning = isAllSectionsServiceLearning,
+                                isPermanentlyDesignated = isPermanentlyDesignated)
 
 @serviceLearning_bp.route('/serviceLearning/newProposal', methods=['GET', 'POST'])
 def slcNewProposal():

--- a/app/controllers/serviceLearning/routes.py
+++ b/app/controllers/serviceLearning/routes.py
@@ -118,4 +118,4 @@ def withdrawCourse(courseID):
             flash("Unauthorized to perform this action", 'warning')
     except Exception as e:
         flash("Withdrawal Unsuccessful", 'warning')
-    return ""
+    return "" 

--- a/app/controllers/serviceLearning/routes.py
+++ b/app/controllers/serviceLearning/routes.py
@@ -55,7 +55,8 @@ def slcEditProposal(courseID):
                                 courseInstructor = courseInstructor,
                                 isRegularlyOccuring = isRegularlyOccuring,
                                 isAllSectionsServiceLearning = isAllSectionsServiceLearning,
-                                isPermanentlyDesignated = isPermanentlyDesignated)
+                                isPermanentlyDesignated = isPermanentlyDesignated,
+                                courseID=courseID)
 
 @serviceLearning_bp.route('/serviceLearning/newProposal', methods=['GET', 'POST'])
 def slcNewProposal():
@@ -64,7 +65,7 @@ def slcNewProposal():
         # courseData["courseInstructorPhone"] = request.form.get("courseInstructorPhone")
         term = Term.get(Term.id==request.form.get("term"))
         status = CourseStatus.get(CourseStatus.status == "Pending")
-        coursecheck = Course.get_or_none(Course.courseName == request.form.get("courseName"))
+        coursecheck = Course.get_or_none(Course.id == request.form.get("courseID"))
         if coursecheck == None:
             course = Course.create(
                 courseName=request.form.get("courseName"),
@@ -89,11 +90,7 @@ def slcNewProposal():
             return redirect('/serviceLearning/courseManagement')
         else:
             updateCourse(request.form.copy())
-<<<<<<< HEAD
-=======
             return redirect('/serviceLearning/courseManagement')
-
->>>>>>> c2811606292f21eb47a7742cccbc4f9cb4b21729
     terms = Term.select().where(Term.year >= g.current_term.year)
     courseData = None
     return render_template('serviceLearning/slcNewProposal.html', terms=terms, courseData = courseData)

--- a/app/controllers/serviceLearning/routes.py
+++ b/app/controllers/serviceLearning/routes.py
@@ -89,6 +89,7 @@ def slcNewProposal():
             return redirect('/serviceLearning/courseManagement')
         else:
             updateCourse(request.form.copy())
+            return redirect('/serviceLearning/courseManagement')
 
     terms = Term.select().where(Term.year >= g.current_term.year)
     courseData = None

--- a/app/controllers/serviceLearning/routes.py
+++ b/app/controllers/serviceLearning/routes.py
@@ -65,11 +65,11 @@ def slcEditProposal(courseID):
 def slcCreateOrEdit():
     if request.method == "POST":
         courseExist = Course.get_or_none(Course.id == request.form.get('courseID'))
-        if not courseExist:
-            createCourse(request.form.copy(), instructorsDict)
+        if courseExist:
+            updateCourse(request.form.copy(), instructorsDict)
             return redirect('/serviceLearning/courseManagement')
         else:
-            updateCourse(request.form.copy(), instructorsDict)
+            createCourse(request.form.copy(), instructorsDict)
             return redirect('/serviceLearning/courseManagement')
     terms = Term.select().where(Term.year >= g.current_term.year)
     courseData = None

--- a/app/controllers/serviceLearning/routes.py
+++ b/app/controllers/serviceLearning/routes.py
@@ -31,6 +31,10 @@ def serviceCourseManagement(username=None):
 
 @serviceLearning_bp.route('/serviceLearning/editProposal/<courseID>', methods=['GET', 'POST'])
 def slcEditProposal(courseID):
+    """
+        Route for editing proposals, it will fill the form with the data found in the database
+        given a courseID.
+    """
     questionData = CourseQuestion.select().where(CourseQuestion.course == courseID)
     questionanswers = [question.questionContent for question in questionData]
     courseData = questionData[0]

--- a/app/controllers/serviceLearning/routes.py
+++ b/app/controllers/serviceLearning/routes.py
@@ -29,11 +29,10 @@ def serviceCourseManagement(username=None):
 
 @serviceLearning_bp.route('/serviceLearning/editProposal/<courseID>', methods=['GET', 'POST'])
 def slcEditProposal(courseID):
-    courseData = CourseQuestion.get(CourseQuestion.course == courseID)
+    questionData = CourseQuestion.select().where(CourseQuestion.course == courseID)
+    courseData = questionData[0]
     courseInstructor = CourseInstructor.select().where(CourseInstructor.course == courseID)
 
-    for inst in courseInstructor:
-        print(inst.user.firstName)
     isRegularlyOccuring = ""
     isAllSectionsServiceLearning = ""
     isPermanentlyDesignated = ""
@@ -47,14 +46,9 @@ def slcEditProposal(courseID):
 
     terms = Term.select().where(Term.year >= g.current_term.year)
 
-    print(type(courseData.course.term))
-
-    for term in terms:
-        print(type(term))
-        if courseData.course.term == term.id:
-            print("Hello")
     return render_template('serviceLearning/slcNewProposal.html',
                                 courseData = courseData,
+                                questionData = questionData,
                                 terms = terms,
                                 courseInstructor = courseInstructor,
                                 isRegularlyOccuring = isRegularlyOccuring,

--- a/app/controllers/serviceLearning/routes.py
+++ b/app/controllers/serviceLearning/routes.py
@@ -26,6 +26,13 @@ def serviceCourseManagement(username=None):
     else:
         flash("Unauthorized to view page", 'warning')
         return redirect(url_for('main.events'))
+@serviceLearning_bp.route('/serviceLearning/editProposal/<courseID>', methods=['GET', 'POST'])
+def slcEditProposal(courseID):
+    courseData = CourseQuestion.get(CourseQuestion.course == courseID)
+    print(courseData.course.id)
+    print(courseData.course.courseName)
+    terms = Term.select().where(Term.year >= g.current_term.year)
+    return render_template('serviceLearning/slcNewProposal.html', courseData = courseData, terms = terms)
 
 @serviceLearning_bp.route('/serviceLearning/newProposal', methods=['GET', 'POST'])
 def slcNewProposal():
@@ -57,7 +64,8 @@ def slcNewProposal():
         return redirect('/serviceLearning/courseManagement')
 
     terms = Term.select().where(Term.year >= g.current_term.year)
-    return render_template('serviceLearning/slcNewProposal.html', terms=terms)
+    courseData = None
+    return render_template('serviceLearning/slcNewProposal.html', terms=terms, courseData = courseData)
 
 instructorsDict = {}
 @serviceLearning_bp.route('/courseInstructors', methods=['POST'])

--- a/app/logic/courseManagement.py
+++ b/app/logic/courseManagement.py
@@ -62,9 +62,5 @@ def updateCourse(courseData):
         isPermanentlyDesignated=1 if "on" in courseData["permanentDesignation"] else 0,
     ).where(Course.id == courseData['courseID']).execute()
     for i in range(1, 7):
-        CourseQuestion.update(
-            course=course,
-            questionContent=courseData[f"{i}"]
-        ).where(CourseQuestion.questionNumber == i).execute()
-    for instructor in instructorsDict["instructors"]:
-        CourseInstructor.update(course=course, user=instructor.username).where(Course.id == courseData['courseID']).execute()
+        (CourseQuestion.update(questionContent=courseData[f"{i}"])
+                    .where((CourseQuestion.questionNumber == i) & (CourseQuestion.course==courseData["courseID"])).execute())

--- a/app/logic/courseManagement.py
+++ b/app/logic/courseManagement.py
@@ -44,13 +44,32 @@ def getinstructorData(courseIds):
 
     return instructorDict
 
-def createOrUpdate(id):
-    """This function will return True or False based on wether a course exist or not"""
-    coursecheck = Course.get_or_none(Course.id == id)
-
-    if coursecheck != None:
-        return False
-    return True
+def createCourse(courseData, instructorsDict):
+    """This function will create a course given a form."""
+    term = Term.get(Term.id==courseData["term"])
+    status = CourseStatus.get(CourseStatus.status == "Pending")
+    for toggler in ["regularOccurenceToggle", "slSectionsToggle", "permanentDesignation"]:
+        courseData.setdefault(toggler, "off")
+    course = Course.create(
+        courseName=courseData["courseName"],
+        courseAbbreviation=courseData["courseAbbreviation"],
+        courseCredit=courseData["credit"],
+        isRegularlyOccuring=("on" in courseData["regularOccurenceToggle"]),
+        term=term,
+        status=status,
+        createdBy=g.current_user,
+        isAllSectionsServiceLearning=("on" in courseData["slSectionsToggle"]),
+        serviceLearningDesignatedSections=courseData["slDesignation"],
+        isPermanentlyDesignated=("on" in courseData["permanentDesignation"]),
+    )
+    for i in range(1, 7):
+        CourseQuestion.create(
+            course=course,
+            questionContent=courseData[f"{i}"],
+            questionNumber=i
+        )
+    for instructor in instructorsDict["instructors"]:
+        CourseInstructor.create(course=course, user=instructor.username)
 
 def updateCourse(courseData, instructorsDict):
     """

--- a/app/logic/courseManagement.py
+++ b/app/logic/courseManagement.py
@@ -50,13 +50,12 @@ def updateCourse(courseData, instructorsDict):
         courseData.setdefault(toggler, "off")
     status = CourseStatus.get(CourseStatus.status == "Pending")
     course = Course.update(
-        courseName= courseData["courseName"],
+        courseName=courseData["courseName"],
         courseAbbreviation=courseData["courseAbbreviation"],
         courseCredit=courseData["credit"],
         isRegularlyOccuring=1 if "on" in courseData["regularOccurenceToggle"] else 0,
-        term= courseData['term'],
+        term=courseData['term'],
         status=status,
-        createdBy=g.current_user,
         isAllSectionsServiceLearning=1 if "on" in courseData["slSectionsToggle"] else 0,
         serviceLearningDesignatedSections=courseData["slDesignation"],
         isPermanentlyDesignated=1 if "on" in courseData["permanentDesignation"] else 0,
@@ -64,9 +63,6 @@ def updateCourse(courseData, instructorsDict):
     for i in range(1, 7):
         (CourseQuestion.update(questionContent=courseData[f"{i}"])
                     .where((CourseQuestion.questionNumber == i) & (CourseQuestion.course==courseData["courseID"])).execute())
-    currentInstructors = CourseInstructor.select().where(CourseInstructor.course == courseData["courseID"])
-    instructors = [instructor.user for instructor in currentInstructors]
-    print(instructors)
+    removeInstructors = CourseInstructor.delete().where(CourseInstructor.course == courseData["courseID"]).execute()
     for instructor in instructorsDict["instructors"]:
-        if instructor not in instructors:
-            CourseInstructor.create(course=courseData["courseID"], user=instructor.username)
+        addInstructors = CourseInstructor.create(course=courseData["courseID"], user=instructor)

--- a/app/logic/courseManagement.py
+++ b/app/logic/courseManagement.py
@@ -44,8 +44,8 @@ def getinstructorData(courseIds):
 
     return instructorDict
 
-def updateCourse(courseData):
-    print(courseData['courseID'])
+def updateCourse(courseData, instructorsDict):
+    print(instructorsDict)
     for toggler in ["regularOccurenceToggle", "slSectionsToggle", "permanentDesignation"]:
         courseData.setdefault(toggler, "off")
     status = CourseStatus.get(CourseStatus.status == "Pending")
@@ -64,3 +64,9 @@ def updateCourse(courseData):
     for i in range(1, 7):
         (CourseQuestion.update(questionContent=courseData[f"{i}"])
                     .where((CourseQuestion.questionNumber == i) & (CourseQuestion.course==courseData["courseID"])).execute())
+    currentInstructors = CourseInstructor.select().where(CourseInstructor.course == courseData["courseID"])
+    instructors = [instructor.user for instructor in currentInstructors]
+    print(instructors)
+    for instructor in instructorsDict["instructors"]:
+        if instructor not in instructors:
+            CourseInstructor.create(course=courseData["courseID"], user=instructor.username)

--- a/app/logic/courseManagement.py
+++ b/app/logic/courseManagement.py
@@ -44,7 +44,19 @@ def getinstructorData(courseIds):
 
     return instructorDict
 
+def createOrUpdate(id):
+    """This function will return True or False based on wether a course exist or not"""
+    coursecheck = Course.get_or_none(Course.id == id)
+
+    if coursecheck != None:
+        return False
+    return True
+
 def updateCourse(courseData, instructorsDict):
+    """
+        This function will take in courseData for the SLC proposal page and a dictionary
+        of instuctors assigned to the course and update the information in the db.
+    """
     print(instructorsDict)
     for toggler in ["regularOccurenceToggle", "slSectionsToggle", "permanentDesignation"]:
         courseData.setdefault(toggler, "off")
@@ -53,12 +65,12 @@ def updateCourse(courseData, instructorsDict):
         courseName=courseData["courseName"],
         courseAbbreviation=courseData["courseAbbreviation"],
         courseCredit=courseData["credit"],
-        isRegularlyOccuring=1 if "on" in courseData["regularOccurenceToggle"] else 0,
+        isRegularlyOccuring=("on" in courseData["regularOccurenceToggle"]),
         term=courseData['term'],
         status=status,
-        isAllSectionsServiceLearning=1 if "on" in courseData["slSectionsToggle"] else 0,
+        isAllSectionsServiceLearning=("on" in courseData["slSectionsToggle"]),
         serviceLearningDesignatedSections=courseData["slDesignation"],
-        isPermanentlyDesignated=1 if "on" in courseData["permanentDesignation"] else 0,
+        isPermanentlyDesignated=("on" in courseData["permanentDesignation"]),
     ).where(Course.id == courseData['courseID']).execute()
     for i in range(1, 7):
         (CourseQuestion.update(questionContent=courseData[f"{i}"])

--- a/app/logic/courseManagement.py
+++ b/app/logic/courseManagement.py
@@ -45,7 +45,6 @@ def getinstructorData(courseIds):
     return instructorDict
 
 def updateCourse(courseData, instructorsDict):
-    print(instructorsDict)
     for toggler in ["regularOccurenceToggle", "slSectionsToggle", "permanentDesignation"]:
         courseData.setdefault(toggler, "off")
     status = CourseStatus.get(CourseStatus.status == "Pending")

--- a/app/logic/courseManagement.py
+++ b/app/logic/courseManagement.py
@@ -45,6 +45,7 @@ def getinstructorData(courseIds):
     return instructorDict
 
 def updateCourse(courseData):
+    print(courseData['courseID'])
     for toggler in ["regularOccurenceToggle", "slSectionsToggle", "permanentDesignation"]:
         courseData.setdefault(toggler, "off")
     status = CourseStatus.get(CourseStatus.status == "Pending")
@@ -59,12 +60,11 @@ def updateCourse(courseData):
         isAllSectionsServiceLearning=1 if "on" in courseData["slSectionsToggle"] else 0,
         serviceLearningDesignatedSections=courseData["slDesignation"],
         isPermanentlyDesignated=1 if "on" in courseData["permanentDesignation"] else 0,
-    ).where(Course.courseName == courseData['courseName']).execute()
-    # for i in range(1, 7):
-    #     CourseQuestion.update(
-    #         course=course,
-    #         questionContent=courseData[f"{i}"]
-    #     ).where(CourseQuestion.questionNumber == i).execute()
-    # for instructor in instructorsDict["instructors"]:
-    #     CourseInstructor.update(course=course, user=instructor.username).where(Course.courseName == courseData['courseName']).execute()
-    return redirect('/serviceLearning/courseManagement')
+    ).where(Course.id == courseData['courseID']).execute()
+    for i in range(1, 7):
+        CourseQuestion.update(
+            course=course,
+            questionContent=courseData[f"{i}"]
+        ).where(CourseQuestion.questionNumber == i).execute()
+    for instructor in instructorsDict["instructors"]:
+        CourseInstructor.update(course=course, user=instructor.username).where(Course.id == courseData['courseID']).execute()

--- a/app/logic/courseManagement.py
+++ b/app/logic/courseManagement.py
@@ -44,26 +44,27 @@ def getinstructorData(courseIds):
 
     return instructorDict
 
-def updatecourse(courseData):
-    print("hello")
+def updateCourse(courseData):
+    for toggler in ["regularOccurenceToggle", "slSectionsToggle", "permanentDesignation"]:
+        courseData.setdefault(toggler, "off")
     status = CourseStatus.get(CourseStatus.status == "Pending")
     course = Course.update(
         courseName= courseData["courseName"],
         courseAbbreviation=courseData["courseAbbreviation"],
         courseCredit=courseData["credit"],
-        isRegularlyOccuring=1 if courseData["regularOccurenceToggle"] else 0,
+        isRegularlyOccuring=1 if "on" in courseData["regularOccurenceToggle"] else 0,
         term= courseData['term'],
         status=status,
         createdBy=g.current_user,
-        isAllSectionsServiceLearning=1 if courseData["slSectionsToggle"] else 0,
+        isAllSectionsServiceLearning=1 if "on" in courseData["slSectionsToggle"] else 0,
         serviceLearningDesignatedSections=courseData["slDesignation"],
-        isPermanentlyDesignated=1 if courseData["permanentDesignation"] else 0,
+        isPermanentlyDesignated=1 if "on" in courseData["permanentDesignation"] else 0,
     ).where(Course.courseName == courseData['courseName']).execute()
-    for i in range(1, 7):
-        CourseQuestion.update(
-            course=course,
-            questionContent=courseData[f"{i}"]
-        ).where(CourseQuestion.questionNumber == i).execute()
-    for instructor in instructorsDict["instructors"]:
-        CourseInstructor.update(course=course, user=instructor.username).where(Course.courseName == courseData['courseName']).execute()
+    # for i in range(1, 7):
+    #     CourseQuestion.update(
+    #         course=course,
+    #         questionContent=courseData[f"{i}"]
+    #     ).where(CourseQuestion.questionNumber == i).execute()
+    # for instructor in instructorsDict["instructors"]:
+    #     CourseInstructor.update(course=course, user=instructor.username).where(Course.courseName == courseData['courseName']).execute()
     return redirect('/serviceLearning/courseManagement')

--- a/app/logic/searchUsers.py
+++ b/app/logic/searchUsers.py
@@ -1,6 +1,6 @@
 from app.models.user import User
 
-def searchUsers(query):
+def searchUsers(query, object):
     '''Accepts user input and queries the database returning results that matches user search'''
     query = query.strip()
     search = query.upper()
@@ -15,6 +15,8 @@ def searchUsers(query):
         for participant in results:
             if participant not in resultsDict:
                 resultsDict[f"{participant.firstName} {participant.lastName} ({participant.username})"] = f"{participant.firstName} {participant.lastName} ({participant.username})"
+                if object:
+                    resultsDict[f"{participant.username} phoneNumber"] = participant.phoneNumber
     else:
         for searchTerm in splitSearch: #searching for specified first and last name
             if len(searchTerm) > 1:
@@ -23,6 +25,8 @@ def searchUsers(query):
                 for participant in results:
                     if participant not in resultsDict:
                         resultsDict[f"{participant.firstName} {participant.lastName} ({participant.username})"] = f"{participant.firstName} {participant.lastName} ({participant.username})"
+                        if object:
+                            resultsDict[f"{participant.username} phoneNumber"] = participant.phoneNumber
 
-    print("resultsDict",resultsDict)
+    print("resultsDict", resultsDict)
     return resultsDict

--- a/app/logic/searchUsers.py
+++ b/app/logic/searchUsers.py
@@ -1,12 +1,12 @@
+from playhouse.shortcuts import model_to_dict
 from app.models.user import User
-
-def searchUsers(query, phoneNumber):
+def searchUsers(query):
     '''Accepts user input and queries the database returning results that matches user search'''
+    print(query)
     query = query.strip()
     search = query.upper()
     splitSearch = search.split()
     resultsDict = {}
-    print(phoneNumber)
 
     firstName = splitSearch[0] + "%"
     lastName = " ".join(splitSearch[1:]) +"%"
@@ -15,9 +15,7 @@ def searchUsers(query, phoneNumber):
         results = User.select().where(User.isStudent & (User.firstName ** firstName | User.lastName ** firstName))
         for participant in results:
             if participant not in resultsDict:
-                resultsDict[f"{participant.firstName} {participant.lastName} ({participant.username})"] = f"{participant.firstName} {participant.lastName} ({participant.username})"
-                if phoneNumber:
-                    resultsDict[f"{participant.username} phoneNumber"] = participant.phoneNumber
+                resultsDict[participant.username]=model_to_dict(participant)
     else:
         for searchTerm in splitSearch: #searching for specified first and last name
             if len(searchTerm) > 1:
@@ -25,8 +23,6 @@ def searchUsers(query, phoneNumber):
                 results = User.select().where(User.isStudent & User.firstName ** firstName & User.lastName ** lastName)
                 for participant in results:
                     if participant not in resultsDict:
-                        resultsDict[f"{participant.firstName} {participant.lastName} ({participant.username})"] = f"{participant.firstName} {participant.lastName} ({participant.username})"
-                        if phoneNumber:
-                            resultsDict[f"{participant.username} phoneNumber"] = participant.phoneNumber
+                        resultsDict[participant.username]=model_to_dict(participant)
 
     return resultsDict

--- a/app/logic/searchUsers.py
+++ b/app/logic/searchUsers.py
@@ -2,7 +2,6 @@ from playhouse.shortcuts import model_to_dict
 from app.models.user import User
 def searchUsers(query):
     '''Accepts user input and queries the database returning results that matches user search'''
-    print(query)
     query = query.strip()
     search = query.upper()
     splitSearch = search.split()

--- a/app/logic/searchUsers.py
+++ b/app/logic/searchUsers.py
@@ -6,6 +6,7 @@ def searchUsers(query, phoneNumber):
     search = query.upper()
     splitSearch = search.split()
     resultsDict = {}
+    print(phoneNumber)
 
     firstName = splitSearch[0] + "%"
     lastName = " ".join(splitSearch[1:]) +"%"
@@ -15,7 +16,7 @@ def searchUsers(query, phoneNumber):
         for participant in results:
             if participant not in resultsDict:
                 resultsDict[f"{participant.firstName} {participant.lastName} ({participant.username})"] = f"{participant.firstName} {participant.lastName} ({participant.username})"
-                if phoneNumber=="true":
+                if phoneNumber:
                     resultsDict[f"{participant.username} phoneNumber"] = participant.phoneNumber
     else:
         for searchTerm in splitSearch: #searching for specified first and last name
@@ -25,7 +26,7 @@ def searchUsers(query, phoneNumber):
                 for participant in results:
                     if participant not in resultsDict:
                         resultsDict[f"{participant.firstName} {participant.lastName} ({participant.username})"] = f"{participant.firstName} {participant.lastName} ({participant.username})"
-                        if phoneNumber=="true":
+                        if phoneNumber:
                             resultsDict[f"{participant.username} phoneNumber"] = participant.phoneNumber
 
     return resultsDict

--- a/app/logic/searchUsers.py
+++ b/app/logic/searchUsers.py
@@ -1,6 +1,6 @@
 from app.models.user import User
 
-def searchUsers(query, object):
+def searchUsers(query, phoneNumber):
     '''Accepts user input and queries the database returning results that matches user search'''
     query = query.strip()
     search = query.upper()
@@ -15,7 +15,7 @@ def searchUsers(query, object):
         for participant in results:
             if participant not in resultsDict:
                 resultsDict[f"{participant.firstName} {participant.lastName} ({participant.username})"] = f"{participant.firstName} {participant.lastName} ({participant.username})"
-                if object=="true":
+                if phoneNumber=="true":
                     resultsDict[f"{participant.username} phoneNumber"] = participant.phoneNumber
     else:
         for searchTerm in splitSearch: #searching for specified first and last name
@@ -25,8 +25,7 @@ def searchUsers(query, object):
                 for participant in results:
                     if participant not in resultsDict:
                         resultsDict[f"{participant.firstName} {participant.lastName} ({participant.username})"] = f"{participant.firstName} {participant.lastName} ({participant.username})"
-                        if object=="true":
+                        if phoneNumber=="true":
                             resultsDict[f"{participant.username} phoneNumber"] = participant.phoneNumber
 
-    print("resultsDict", resultsDict)
     return resultsDict

--- a/app/logic/searchUsers.py
+++ b/app/logic/searchUsers.py
@@ -15,7 +15,7 @@ def searchUsers(query, object):
         for participant in results:
             if participant not in resultsDict:
                 resultsDict[f"{participant.firstName} {participant.lastName} ({participant.username})"] = f"{participant.firstName} {participant.lastName} ({participant.username})"
-                if object:
+                if object=="true":
                     resultsDict[f"{participant.username} phoneNumber"] = participant.phoneNumber
     else:
         for searchTerm in splitSearch: #searching for specified first and last name
@@ -25,7 +25,7 @@ def searchUsers(query, object):
                 for participant in results:
                     if participant not in resultsDict:
                         resultsDict[f"{participant.firstName} {participant.lastName} ({participant.username})"] = f"{participant.firstName} {participant.lastName} ({participant.username})"
-                        if object:
+                        if object=="true":
                             resultsDict[f"{participant.username} phoneNumber"] = participant.phoneNumber
 
     print("resultsDict", resultsDict)

--- a/app/logic/searchUsers.py
+++ b/app/logic/searchUsers.py
@@ -23,4 +23,6 @@ def searchUsers(query):
                 for participant in results:
                     if participant not in resultsDict:
                         resultsDict[f"{participant.firstName} {participant.lastName} ({participant.username})"] = f"{participant.firstName} {participant.lastName} ({participant.username})"
+
+    print("resultsDict",resultsDict)
     return resultsDict

--- a/app/static/js/base.js
+++ b/app/static/js/base.js
@@ -2,7 +2,7 @@
 function msgFlash(flash_message, status){
     if (status === "success") {
         category = "success";
-        $("#flash_container").prepend("<div class=\"alert alert-"+ category +"\" role=\"alert\" id=\"flasher\">"+flash_message+"</div>");
+        $("#flash_container").prepend('<div class=\"alert alert-'+ category + '\" role="alert" id="flasher">' + flash_message + '</div>');
         $("#flasher").delay(5000).fadeOut();
     }
     else {

--- a/app/static/js/base.js
+++ b/app/static/js/base.js
@@ -1,13 +1,12 @@
-
 function msgFlash(flash_message, status){
     if (status === "success") {
         category = "success";
-        $("#flash_container").prepend('<div class=\"alert alert-'+ category + '\" role="alert" id="flasher">' + flash_message + '</div>');
+        $("#flash_container").prepend('<div class=\"w-50 position-absolute top-0 start-50 translate-middle-x alert alert-'+ category + '\" role="alert" id="flasher">' + flash_message + '</div>');
         $("#flasher").delay(5000).fadeOut();
     }
     else {
         category = "danger";
-        $("#flash_container").prepend("<div class=\"alert alert-"+ category +"\" role=\"alert\" id=\"flasher\">"+flash_message+"</div>");
+        $("#flash_container").prepend("<div class=\"w-50 position-absolute top-0 start-50 translate-middle-x alert alert-"+ category +"\" role=\"alert\" id=\"flasher\">"+flash_message+"</div>");
         $("#flasher").delay(5000).fadeOut();
     }
 

--- a/app/static/js/searchUser.js
+++ b/app/static/js/searchUser.js
@@ -18,7 +18,6 @@ export default function searchUser(inputId, callback, parentElementId=null, obje
             })
           )}
           else {
-            console.log("phone")
             response(Object.keys(dictToJSON).map( (item, index) => {
               if (index === 0){
                 return {
@@ -44,6 +43,8 @@ export default function searchUser(inputId, callback, parentElementId=null, obje
        var user = ui.item.value
        $(`#${inputId}`).val(ui.item.value);
        callback();
+       $(`#${inputId}`).val("");
+       return false;
      }
   });
 };

--- a/app/static/js/searchUser.js
+++ b/app/static/js/searchUser.js
@@ -1,6 +1,6 @@
 export default function searchUser(inputId, callback, parentElementId=null){
   var query = $(`#${inputId}`).val()
-
+  console.log(query)
   $(`#${inputId}`).autocomplete({
     appendTo: (parentElementId === null) ? null : `#${parentElementId}`,
     minLength: 2,

--- a/app/static/js/searchUser.js
+++ b/app/static/js/searchUser.js
@@ -18,6 +18,7 @@ export default function searchUser(inputId, callback, parentElementId=null, obje
             })
           )}
           else {
+            console.log("phone")
             response(Object.keys(dictToJSON).map( (item, index) => {
               if (index === 0){
                 return {

--- a/app/static/js/searchUser.js
+++ b/app/static/js/searchUser.js
@@ -19,10 +19,16 @@ export default function searchUser(inputId, callback, parentElementId=null, obje
           )}
           else {
             response(Object.keys(dictToJSON).map( (item, index) => {
-              if (index ===0){
+              if (index === 0){
                 return {
                   label: item,
-                  value: dictToJSON[item]
+                  value: Object.values(dictToJSON)
+                }
+              }
+              else {
+                return {
+                  label: "",
+                  value: ""
                 }
               }
             })

--- a/app/static/js/searchUser.js
+++ b/app/static/js/searchUser.js
@@ -1,15 +1,15 @@
-export default function searchUser(inputId, callback, parentElementId=null, object=false){
+export default function searchUser(inputId, callback, parentElementId=null, phoneNumber=false){
   var query = $(`#${inputId}`).val()
   $(`#${inputId}`).autocomplete({
     appendTo: (parentElementId === null) ? null : `#${parentElementId}`,
     minLength: 2,
     source: function(request, response) {
       $.ajax({
-        url: `/searchUser/${query}/${object}`,
+        url: `/searchUser/${query}/${phoneNumber}`,
         type: "GET",
         dataType: "json",
         success: function(dictToJSON) {
-          if (object===false){
+          if (phoneNumber===false){
             response($.map( dictToJSON, function( item ) {
               return {
                 label: item,
@@ -18,7 +18,6 @@ export default function searchUser(inputId, callback, parentElementId=null, obje
             })
           )}
           else {
-            console.log("phone")
             response(Object.keys(dictToJSON).map( (item, index) => {
               if (index === 0){
                 return {

--- a/app/static/js/searchUser.js
+++ b/app/static/js/searchUser.js
@@ -1,45 +1,43 @@
-export default function searchUser(inputId, callback, parentElementId=null, phoneNumber=0){
+export default function searchUser(inputId, callback, parentElementId=null, columnRequested=null){
   var query = $(`#${inputId}`).val()
+  let columnDict={};
   $(`#${inputId}`).autocomplete({
     appendTo: (parentElementId === null) ? null : `#${parentElementId}`,
     minLength: 2,
     source: function(request, response) {
       $.ajax({
-        url: `/searchUser/${query}/${phoneNumber}`,
+        url: `/searchUser/${query}`,
         type: "GET",
         dataType: "json",
-        success: function(dictToJSON) {
-          if (phoneNumber===false){
-            response($.map( dictToJSON, function( item ) {
+        success: function(searchResults) {
+          response(Object.entries(searchResults).map( (item) => {
+            if (!columnRequested){
               return {
-                label: item,
-                value: dictToJSON[item]
+                // label: firstName lastName (username)
+                // value: username
+                label: (item[1]["firstName"]+" "+item[1]["lastName"]+" ("+item[0]+")"),
+                value: item[0]
               }
-            })
-          )}
-          else {
-            response(Object.keys(dictToJSON).map( (item, index) => {
-              if (index === 0){
-                return {
-                  label: item,
-                  value: Object.values(dictToJSON)
-                }
+            } else {
+              for (const column of columnRequested) {
+                columnDict[column]=item[1][column];
+              };
+              return {
+                // label: firstName lastName (username)
+                // value: "{column: response, column2: response2, ...}"
+                // must JSON.parse
+                label: (item[1]["firstName"]+" "+item[1]["lastName"]+" ("+item[0]+")"),
+                value: JSON.stringify(columnDict)
               }
-              else {
-                return {
-                  label: "",
-                  value: ""
-                }
-              }
-            })
-          )}
-        },
+            }
+          }
+        ))},
         error: function(request, status, error) {
           console.log(status, error);
         }
       })
     },
-     select: function(event , ui) {
+     select: function(event, ui) {
        var user = ui.item.value
        $(`#${inputId}`).val(ui.item.value);
        callback();

--- a/app/static/js/searchUser.js
+++ b/app/static/js/searchUser.js
@@ -1,4 +1,4 @@
-export default function searchUser(inputId, callback, parentElementId=null, phoneNumber=false){
+export default function searchUser(inputId, callback, parentElementId=null, phoneNumber=0){
   var query = $(`#${inputId}`).val()
   $(`#${inputId}`).autocomplete({
     appendTo: (parentElementId === null) ? null : `#${parentElementId}`,

--- a/app/static/js/searchUser.js
+++ b/app/static/js/searchUser.js
@@ -1,21 +1,32 @@
-export default function searchUser(inputId, callback, parentElementId=null){
+export default function searchUser(inputId, callback, parentElementId=null, object=false){
   var query = $(`#${inputId}`).val()
-  console.log(query)
   $(`#${inputId}`).autocomplete({
     appendTo: (parentElementId === null) ? null : `#${parentElementId}`,
     minLength: 2,
     source: function(request, response) {
       $.ajax({
-        url: `/searchUser/${query}`,
+        url: `/searchUser/${query}/${object}`,
         type: "GET",
         dataType: "json",
         success: function(dictToJSON) {
-          response($.map( dictToJSON, function( item ) {
-            return {
-              label: item,
-              value: dictToJSON[item]
-            }
-          }))
+          if (object===false){
+            response($.map( dictToJSON, function( item ) {
+              return {
+                label: item,
+                value: dictToJSON[item]
+              }
+            })
+          )}
+          else {
+            response(Object.keys(dictToJSON).map( (item, index) => {
+              if (index ===0){
+                return {
+                  label: item,
+                  value: dictToJSON[item]
+                }
+              }
+            })
+          )}
         },
         error: function(request, status, error) {
           console.log(status, error);

--- a/app/static/js/slcManagement.js
+++ b/app/static/js/slcManagement.js
@@ -9,17 +9,18 @@ $(document).ready(function() {
 });
 
 function changeAction(action){
+  courseID = action.id;
   // decides what to do based on selection
   if (action.value=="Renew"){
     // Renew
   } else if (action.value=="View"){
     // View
   } else if (action.value=="Withdraw"){
-    courseID = action.id;
     $('#courseID').val(courseID);
     $('#withdrawModal').modal('show');
   } else if(action.value=="Edit"){
-    // Edit
+    console.log(courseID)
+    location = '/serviceLearning/editProposal/' + courseID;
   }
 }
 

--- a/app/static/js/slcManagement.js
+++ b/app/static/js/slcManagement.js
@@ -19,7 +19,6 @@ function changeAction(action){
     $('#courseID').val(courseID);
     $('#withdrawModal').modal('show');
   } else if(action.value=="Edit"){
-    console.log(courseID)
     location = '/serviceLearning/editProposal/' + courseID;
   }
 }

--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -89,14 +89,15 @@ function callback() {
   let data = $("#courseInstructor").val();
   data = data.split(",");
   let instructor = data[0]
+  let username = instructor.split('(').pop().split(')')[0]; // returns 'two'
   let phone = data[1]
   let tableBody = $("#instructorTable").find("tbody");
   let lastRow = tableBody.find("tr:last");
   let newRow = lastRow.clone();
   newRow.find("td:eq(0) p").text(instructor);
   newRow.find("td:eq(0) div input").val(phone);
-  newRow.find("td:eq(0) div button").attr("data-id", instructor);
-  newRow.find("td:eq(0) div input").attr("id", instructor);
+  newRow.find("td:eq(0) div button").attr("data-id", username);
+  newRow.find("td:eq(0) div input").attr("id", username);
   newRow.prop("hidden", false);
   lastRow.after(newRow);
 }
@@ -107,9 +108,7 @@ $("#courseInstructor").on('input', function() {
 
 $("#instructorTable").on("click", "#instructorPhoneUpdate", function() {
    var inputId = $(this).attr("data-id")
-   console.log($("#" + inputId).val())
    var instructorData = [inputId, $("#" + inputId).val()]
-
    $.ajax({
      url: "/updateInstructorPhone",
      data: JSON.stringify(instructorData),
@@ -133,7 +132,6 @@ let courseInstructors = []
 async function saveCourseInstructors() {
   $("#instructorTable tr").each(function(a, b) {
     courseInstructors.push($('.instructorName', b).text());
-    console.log(courseInstructors)
   });
   return await $.ajax({
     url: "/courseInstructors",

--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -59,7 +59,21 @@ function displayCorrectTab(navigateTab) {
 function validateForm() {
   // TODO: Generalize form validation to include textareas and selects
   // This function deals with validation of the form fields
-  return true;
+  let valid = true;
+  console.log($( ":input" ));
+  let allTabs = $(".tab");
+  let allInputs = $(allTabs[currentTab]).find("input");
+
+  for (let i = 0; i < allInputs.length; i++) {
+    if (allInputs[i].value == "") {
+      allInputs[i].className += " invalid";
+      valid = false;
+    }
+  }
+  if (valid) {
+    $(".step")[currentTab].className += " finish"
+  }
+  return valid;
 }
 
 function fixStepIndicator(navigateTab) {
@@ -73,8 +87,7 @@ function fixStepIndicator(navigateTab) {
 
 // TODO: empty the courseInstructor input after an instructor has been added to the table.
 function callback() {
-  let data = $("#courseInstructor").val();
-  data = data.split(",");
+  let data = $("#courseInstructor").val().split(",");
   let instructor = data[0]
   let username = instructor.split('(').pop().split(')')[0]; // returns 'two'
   let phone = data[1]
@@ -90,7 +103,7 @@ function callback() {
 }
 
 $("#courseInstructor").on('input', function() {
-  searchUser("courseInstructor", callback, null, true);
+  searchUser("courseInstructor", callback, null, 1);
 });
 
 $("#instructorTable").on("click", "#instructorPhoneUpdate", function() {
@@ -105,7 +118,6 @@ $("#instructorTable").on("click", "#instructorPhoneUpdate", function() {
          msgFlash("Instructor's phone number updated", "success")
      },
      error: function(request, status, error) {
-       console.log(status,error);
        msgFlash("Error updating phone number", "danger")
      }
    });

--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -72,7 +72,7 @@ function validateForm() {
   if (valid) {
     $(".step")[currentTab].className += " finish"
   }
-  return valid;
+  return true;
 }
 
 function fixStepIndicator(navigateTab) {

--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -63,11 +63,12 @@ function validateForm() {
   let allTabs = $(".tab");
   let allInputs = $(allTabs[currentTab]).find("input");
   for (let i = 0; i < allInputs.length; i++) {
-    console.log(allInputs[i])
-    if ($(allInputs[i].id).attr("required")) {
-      if (allInputs[i].value == ""){
+    if (allInputs[i].required) {
+      if (!allInputs[i].value){
         allInputs[i].className += " invalid";
         valid = false;
+      } else {
+        allInputs[i].className = "form-control";
       }
     }
   }
@@ -86,12 +87,12 @@ function fixStepIndicator(navigateTab) {
   steps[navigateTab].className += " active";
 }
 
-// TODO: empty the courseInstructor input after an instructor has been added to the table.
 function callback() {
-  let data = $("#courseInstructor").val().split(",");
-  let instructor = data[0]
-  let username = instructor.split('(').pop().split(')')[0]; // returns 'two'
-  let phone = data[1]
+  // JSON.parse is required to de-stringify the search results into a dictionary.
+  let data = JSON.parse($("#courseInstructor").val());
+  let instructor = (data["firstName"]+" "+data["lastName"]+" ("+data["username"]+")");
+  let username = data["username"];
+  let phone = data["phoneNumber"];
   let tableBody = $("#instructorTable").find("tbody");
   let lastRow = tableBody.find("tr:last");
   let newRow = lastRow.clone();
@@ -104,7 +105,8 @@ function callback() {
 }
 
 $("#courseInstructor").on('input', function() {
-  searchUser("courseInstructor", callback, null, 1);
+  // To retrieve specific columns into a dict, create a [] list and put columns inside
+  searchUser("courseInstructor", callback, null, ["phoneNumber", "firstName", "lastName", "username"]);
 });
 
 $("#instructorTable").on("click", "#instructorPhoneUpdate", function() {

--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -59,19 +59,6 @@ function displayCorrectTab(navigateTab) {
 function validateForm() {
   // TODO: Generalize form validation to include textareas and selects
   // This function deals with validation of the form fields
-  let valid = true;
-  let allTabs = $(".tab");
-  let allInputs = $(allTabs[currentTab]).find("input");
-
-  for (let i = 0; i < allInputs.length; i++) {
-    if (allInputs[i].value == "") {
-      allInputs[i].className += " invalid";
-      valid = false;
-    }
-  }
-  if (valid) {
-    $(".step")[currentTab].className += " finish"
-  }
   return true;
 }
 

--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -95,9 +95,8 @@ function callback() {
   let newRow = lastRow.clone();
   newRow.find("td:eq(0) p").text(instructor);
   newRow.find("td:eq(0) div input").val(phone);
-  newRow.find("td:eq(0) div button").attr("data-id", phone);
-  newRow.find("td:eq(0) div input").attr("data-id", instructor);
-  newRow.find("td:eq(0) div input").attr("id", phone);
+  newRow.find("td:eq(0) div button").attr("data-id", instructor);
+  newRow.find("td:eq(0) div input").attr("id", instructor);
   newRow.prop("hidden", false);
   lastRow.after(newRow);
 }
@@ -108,14 +107,21 @@ $("#courseInstructor").on('input', function() {
 
 $("#instructorTable").on("click", "#instructorPhoneUpdate", function() {
    var inputId = $(this).attr("data-id")
-   var instructorData = [$("#" + inputId).attr("data-id"), $("#" + inputId).val()]
+   console.log($("#" + inputId).val())
+   var instructorData = [inputId, $("#" + inputId).val()]
 
    $.ajax({
      url: "/updateInstructorPhone",
      data: JSON.stringify(instructorData),
      type: "POST",
      contentType: "application/json",
-     success: function(){}
+     success: function(response) {
+         msgFlash("Instructor's phone number updated", "success")
+     },
+     error: function(request, status, error) {
+       console.log(status,error);
+       msgFlash("Error updating phone number", "danger")
+     }
    });
 });
 

--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -96,7 +96,7 @@ function callback() {
 }
 
 $("#courseInstructor").on('input', function() {
-  searchUser("courseInstructor", callback);
+  searchUser("courseInstructor", callback, null, true);
 });
 
 $("#instructorTable").on("click", "#remove", function() {
@@ -107,6 +107,7 @@ let courseInstructors = []
 async function saveCourseInstructors() {
   $("#instructorTable tr").each(function(a, b) {
     courseInstructors.push($('.instructorName', b).text());
+    console.log(courseInstructors)
   });
   return await $.ajax({
     url: "/courseInstructors",

--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -60,21 +60,22 @@ function validateForm() {
   // TODO: Generalize form validation to include textareas and selects
   // This function deals with validation of the form fields
   let valid = true;
-  console.log($( ":input" ));
   let allTabs = $(".tab");
   let allInputs = $(allTabs[currentTab]).find("input");
-
   for (let i = 0; i < allInputs.length; i++) {
-    if (allInputs[i].value == "") {
-      allInputs[i].className += " invalid";
-      valid = false;
+    console.log(allInputs[i])
+    if ($(allInputs[i].id).attr("required")) {
+      if (allInputs[i].value == ""){
+        allInputs[i].className += " invalid";
+        valid = false;
+      }
     }
   }
   if (valid) {
     $(".step")[currentTab].className += " finish"
   }
   return valid;
-}
+};
 
 function fixStepIndicator(navigateTab) {
   // This function updates the active step indicator

--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -87,7 +87,6 @@ function fixStepIndicator(navigateTab) {
 // TODO: empty the courseInstructor input after an instructor has been added to the table.
 function callback() {
   let data = $("#courseInstructor").val();
-  $("#courseInstructor").val("");
   data = data.split(",");
   let instructor = data[0]
   let phone = data[1]
@@ -96,12 +95,28 @@ function callback() {
   let newRow = lastRow.clone();
   newRow.find("td:eq(0) p").text(instructor);
   newRow.find("td:eq(0) div input").val(phone);
+  newRow.find("td:eq(0) div button").attr("data-id", phone);
+  newRow.find("td:eq(0) div input").attr("data-id", instructor);
+  newRow.find("td:eq(0) div input").attr("id", phone);
   newRow.prop("hidden", false);
   lastRow.after(newRow);
 }
 
 $("#courseInstructor").on('input', function() {
   searchUser("courseInstructor", callback, null, true);
+});
+
+$("#instructorTable").on("click", "#instructorPhoneUpdate", function() {
+   var inputId = $(this).attr("data-id")
+   var instructorData = [$("#" + inputId).attr("data-id"), $("#" + inputId).val()]
+
+   $.ajax({
+     url: "/updateInstructorPhone",
+     data: JSON.stringify(instructorData),
+     type: "POST",
+     contentType: "application/json",
+     success: function(){}
+   });
 });
 
 $("#instructorTable").on("click", "#remove", function() {

--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -86,11 +86,16 @@ function fixStepIndicator(navigateTab) {
 
 // TODO: empty the courseInstructor input after an instructor has been added to the table.
 function callback() {
-  let instructor = $("#courseInstructor").val();
+  let data = $("#courseInstructor").val();
+  $("#courseInstructor").val("");
+  data = data.split(",");
+  let instructor = data[0]
+  let phone = data[1]
   let tableBody = $("#instructorTable").find("tbody");
   let lastRow = tableBody.find("tr:last");
   let newRow = lastRow.clone();
-  newRow.find("td:eq(0)").text(instructor);
+  newRow.find("td:eq(0) p").text(instructor);
+  newRow.find("td:eq(0) div input").val(phone);
   newRow.prop("hidden", false);
   lastRow.after(newRow);
 }

--- a/app/static/js/userManagement.js
+++ b/app/static/js/userManagement.js
@@ -1,7 +1,6 @@
 import searchUser from './searchUser.js'
 
 function callback() {
-  console.log("This function is called")
   $("#searchAdmin").submit();
 }
 

--- a/app/templates/admin/createSingleEvent.html
+++ b/app/templates/admin/createSingleEvent.html
@@ -133,34 +133,6 @@
           </div>
         </div>
         <!-- Start and End Datepickers -->
-<<<<<<< HEAD
-        <div class="flex-container">
-          <div>
-            <div  class="form-group" >
-              <div class="d-inline-flex w-50 mb-2">
-                <label class="form-label me-2" for="startDatePicker" id="startDatePickerLabel" ><span><strong>Start Date</strong></span></label><br>
-              {% if  isEditable  %}
-                <div class='input-group date' id="startDate">
-                  <input type='text' class="form-control datePicker readonly" value="{{ eventData.startDate.strftime('%m-%d-%Y') if eventData.startDate and eventData.startDate.strftime else eventData.startDate}}" name="startDate" placeholder="Start Date" onchange=updateDate(this) id=startDatePicker required>
-
-                  <div class="input-group-text" id="calendarIconStart">
-                    <span><i class="bi bi-calendar-plus-fill"></i></span>
-                  </div>
-                </div>
-              </div>
-              {% else %}
-                  <p>{{eventData.startDate.strftime('%m-%d-%Y') if eventData.startDate and eventData.startDate.strftime else eventData.startDate}}</p>
-              {% endif %}
-            </div>
-            <div class="d-inline-flex d-none w-50" id ="endDateStyle">
-              <!--datePicker for End date-->
-              <label class="form-label" for="endDatePicker"><strong>End Date</strong></label>
-              <div class='input-group date ms-2' id="endDate">
-                <input type='text' class="form-control datePicker readonly" id='endDatePicker' value="{{eventData.endDate.strftime('%m-%d-%Y') if eventData.endDate and eventData.endDate.strftime else eventData.endDate}}" name="endDate" placeholder="End date" onchange="updateDate(this)" {{"readonly" if not isEditable}}>
-                <div class="input-group-text" id="calendarIconEnd">
-                  <span><i class="bi bi-calendar-plus-fill"></i></span>
-                </div>
-=======
         <div class="row col-md-12">
           <div class="form-group col-md-6">
             <label class="form-label me-2" for="startDatePicker"><strong>Start Date:</strong></label>
@@ -182,7 +154,6 @@
               <input type='text' class="form-control datePicker readonly" id='endDatePicker' value="{{eventData.endDate.strftime('%m-%d-%Y') if eventData.endDate and eventData.endDate.strftime else eventData.endDate}}" name="endDate" placeholder="Pick an end date" onchange="updateDate(this)" {{"readonly" if not isEditable}}>
               <div class="input-group-text" id="calendarIconEnd">
                 <span><i class="bi bi-calendar-plus-fill"></i></span>
->>>>>>> 02d2bf676b0d350ff2f96996d4aae5a50c2af3a1
               </div>
             </div>
           </div>

--- a/app/templates/admin/createSingleEvent.html
+++ b/app/templates/admin/createSingleEvent.html
@@ -105,7 +105,7 @@
         </div> <br>
 
         {% if isNewEvent %}
-        <div class="form-check form-switch" style="padding-bottom: 1.5em" >
+        <div class="form-check form-switch pb-1">
           <label class="custom-control-label" for='checkIsRecurring'><strong>This event is a recurring event</strong></label>
           <input class="form-check-input" type="checkbox" id="checkIsRecurring" name="isRecurring"/>
         </div>
@@ -123,7 +123,7 @@
                   <p>{{ eventData.timeStart.strftime("%I: %M %p") if eventData.timeStart }}</p>
                 {% endif %}
               </div>
-              <div class='form-group time d-inline-flex' style="padding: 0 0 0 2rem">
+              <div class='form-group time d-inline-flex ps-4'>
                 <label for="endTime"><strong>End Time:</strong></label>
                 {% if isEditable %}
                   <input type='time' class="form-control timePicker" id='pickEndTime' value="{{eventData.timeEnd}}" name="timeEnd" required>
@@ -139,7 +139,7 @@
         <div class="flex-container">
           <div>
             <div  class="form-group" >
-              <div class="d-inline-flex" style="width:48%;">
+              <div class="d-inline-flex w-50 mb-2">
                 <label for="startDatePicker" id="startDatePickerLabel" ><span><strong>Start Date</strong></span></label><br>
               {% if  isEditable  %}
                 <div class='input-group date' id="startDate">
@@ -154,10 +154,10 @@
                 {% endif %}
               </div>
 
-              <div class="d-inline-flex d-none" id ="endDateStyle" style="width:51%;">
+              <div class="d-inline-flex d-none w-50" id ="endDateStyle">
                 <!--datePicker for End date-->
-                <label for="endDatePicker" id="endDatePickerLabel" style="padding:0 0 0 2rem" ><span><strong>End Date</strong></span></label>
-                <div class='input-group date' id="endDate">
+                <label for="endDatePicker" id="endDatePickerLabel" ><span><strong>End Date</strong></span></label>
+                <div class='input-group date ms-2' id="endDate">
                   <input type='text' class="form-control datePicker readonly" id='endDatePicker' value="{{eventData.endDate.strftime('%m-%d-%Y') if eventData.endDate and eventData.endDate.strftime else eventData.endDate}}" name="endDate" placeholder="End Date" onchange="updateDate(this)" {{"readonly" if not isEditable}}>
                   <div class="input-group-text" id="calendarIconEnd">
                     <span><i class="bi bi-calendar-plus-fill"></i></span>
@@ -240,7 +240,7 @@
       </div>
 
       </div>
-      <div class="row justify-content-left" style="margin-top: 1.5em">
+      <div class="row justify-content-left mt-2">
           <div class="col-md-6 offset-md-3">
             <div class="text-center">
               {% if (not isPastEvent) and (not isNewEvent)%}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -52,18 +52,8 @@
     <div class='col-12 col-md scroll-container overflow-visible'>
       <div>
         <div id="maincontent" class="main-content container">
-          <div class="flash_container">
-            {% with messages = get_flashed_messages(with_categories=true) %}
-              {% if messages %}
-                {% for category, message in messages %}
-                  <div class="alert  alert-{{category}} alert-dismissible" role="alert">{{ message }}
-                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-                  </div>
-                {% endfor %}
-              {% endif %}
-            {% endwith %}
+          <div class="flash_container" id="flash_container">
           </div>
-
           <div class="d-lg-none position-fixed top-0 start-0 d-print-none">
             <button class="btn btn-dark rounded-0 rounded-end" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasSidebar" aria-controls="sidebar">
               <span class="bi bi-list" role="button" aria-label="Sidebar"></span>

--- a/app/templates/serviceLearning/slcManagment.html
+++ b/app/templates/serviceLearning/slcManagment.html
@@ -29,7 +29,7 @@
           <td>{{courseDict[course]['term'].description}}</td>
           <td>{{courseDict[course]['status']}}</td>
           <td>
-            <select class="form-select" id="{{courseDict[course]['id']}}" onchange='changeAction(this)'>
+            <select class="form-select courseData" id="{{courseDict[course]['id']}}" onchange='changeAction(this)'>
               <option value="---" disabled selected>Select Action</option>
               <option value="Renew">Renew</option>
               <option value="View">View</option>

--- a/app/templates/serviceLearning/slcNewProposal.html
+++ b/app/templates/serviceLearning/slcNewProposal.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block app_content %}
-<form id="slcNewProposal" method="post">
+<form id="slcNewProposal" method="post" action="/serviceLearning/newProposal">
   <div class="tab">
       {% include "serviceLearning/slcGuidelines.html" %}
   </div>

--- a/app/templates/serviceLearning/slcProposal.html
+++ b/app/templates/serviceLearning/slcProposal.html
@@ -8,7 +8,8 @@
         id="courseInstructor"
         class="form-control"
         type="search"
-        placeholder="Search instructor" />
+        placeholder="Search instructor"
+        value="" />
       <table
         class="table"
         id="instructorTable"
@@ -26,7 +27,18 @@
               <button id="remove" type="button" class="btn btn-danger">Remove</button>
             </td>
           </tr>
+          {% for instructor in courseInstructor %}
+          <tr>
+            <td>
+              {{instructor.user.firstName}} {{instructor.user.lastName}} ({{instructor.user}})
+            </td>
+            <td>
+              <button id="remove" type="button" class="btn btn-danger">Remove</button>
+            </td>
+          </tr>
+          {% endfor %}
         </tbody>
+
       </table>
       <label for="courseName" class="pt-3">Course Name</label>
       <input
@@ -71,7 +83,7 @@
         value="{{courseData.course.term.description if courseData != None}}"
         name="term">
         {% for term in terms %}
-          <option value="{{ term.id }}"> {{ term.description }}</option>
+          <option value="{{ term.id }}" {{ "selected" if courseData.course.term == term }}> {{ term.description }}</option>
         {% endfor %}
       </select>
       <span>Are all sections SL?</span>

--- a/app/templates/serviceLearning/slcProposal.html
+++ b/app/templates/serviceLearning/slcProposal.html
@@ -31,6 +31,11 @@
           <tr>
             <td>
               {{instructor.user.firstName}} {{instructor.user.lastName}} ({{instructor.user}})
+              <input
+              class="form-control mb-3"
+              type="text"
+              value="{{instructor.user.phoneNumber}}"
+              name="courseInstructorPhone"/>
             </td>
             <td>
               <button id="remove" type="button" class="btn btn-danger">Remove</button>
@@ -62,11 +67,6 @@
         name="credit"
         value="{{courseData.course.courseCredit if courseData != None}}"
         type="number"/>
-      <label for="courseInstructorPhone">Course Instructor Phone</label>
-      <input
-        class="form-control mb-3"
-        type="text"
-        name="courseInstructorPhone"/>
       <label for="regularOccurenceToggle">Regularly-occurring?</label>
       <div class="form-check form-switch pb-4">
         <input

--- a/app/templates/serviceLearning/slcProposal.html
+++ b/app/templates/serviceLearning/slcProposal.html
@@ -34,18 +34,21 @@
         id="coursName"
         name="courseName"
         type="text"
+        value="{{courseData.course.courseName if courseData != None }}"
         required/>
       <label for="courseAbbreviation">Course Abbreviation</label>
       <input
         class="form-control"
         id="courseAbbreviation"
         name="courseAbbreviation"
+        value="{{courseData.course.courseAbbreviation if courseData != None}}"
         type="text"/>
       <label for="credit">Credit</label>
       <input
         class="form-control"
         id="credit"
         name="credit"
+        value="{{courseData.course.courseCredit if courseData != None}}"
         type="number"/>
       <label for="courseInstructorPhone">Course Instructor Phone</label>
       <input
@@ -65,6 +68,7 @@
       <select
         class="dropdown form-control mb-3"
         id="inputCourseInstructor"
+        value="{{courseData.course.term.description if courseData != None}}"
         name="term">
         {% for term in terms %}
           <option value="{{ term.id }}"> {{ term.description }}</option>

--- a/app/templates/serviceLearning/slcProposal.html
+++ b/app/templates/serviceLearning/slcProposal.html
@@ -24,19 +24,23 @@
           <tr hidden>
             <td class="instructorName"></td>
             <td><button id="remove" type="button" class="btn btn-danger">Remove</button></td>
+            <td class="phone"></td>
+            <!-- <div class="input-group mb-3 pt-3">
+              <input type="text" class="form-control-sm mb-3" name="courseInstructorPhone" aria-label="Recipient's username" aria-describedby="button-addon2" value=""/>
+              <button class="btn btn-primary mb-3" type="button" id="button-addon2">Save</button>
+            </div> -->
           </tr>
           {% for instructor in courseInstructor %}
           <tr>
             <td>
               {{instructor.user.firstName}} {{instructor.user.lastName}} ({{instructor.user}})
-              <div class="input-group mb-3 pt-3">
-                <input type="text" class="form-control-sm mb-3" name="courseInstructorPhone" aria-label="Recipient's username" aria-describedby="button-addon2"value="{{instructor.user.phoneNumber}}"/>
-                <button class="btn btn-primary mb-3" type="button" id="button-addon2">Save</button>
-              </div>
             </td>
             <td>
               <button id="remove" type="button" class="btn btn-danger">Remove</button>
             </td>
+            <!-- <td>
+              Phone
+              </td> -->
           </tr>
           {% endfor %}
         </tbody>
@@ -109,4 +113,5 @@
       </div>
     </div>
   </div>
+  <input value={{courseID}} name="courseID" hidden/>
 </div>

--- a/app/templates/serviceLearning/slcProposal.html
+++ b/app/templates/serviceLearning/slcProposal.html
@@ -23,19 +23,16 @@
         <tbody>
           <tr hidden>
             <td class="instructorName"></td>
-            <td>
-              <button id="remove" type="button" class="btn btn-danger">Remove</button>
-            </td>
+            <td><button id="remove" type="button" class="btn btn-danger">Remove</button></td>
           </tr>
           {% for instructor in courseInstructor %}
           <tr>
             <td>
               {{instructor.user.firstName}} {{instructor.user.lastName}} ({{instructor.user}})
-              <input
-              class="form-control mb-3"
-              type="text"
-              value="{{instructor.user.phoneNumber}}"
-              name="courseInstructorPhone"/>
+              <div class="input-group mb-3 pt-3">
+                <input type="text" class="form-control-sm mb-3" name="courseInstructorPhone" aria-label="Recipient's username" aria-describedby="button-addon2"value="{{instructor.user.phoneNumber}}"/>
+                <button class="btn btn-primary mb-3" type="button" id="button-addon2">Save</button>
+              </div>
             </td>
             <td>
               <button id="remove" type="button" class="btn btn-danger">Remove</button>

--- a/app/templates/serviceLearning/slcProposal.html
+++ b/app/templates/serviceLearning/slcProposal.html
@@ -25,15 +25,15 @@
             <td class="instructorName"></td>
             <td><button id="remove" type="button" class="btn btn-danger">Remove</button></td>
             <td class="phone"></td>
-            <!-- <div class="input-group mb-3 pt-3">
-              <input type="text" class="form-control-sm mb-3" name="courseInstructorPhone" aria-label="Recipient's username" aria-describedby="button-addon2" value=""/>
-              <button class="btn btn-primary mb-3" type="button" id="button-addon2">Save</button>
-            </div> -->
           </tr>
           {% for instructor in courseInstructor %}
           <tr>
             <td>
               {{instructor.user.firstName}} {{instructor.user.lastName}} ({{instructor.user}})
+              <div class="input-group mb-3 pt-3">
+                <input type="text" class="form-control-sm mb-3" name="courseInstructorPhone" aria-label="Recipient's username" aria-describedby="button-addon2" value="{{instructor.user.phoneNumber}}"/>
+                <button class="btn btn-primary mb-3" type="button" id="button-addon2">Update</button>
+              </div>
             </td>
             <td>
               <button id="remove" type="button" class="btn btn-danger">Remove</button>

--- a/app/templates/serviceLearning/slcProposal.html
+++ b/app/templates/serviceLearning/slcProposal.html
@@ -23,9 +23,9 @@
         <tbody>
           <tr hidden>
             <td>
-              <p id="instructorName"></p>
+              <p class="instructorName"></p>
               <div class="input-group mb-3 pt-3">
-                <input type="text" class="form-control-sm mb-3" data-id="" id="" name="courseInstructorPhone" aria-label="Instructor's Phone Number." />
+                <input type="text" class="form-control-sm mb-3" id="" name="courseInstructorPhone" aria-label="Instructor's Phone Number." />
                 <button class="btn btn-primary mb-3" data-id='' aria-label="Button updates Instructor's phone number." type="button" id="instructorPhoneUpdate">Update</button>
               </div>
             </td>
@@ -36,10 +36,10 @@
           {% for instructor in courseInstructor %}
           <tr>
             <td>
-              <p>{{instructor.user.firstName}} {{instructor.user.lastName}} ({{instructor.user}})</p>
+              <p class="instructorName">{{instructor.user.firstName}} {{instructor.user.lastName}} ({{instructor.user}})</p>
               <div class="input-group mb-3 pt-3">
-                <input type="text" class="form-control-sm mb-3" data-id="{{instructor.user}}" id="{{instructor.user.phoneNumber}}" name="" aria-label="Recipient's username" aria-describedby="button-addon2" value="{{instructor.user.phoneNumber}}"/>
-                <button class="btn btn-primary mb-3" data-id="{{instructor.user.phoneNumber}}" type="button" id="instructorPhoneUpdate">Update</button>
+                <input type="text" class="form-control-sm mb-3" id="{{instructor.user}}" name="" aria-label="Recipient's username" aria-describedby="button-addon2" value="{{instructor.user.phoneNumber}}"/>
+                <button class="btn btn-primary mb-3" data-id="{{instructor.user}}" type="button" id="instructorPhoneUpdate">Update</button>
               </div>
             </td>
             <td>
@@ -106,7 +106,6 @@
         name="slDesignation"
         rows="3">{{courseData.course.serviceLearningDesignatedSections if courseData != None}}
       </textarea>
-      <span class="pt-5">Will this course be a permanently designated service learning course?</span>
       <div class="form-check form-switch">
         <label class="form-label" for="permanentDesignation"><strong>Will this course be a permanently designated service-learning course?</strong></label>
         <input

--- a/app/templates/serviceLearning/slcProposal.html
+++ b/app/templates/serviceLearning/slcProposal.html
@@ -78,7 +78,7 @@
         <input
           class="form-check-input"
           type="checkbox"
-          name="regularOccurenceToggle"{{isRegularlyOccuring}}/>
+          name="regularOccurenceToggle"{{"checked" if isRegularlyOccuring}}/>
       </div>
     </div>
     <div class="p-2 col-md-6">
@@ -97,7 +97,7 @@
         <input
           class="form-check-input"
           type="checkbox"
-          name="slSectionsToggle" {{isAllSectionsServiceLearning}}/>
+          name="slSectionsToggle" {{"checked" if isAllSectionsServiceLearning}}/>
       </div>
       <label class="pt-2" for="slDesignation">Sections with SL Designation</label>
       <textarea
@@ -113,7 +113,7 @@
           type="checkbox"
           name="permanentDesignation"
           id="permanentDesignation"
-          {{isPermanentlyDesignated}}/>
+          {{"checked" if isPermanentlyDesignated}}/>
       </div>
     </div>
   </div>

--- a/app/templates/serviceLearning/slcProposal.html
+++ b/app/templates/serviceLearning/slcProposal.html
@@ -60,7 +60,7 @@
         <input
           class="form-check-input"
           type="checkbox"
-          name="regularOccurenceToggle"/>
+          name="regularOccurenceToggle"{{isRegularlyOccuring}}/>
       </div>
     </div>
     <div class="p-2 col-md-6">
@@ -79,21 +79,21 @@
         <input
           class="form-check-input"
           type="checkbox"
-          name="slSectionsToggle"/>
+          name="slSectionsToggle" {{isAllSectionsServiceLearning}}/>
       </div>
       <label class="pt-2" for="slDesignation">Sections with SL Designation</label>
       <textarea
         class="form-control"
         id="slDesignation"
         name="slDesignation"
-        rows="3">
+        rows="3">{{courseData.course.serviceLearningDesignatedSections if courseData != None}}
       </textarea>
       <span class="pt-5">Will this course be a permanently designated service learning course?</span>
       <div class="form-check form-switch">
         <input
           class="form-check-input"
           type="checkbox"
-          name="permanentDesignation"/>
+          name="permanentDesignation" {{isPermanentlyDesignated}}/>
       </div>
     </div>
   </div>

--- a/app/templates/serviceLearning/slcProposal.html
+++ b/app/templates/serviceLearning/slcProposal.html
@@ -74,6 +74,7 @@
         name="credit"
         value="{{courseData.course.courseCredit if courseData != None}}"
         type="number"
+        min="0"
         required/>
       <label for="regularOccurenceToggle">Regularly-occurring?</label>
       <div class="form-check form-switch pb-4">

--- a/app/templates/serviceLearning/slcProposal.html
+++ b/app/templates/serviceLearning/slcProposal.html
@@ -29,7 +29,7 @@
           {% for instructor in courseInstructor %}
           <tr>
             <td>
-              {{instructor.user.firstName}} {{instructor.user.lastName}} ({{instructor.user}})
+              <p>{{instructor.user.firstName}} {{instructor.user.lastName}} ({{instructor.user}})</p>
               <div class="input-group mb-3 pt-3">
                 <input type="text" class="form-control-sm mb-3" name="courseInstructorPhone" aria-label="Recipient's username" aria-describedby="button-addon2" value="{{instructor.user.phoneNumber}}"/>
                 <button class="btn btn-primary mb-3" type="button" id="button-addon2">Update</button>

--- a/app/templates/serviceLearning/slcProposal.html
+++ b/app/templates/serviceLearning/slcProposal.html
@@ -22,25 +22,30 @@
         </thead>
         <tbody>
           <tr hidden>
-            <td class="instructorName"></td>
+            <td>
+              <p id="instructorName"></p>
+              <div class="input-group mb-3 pt-3">
+                <input type="text" class="form-control-sm mb-3" data-id="" id="" name="courseInstructorPhone" aria-label="Instructor's Phone Number." />
+                <button class="btn btn-primary mb-3" data-id='' aria-label="Button updates Instructor's phone number." type="button" id="instructorPhoneUpdate">Update</button>
+              </div>
+            </td>
             <td><button id="remove" type="button" class="btn btn-danger">Remove</button></td>
             <td class="phone"></td>
+
           </tr>
           {% for instructor in courseInstructor %}
           <tr>
             <td>
               <p>{{instructor.user.firstName}} {{instructor.user.lastName}} ({{instructor.user}})</p>
               <div class="input-group mb-3 pt-3">
-                <input type="text" class="form-control-sm mb-3" name="courseInstructorPhone" aria-label="Recipient's username" aria-describedby="button-addon2" value="{{instructor.user.phoneNumber}}"/>
-                <button class="btn btn-primary mb-3" type="button" id="button-addon2">Update</button>
+                <input type="text" class="form-control-sm mb-3" data-id="{{instructor.user}}" id="{{instructor.user.phoneNumber}}" name="" aria-label="Recipient's username" aria-describedby="button-addon2" value="{{instructor.user.phoneNumber}}"/>
+                <button class="btn btn-primary mb-3" data-id="{{instructor.user.phoneNumber}}" type="button" id="instructorPhoneUpdate">Update</button>
               </div>
             </td>
             <td>
               <button id="remove" type="button" class="btn btn-danger">Remove</button>
             </td>
-            <!-- <td>
-              Phone
-              </td> -->
+
           </tr>
           {% endfor %}
         </tbody>

--- a/app/templates/serviceLearning/slcProposal.html
+++ b/app/templates/serviceLearning/slcProposal.html
@@ -80,7 +80,7 @@
         value="{{courseData.course.term.description if courseData != None}}"
         name="term">
         {% for term in terms %}
-          <option value="{{ term.id }}" {{ "selected" if courseData.course.term == term }}> {{ term.description }}</option>
+          <option value="{{ term.id }}" {{ "selected" if courseData != None and courseData.course.term == term }}> {{ term.description }}</option>
         {% endfor %}
       </select>
       <span>Are all sections SL?</span>

--- a/app/templates/serviceLearning/slcProposal.html
+++ b/app/templates/serviceLearning/slcProposal.html
@@ -23,7 +23,7 @@
         <tbody>
           <tr hidden>
             <td>
-              <p class="instructorName"></p>
+              <p class="instructorName" required></p>
               <div class="input-group mb-3 pt-3">
                 <input type="text" class="form-control-sm mb-3" id="" name="courseInstructorPhone" aria-label="Instructor's Phone Number." />
                 <button class="btn btn-primary mb-3" data-id='' aria-label="Button updates Instructor's phone number." type="button" id="instructorPhoneUpdate">Update</button>
@@ -65,14 +65,16 @@
         id="courseAbbreviation"
         name="courseAbbreviation"
         value="{{courseData.course.courseAbbreviation if courseData != None}}"
-        type="text"/>
+        type="text"
+        required/>
       <label for="credit">Credit</label>
       <input
         class="form-control"
         id="credit"
         name="credit"
         value="{{courseData.course.courseCredit if courseData != None}}"
-        type="number"/>
+        type="number"
+        required/>
       <label for="regularOccurenceToggle">Regularly-occurring?</label>
       <div class="form-check form-switch pb-4">
         <input

--- a/app/templates/serviceLearning/slcQuestionnaire.html
+++ b/app/templates/serviceLearning/slcQuestionnaire.html
@@ -4,7 +4,7 @@
   <label>
     1. Indicate the specific course learning objective(s) that will be addressed by the service-learning component
   </label>
-  <textarea class="form-control" aria-label="With textarea" name="1"></textarea>
+  <textarea class="form-control" aria-label="With textarea" name="1">{{courseData.questionContent if courseData.questionNumber == 1 }}</textarea>
   <label>
     2. Describe the method of structured, critical reflection you will use in order to connect the service
     activity or activities to the learning objective(s) of the course.

--- a/app/templates/serviceLearning/slcQuestionnaire.html
+++ b/app/templates/serviceLearning/slcQuestionnaire.html
@@ -1,39 +1,36 @@
-{% for i in questionData %}
-  {% set answer[loop.index] = i %}
-{% endfor %}
 <h1 class="text-center pt-4 fs-2">New Designated Service Learning Course</h1>
 <p class="text-center fw-bold"> Please review the <a href="/slcGuidelines">service learning course guidelines</a> before completing this form </p>
 <div class="pt-4">
   <label>
     1. Indicate the specific course learning objective(s) that will be addressed by the service-learning component
   </label>
-  <textarea class="form-control" aria-label="With textarea" name="1">{{ answer[1] }}</textarea>
+  <textarea class="form-control" aria-label="With textarea" name="1">{{questionanswers[0] if questionanswers}}</textarea>
   <label>
     2. Describe the method of structured, critical reflection you will use in order to connect the service
     activity or activities to the learning objective(s) of the course.
   </label>
-  <textarea class="form-control" aria-label="With textarea" name="2"></textarea>
+  <textarea class="form-control" aria-label="With textarea" name="2">{{questionanswers[1] if questionanswers}}</textarea>
   <label>
     3. Describe the service-learning activity or activities. Indicate the approximate number of hours or
     days of service experience. There is no formal requirement, but the activity must be substantial and
     sustained throughout the semester.
   </label>
-  <textarea class="form-control" aria-label="With textarea" name="3"></textarea>
+  <textarea class="form-control" aria-label="With textarea" name="3">{{questionanswers[2] if questionanswers}}</textarea>
   <label>
     4. Identify the community partner(s) with whom you will collaborate in order to structure this
     service-learning experience.  How will the community partner(s) be involved in planning, implementation,
     and evaluation?
   </label>
-  <textarea class="form-control" aria-label="With textarea" name="4"></textarea>
+  <textarea class="form-control" aria-label="With textarea" name="4">{{questionanswers[3] if questionanswers}}</textarea>
   <label>
     5. Describe the final product to be completed by the students. How will this benefit the community?
   </label>
-  <textarea class="form-control" aria-label="With textarea" name="5"></textarea>
+  <textarea class="form-control" aria-label="With textarea" name="5">{{questionanswers[4] if questionanswers}}</textarea>
   <label>
     6. Indicate how you will assess student learning related to the identified course objective(s) that will
     be enhanced by the service-learning experience. Identify what percentage of the final grade will be based
     on the assessment of reflection, the final product, and other forms of assessment related to the identified
     course objective(s).
   </label>
-  <textarea class="form-control" aria-label="With textarea" name="6"></textarea>
+  <textarea class="form-control" aria-label="With textarea" name="6">{{questionanswers[5] if questionanswers}}</textarea>
 </div>

--- a/app/templates/serviceLearning/slcQuestionnaire.html
+++ b/app/templates/serviceLearning/slcQuestionnaire.html
@@ -1,10 +1,13 @@
+{% for i in questionData %}
+  {% set answer[loop.index] = i %}
+{% endfor %}
 <h1 class="text-center pt-4 fs-2">New Designated Service Learning Course</h1>
 <p class="text-center fw-bold"> Please review the <a href="/slcGuidelines">service learning course guidelines</a> before completing this form </p>
 <div class="pt-4">
   <label>
     1. Indicate the specific course learning objective(s) that will be addressed by the service-learning component
   </label>
-  <textarea class="form-control" aria-label="With textarea" name="1">{{courseData.questionContent if courseData.questionNumber == 1 }}</textarea>
+  <textarea class="form-control" aria-label="With textarea" name="1">{{ answer[1] }}</textarea>
   <label>
     2. Describe the method of structured, critical reflection you will use in order to connect the service
     activity or activities to the learning objective(s) of the course.

--- a/app/templates/serviceLearning/slcQuestionnaire.html
+++ b/app/templates/serviceLearning/slcQuestionnaire.html
@@ -4,33 +4,33 @@
   <label>
     1. Indicate the specific course learning objective(s) that will be addressed by the service-learning component
   </label>
-  <textarea class="form-control" aria-label="With textarea" name="1">{{questionanswers[0] if questionanswers}}</textarea>
+  <textarea class="form-control" aria-label="With textarea" name="1">{{questionanswers[0] if questionanswers}} </textarea>
   <label>
     2. Describe the method of structured, critical reflection you will use in order to connect the service
     activity or activities to the learning objective(s) of the course.
   </label>
-  <textarea class="form-control" aria-label="With textarea" name="2">{{questionanswers[1] if questionanswers}}</textarea>
+  <textarea class="form-control" aria-label="With textarea" name="2">{{questionanswers[1] if questionanswers}} </textarea>
   <label>
     3. Describe the service-learning activity or activities. Indicate the approximate number of hours or
     days of service experience. There is no formal requirement, but the activity must be substantial and
     sustained throughout the semester.
   </label>
-  <textarea class="form-control" aria-label="With textarea" name="3">{{questionanswers[2] if questionanswers}}</textarea>
+  <textarea class="form-control" aria-label="With textarea" name="3">{{questionanswers[2] if questionanswers}} </textarea>
   <label>
     4. Identify the community partner(s) with whom you will collaborate in order to structure this
     service-learning experience.  How will the community partner(s) be involved in planning, implementation,
     and evaluation?
   </label>
-  <textarea class="form-control" aria-label="With textarea" name="4">{{questionanswers[3] if questionanswers}}</textarea>
+  <textarea class="form-control" aria-label="With textarea" name="4">{{questionanswers[3] if questionanswers}} </textarea>
   <label>
     5. Describe the final product to be completed by the students. How will this benefit the community?
   </label>
-  <textarea class="form-control" aria-label="With textarea" name="5">{{questionanswers[4] if questionanswers}}</textarea>
+  <textarea class="form-control" aria-label="With textarea" name="5">{{questionanswers[4] if questionanswers}} </textarea>
   <label>
     6. Indicate how you will assess student learning related to the identified course objective(s) that will
     be enhanced by the service-learning experience. Identify what percentage of the final grade will be based
     on the assessment of reflection, the final product, and other forms of assessment related to the identified
     course objective(s).
   </label>
-  <textarea class="form-control" aria-label="With textarea" name="6">{{questionanswers[5] if questionanswers}}</textarea>
+  <textarea class="form-control" aria-label="With textarea" name="6">{{questionanswers[5] if questionanswers}} </textarea>
 </div>

--- a/database/test_data.py
+++ b/database/test_data.py
@@ -633,12 +633,12 @@ courseQuestions = [
     "questionNumber":3,
     },
     {
-    "course":1,
+    "course":3,
     "questionContent":" This is another random question",
     "questionNumber":4,
     },
     {
-    "course":1,
+    "course":2,
     "questionContent":" Why are you interested in teaching this course?",
     "questionNumber":5,
     }

--- a/database/test_data.py
+++ b/database/test_data.py
@@ -53,7 +53,7 @@ users = [
         "username": "neillz",
         "bnumber": "B00751864",
         "email": "neillz@berea.edu",
-        "phoneNumber": "555-555-5555",
+        "phoneNumber": "555-985-1234",
         "firstName": "Zach",
         "lastName": "Neill",
         "isStudent": True,

--- a/tests/code/test_edit_slc_course.py
+++ b/tests/code/test_edit_slc_course.py
@@ -1,0 +1,69 @@
+import pytest
+from flask import Flask, g
+from app.models import mainDB
+from app.models.course import Course
+from app.models.courseInstructor import CourseInstructor
+from app.models.user import User
+from app.logic.courseManagement import updateCourse
+
+@pytest.mark.integration
+def test_update_course():
+    app = Flask(__name__)
+    with app.app_context():
+        with mainDB.atomic() as transaction:
+            testUser = User.create( username="testuser",
+                                    bnumber="B00000001",
+                                    email="test@test.edu",
+                                    phoneNumber="555-555-5555",
+                                    firstName="Test",
+                                    lastName="User",
+                                    isFaculty="1")
+            testingCourse = Course.create(
+                                            courseName = "Testing Course",
+                                            courseAbbreviation = "TC",
+                                            courseCredit = 2,
+                                            isRegularlyOccuring = 0,
+                                            term = 3,
+                                            status = 2,
+                                            createdBy = testUser,
+                                            isAllSectionsServiceLearning = 0,
+                                            serviceLearningDesignatedSections = "None",
+                                            isPermanentlyDesignated = 0)
+
+            testingCourseInstructor = CourseInstructor.create(
+                                                                course=testingCourse,
+                                                                user="ramsayb2")
+
+            courseDict = {
+                            "courseName" : "Course Edited",
+                            "courseID": testingCourse,
+                            "courseAbbreviation": "EDIT",
+                            "credit": 1.5,
+                            "regularOccurenceToggle": "on",
+                            "term": 2,
+                            "slSectionsToggle": "on",
+                            "slDesignation": "All",
+                            "permanentDesignation": "on",
+                            "1": "Question 1",
+                            "2": "Question 2",
+                            "3": "Question 3",
+                            "4": "Question 4",
+                            "5": "Question 5",
+                            "6": "Question 6"}
+
+            instructorsDict = {"instructors": [testUser, testUser]}
+            runUpdateCourse = updateCourse(courseDict, instructorsDict)
+            updatedCourse = Course.get(Course.id == testingCourse.id)
+            updatedInstructors = CourseInstructor.select().where(CourseInstructor.course == updatedCourse.id)
+            instructors = [instructor for instructor in updatedInstructors]
+
+            assert updatedCourse.courseName == "Course Edited"
+            assert updatedCourse.courseAbbreviation == "EDIT"
+            assert updatedCourse.courseCredit == 1.5
+            assert updatedCourse.isRegularlyOccuring
+            assert updatedCourse.status.status == "Pending"
+            assert updatedCourse.isAllSectionsServiceLearning
+            assert updatedCourse.serviceLearningDesignatedSections == "All"
+            assert updatedCourse.isPermanentlyDesignated
+            assert len(instructors) == 2
+            transaction.rollback()

--- a/tests/code/test_search.py
+++ b/tests/code/test_search.py
@@ -56,7 +56,7 @@ def test_searchStudents():
         User.get_or_create(username = 'sawconc', firstName = 'Candace', lastName = 'Sawcon', bnumber = '021556782', isStudent = True)
         query = 'sa'
         searchResults = searchUsers(query, False)
-        searchPhoneNumber = searchUsers(query, 'true')
+        searchPhoneNumber = searchUsers(query, True)
         assert len(searchResults) == 2
         assert searchResults['Sandesh Lamichhane (lamichhanes2)'] == 'Sandesh Lamichhane (lamichhanes2)'
         assert searchResults['Candace Sawcon (sawconc)'] == 'Candace Sawcon (sawconc)'

--- a/tests/code/test_search.py
+++ b/tests/code/test_search.py
@@ -28,37 +28,39 @@ def test_searchStudents():
 
     #tests that the search works
 
-    query = 'z'
-    searchResults = searchUsers(query, False)
-    assert searchResults['Zach Neill (neillz)'] == 'Zach Neill (neillz)'
+    query = 'za'
+    test1 = User.select().where(User.firstName == query)
+    searchResults = searchUsers(query)
+    assert searchResults['neillz'] == test1
 
 
     #test for last name
     query = 'khatt'
-    searchResults = searchUsers(query, False)
-    assert searchResults['Sreynit Khatt (khatts)'] == 'Sreynit Khatt (khatts)'
+    test2 = User.select().where(User.firstName == query)
+    searchResults = searchUsers(query)
+    assert searchResults['khatts'] == test2
 
     #test with non existing username
     query = 'abc'
-    searchResults = searchUsers(query, False)
+    searchResults = searchUsers(query)
     assert len(searchResults) == 0
 
     query = 'its easy as'
-    searchResults = searchUsers(query, False)
+    searchResults = searchUsers(query)
     assert len(searchResults) == 0
 
     query = '123'
-    searchResults = searchUsers(query, False)
+    searchResults = searchUsers(query)
     assert len(searchResults) == 0
 
     #test with multiple users matching query
     with mainDB.atomic() as transaction:
         User.get_or_create(username = 'sawconc', firstName = 'Candace', lastName = 'Sawcon', bnumber = '021556782', isStudent = True)
         query = 'sa'
-        searchResults = searchUsers(query, False)
-        searchPhoneNumber = searchUsers(query, True)
+        searchResults = searchUsers(query)
+        test3 = User.select().where(User.firstName == query)
         assert len(searchResults) == 2
-        assert searchResults['Sandesh Lamichhane (lamichhanes2)'] == 'Sandesh Lamichhane (lamichhanes2)'
-        assert searchResults['Candace Sawcon (sawconc)'] == 'Candace Sawcon (sawconc)'
-        assert searchPhoneNumber['lamichhanes2 phoneNumber'] == '555-555-5555'
+        assert searchResults['lamichhanes2'] == test3
+        assert 'Sawcon' in searchResults["sawconc"].values()
+        assert '555-555-5555' in searchResults["lamichhanes2"].values()
         transaction.rollback()

--- a/tests/code/test_search.py
+++ b/tests/code/test_search.py
@@ -56,7 +56,9 @@ def test_searchStudents():
         User.get_or_create(username = 'sawconc', firstName = 'Candace', lastName = 'Sawcon', bnumber = '021556782', isStudent = True)
         query = 'sa'
         searchResults = searchUsers(query, False)
+        searchPhoneNumber = searchUsers(query, 'true')
         assert len(searchResults) == 2
         assert searchResults['Sandesh Lamichhane (lamichhanes2)'] == 'Sandesh Lamichhane (lamichhanes2)'
         assert searchResults['Candace Sawcon (sawconc)'] == 'Candace Sawcon (sawconc)'
+        assert searchPhoneNumber['lamichhanes2 phoneNumber'] == '555-555-5555'
         transaction.rollback()

--- a/tests/code/test_search.py
+++ b/tests/code/test_search.py
@@ -29,33 +29,33 @@ def test_searchStudents():
     #tests that the search works
 
     query = 'z'
-    searchResults = searchUsers(query)
+    searchResults = searchUsers(query, False)
     assert searchResults['Zach Neill (neillz)'] == 'Zach Neill (neillz)'
 
 
     #test for last name
     query = 'khatt'
-    searchResults = searchUsers(query)
+    searchResults = searchUsers(query, False)
     assert searchResults['Sreynit Khatt (khatts)'] == 'Sreynit Khatt (khatts)'
 
     #test with non existing username
     query = 'abc'
-    searchResults = searchUsers(query)
+    searchResults = searchUsers(query, False)
     assert len(searchResults) == 0
 
     query = 'its easy as'
-    searchResults = searchUsers(query)
+    searchResults = searchUsers(query, False)
     assert len(searchResults) == 0
 
     query = '123'
-    searchResults = searchUsers(query)
+    searchResults = searchUsers(query, False)
     assert len(searchResults) == 0
 
     #test with multiple users matching query
     with mainDB.atomic() as transaction:
         User.get_or_create(username = 'sawconc', firstName = 'Candace', lastName = 'Sawcon', bnumber = '021556782', isStudent = True)
         query = 'sa'
-        searchResults = searchUsers(query)
+        searchResults = searchUsers(query, False)
         assert len(searchResults) == 2
         assert searchResults['Sandesh Lamichhane (lamichhanes2)'] == 'Sandesh Lamichhane (lamichhanes2)'
         assert searchResults['Candace Sawcon (sawconc)'] == 'Candace Sawcon (sawconc)'


### PR DESCRIPTION
This is for issue #79 . Existing proposals as well as newly created proposals can be edited. The database updates accordingly. Setting object to true in searchUser returns the actual object instead of a string. 

TO TEST 
Go to /serviceLearning/courseManagement
Click "Edit" in the dropdown on any proposal
Modify any values
Hit submit

We also have test suite: test_edit_slc_course.py