### PR TITLE
Search logic fix 238

### DIFF
--- a/app/logic/searchUsers.py
+++ b/app/logic/searchUsers.py
@@ -3,6 +3,7 @@ from app.models.user import User
 def searchUsers(query):
     '''Accepts user input and queries the database returning results that matches user search'''
     query = query.strip()
+    print(query)
     search = query.upper()
     splitSearch = search.split()
     resultsDict = {}
@@ -12,6 +13,8 @@ def searchUsers(query):
 
     if len(splitSearch) == 1: #search for first or last name
         results = User.select().where(User.isStudent & (User.firstName ** firstName | User.lastName ** firstName))
+        for r in results:
+            print(r)
         for participant in results:
             if participant not in resultsDict:
                 resultsDict[participant.username]=model_to_dict(participant)

--- a/app/logic/searchUsers.py
+++ b/app/logic/searchUsers.py
@@ -3,7 +3,6 @@ from app.models.user import User
 def searchUsers(query):
     '''Accepts user input and queries the database returning results that matches user search'''
     query = query.strip()
-    print(query)
     search = query.upper()
     splitSearch = search.split()
     resultsDict = {}
@@ -13,8 +12,6 @@ def searchUsers(query):
 
     if len(splitSearch) == 1: #search for first or last name
         results = User.select().where(User.isStudent & (User.firstName ** firstName | User.lastName ** firstName))
-        for r in results:
-            print(r)
         for participant in results:
             if participant not in resultsDict:
                 resultsDict[participant.username]=model_to_dict(participant)

--- a/app/logic/userManagement.py
+++ b/app/logic/userManagement.py
@@ -4,7 +4,6 @@ from app.models.studentManager import StudentManager
 from app.models.program import Program
 from flask import g, session
 from app.logic.adminLogs import createLog
-
 from playhouse.shortcuts import model_to_dict
 
 def addCeltsAdmin(user):

--- a/app/static/js/searchUser.js
+++ b/app/static/js/searchUser.js
@@ -1,8 +1,6 @@
 export default function searchUser(inputId, callback, clear=false, parentElementId=null, columnRequested=null){
   var query = $(`#${inputId}`).val()
   let columnDict={};
-  console.log(inputId)
-  console.log(clear)
   $(`#${inputId}`).autocomplete({
     appendTo: (parentElementId === null) ? null : `#${parentElementId}`,
     minLength: 2,

--- a/app/static/js/searchUser.js
+++ b/app/static/js/searchUser.js
@@ -41,7 +41,7 @@ export default function searchUser(inputId, callback, clear=false, parentElement
        var user = ui.item.value
        $(`#${inputId}`).val(ui.item.value);
        callback();
-       if(clear == true){
+       if(clear){
        $(`#${inputId}`).val("");
        return false;
      }

--- a/app/static/js/searchUser.js
+++ b/app/static/js/searchUser.js
@@ -1,4 +1,4 @@
-export default function searchUser(inputId, callback, parentElementId=null, columnRequested=null){
+export default function searchUser(inputId, callback, clear=false, parentElementId=null, columnRequested=null){
   var query = $(`#${inputId}`).val()
   let columnDict={};
   $(`#${inputId}`).autocomplete({
@@ -41,6 +41,10 @@ export default function searchUser(inputId, callback, parentElementId=null, colu
        var user = ui.item.value
        $(`#${inputId}`).val(ui.item.value);
        callback();
+       if(clear == true){
+       $(`#${inputId}`).val("");
+       return false;
+     }
      }
   });
 };

--- a/app/static/js/searchUser.js
+++ b/app/static/js/searchUser.js
@@ -41,8 +41,6 @@ export default function searchUser(inputId, callback, parentElementId=null, colu
        var user = ui.item.value
        $(`#${inputId}`).val(ui.item.value);
        callback();
-       $(`#${inputId}`).val("");
-       return false;
      }
   });
 };

--- a/app/static/js/searchUser.js
+++ b/app/static/js/searchUser.js
@@ -1,6 +1,8 @@
 export default function searchUser(inputId, callback, clear=false, parentElementId=null, columnRequested=null){
   var query = $(`#${inputId}`).val()
   let columnDict={};
+  console.log(inputId)
+  console.log(clear)
   $(`#${inputId}`).autocomplete({
     appendTo: (parentElementId === null) ? null : `#${parentElementId}`,
     minLength: 2,

--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -106,7 +106,7 @@ function callback() {
 
 $("#courseInstructor").on('input', function() {
   // To retrieve specific columns into a dict, create a [] list and put columns inside
-  searchUser("courseInstructor", callback, null, ["phoneNumber", "firstName", "lastName", "username"]);
+  searchUser("courseInstructor", callback, true, null, ["phoneNumber", "firstName", "lastName", "username"]);
 });
 
 $("#instructorTable").on("click", "#instructorPhoneUpdate", function() {

--- a/app/static/js/trackVolunteers.js
+++ b/app/static/js/trackVolunteers.js
@@ -44,7 +44,7 @@ function callback() {
 
 $("#selectVolunteerButton").prop('disabled', true)
 $("#addVolunteerInput").on("input", function() {
-  searchUser("addVolunteerInput", callback, "addVolunteerModal");
+  searchUser("addVolunteerInput", callback, false, "addVolunteerModal");
 });
 
 $(".removeVolunteer").on("click", function() {


### PR DESCRIPTION
# This pr fixes issue #238 

## Summary: 
A bug occurred after the search function was modified to clear the search bar after a user selected a result. However, some sections were built to take data from an input and run a query after it was selected, and thus clearing it prior to this action would break other search bars. So I added a clear parameter to the `searcherUsers` function in the `searchUsers.js` where you can specify if you want to clear the bar afterward or not. This was necessary because if you attempt to clear in a callback jQuery will override the clear and place to search data in the input anyway.

## To Test: 
You can attempt to search at the following URL's and all will work as intended. `/admin` , `/track_volunteers` ,`/search_student`