### PR TITLE
Rework sidebar 237

### DIFF
--- a/app/controllers/admin/routes.py
+++ b/app/controllers/admin/routes.py
@@ -212,7 +212,9 @@ def courseManagement(term = None):
                             term = term)
 @admin_bp.route('/adminLogs', methods = ['GET', 'POST'])
 def adminLogs():
-    allLogs = AdminLogs.select().order_by(AdminLogs.createdOn.desc())
-
-    return render_template("/admin/adminLogs.html",
-                            allLogs = allLogs)
+    if g.current_user.isCeltsAdmin:
+        allLogs = AdminLogs.select().order_by(AdminLogs.createdOn.desc())
+        return render_template("/admin/adminLogs.html",
+                                allLogs = allLogs)
+    else:
+        abort(403)

--- a/app/controllers/admin/userManagement.py
+++ b/app/controllers/admin/userManagement.py
@@ -67,7 +67,7 @@ def removeProgramManagers():
 @admin_bp.route('/admin', methods = ['GET'])
 def userManagement():
     terms = selectSurroundingTerms(g.current_term)
-    if g.current_user.isAdmin:
+    if g.current_user.isCeltsAdmin:
         return render_template('admin/userManagement.html',
                                 terms=terms)
     abort(403)

--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -194,5 +194,8 @@ def getAllCourseIntructors():
     """
     This function selects all the Intructors Name and the previous courses
     """
-    courseDict = getCourseDict()
-    return render_template('/main/manageServiceLearningFaculty.html', courseInstructors = courseDict)
+    if g.current_user.isCeltsAdmin:
+        courseDict = getCourseDict()
+        return render_template('/main/manageServiceLearningFaculty.html', courseInstructors = courseDict)
+    else:
+        abort(403)

--- a/app/controllers/serviceLearning/routes.py
+++ b/app/controllers/serviceLearning/routes.py
@@ -19,7 +19,7 @@ from app.logic.courseManagement import updateCourse, createCourse
 def serviceCourseManagement(username=None):
     """This is a Temporary Page for the Service Course Managment Screen."""
     # TODO: How to make accessing other user's interfaces more userfriendly?
-    if g.current_user.isAdmin or g.current_user.isFaculty:
+    if g.current_user.isCeltsAdmin or g.current_user.isFaculty:
         user = User.get(User.username==username) if username else g.current_user
         courseDict = getServiceLearningCoursesData(user)
         return render_template('serviceLearning/slcManagment.html',

--- a/app/templates/sidebar.html
+++ b/app/templates/sidebar.html
@@ -40,13 +40,7 @@
         </a>
       </li>
       <li>
-        <a href="/admin"
-           class="nav-link text-white {{'active' if request.path =='/admin'}}"
-           {{"aria-current='page'" if request.path =='/admin'}}>
-          Settings
-        </a>
-      </li>
-      <li>
+      {% if g.current_user.isCeltsAdmin %}
         <nav class="navbar navbar-dark bg-dark">
           <div class="container-fluid">
             <button class="navbar-toggler text-white border-0 fs-6 ps-3" type="button" data-bs-toggle="collapse" data-bs-target="#navbarToggleExternalContent" aria-controls="navbarToggleExternalContent" aria-expanded="false" aria-label="Toggle navigation">
@@ -56,25 +50,25 @@
         </nav>
         <div class="collapse" id="navbarToggleExternalContent">
           <div class="bg-dark p-4">
-            <h5 class="text-white h4">Collapsed content</h5>
-            <span class="text-muted">Toggleable via the navbar brand.</span>
+            <a href="/adminLogs" class="nav-link text-white {{ 'active' if request.path =='/adminLogs' }}">
+              Admin Logs
+            </a>
+            <a href="/admin"
+               class="nav-link text-white {{'active' if request.path =='/admin'}}"
+               {{"aria-current='page'" if request.path =='/admin'}}>
+              Settings
+            </a>
+            <a href="/manageServiceLearning" class="nav-link text-white {{ 'active' if request.path =='/manageServiceLearning' }}">
+              Service Learning
+
+            <a href="/serviceLearning/courseManagement"
+               class="nav-link text-white {{'active' if 'serviceLearning' in request.path }}"
+               {{"aria-current='page'"  if 'serviceLearning' in request.path}}>
+              Course Proposal Management
+            </a>
           </div>
         </div>
-      </li>
-      <li>
-        <a href="/manageServiceLearning" class="nav-link text-white {{ 'active' if request.path =='/manageServiceLearning' }}">
-          Service Learning
-
-        <a href="/serviceLearning/courseManagement"
-           class="nav-link text-white {{'active' if 'serviceLearning' in request.path }}"
-           {{"aria-current='page'"  if 'serviceLearning' in request.path}}>
-          Course Proposal Management
-        </a>
-      </li>
-      <li>
-        <a href="/adminLogs" class="nav-link text-white {{ 'active' if request.path =='/adminLogs' }}">
-          Admin Logs
-        </a>
+        {% endif %}
       </li>
 
     {% endif %}

--- a/app/templates/sidebar.html
+++ b/app/templates/sidebar.html
@@ -51,7 +51,7 @@
         <div class="collapse" id="navbarToggleExternalContent">
           <div class="bg-dark p-4">
             <a href="/adminLogs" class="nav-link text-white {{ 'active' if request.path =='/adminLogs' }}">
-              Admin Logs
+              Activity Logs
             </a>
             <a href="/admin"
                class="nav-link text-white {{'active' if request.path =='/admin'}}"
@@ -64,7 +64,7 @@
             <a href="/serviceLearning/courseManagement"
                class="nav-link text-white {{'active' if 'serviceLearning' in request.path }}"
                {{"aria-current='page'"  if 'serviceLearning' in request.path}}>
-              Course Proposal Management
+              Course Proposals
             </a>
           </div>
         </div>

--- a/app/templates/sidebar.html
+++ b/app/templates/sidebar.html
@@ -43,13 +43,13 @@
       {% if g.current_user.isCeltsAdmin %}
         <nav class="navbar navbar-dark bg-dark">
           <div class="container-fluid">
-            <button class="navbar-toggler text-white border-0 fs-6 ps-3" type="button" data-bs-toggle="collapse" data-bs-target="#navbarToggleExternalContent" aria-controls="navbarToggleExternalContent" aria-expanded="false" aria-label="Toggle navigation">
+            <button class="navbar-toggler text-white border-0 fs-6 ps-3 dropdown-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#navbarToggleExternalContent" aria-controls="navbarToggleExternalContent" aria-expanded="false" aria-label="Toggle navigation">
               Admin
             </button>
           </div>
         </nav>
-        <div class="collapse" id="navbarToggleExternalContent">
-          <div class="bg-dark p-4">
+        <div class="{{ 'collapse-show' if request.path =='/adminLogs' or request.path =='/manageServiceLearning' or request.path =='/admin' or 'serviceLearning' in request.path else 'collapse'}}" id="navbarToggleExternalContent">
+          <div class="bg-dark ps-3">
             <a href="/adminLogs" class="nav-link text-white {{ 'active' if request.path =='/adminLogs' }}">
               Activity Logs
             </a>
@@ -62,7 +62,7 @@
               Service Learning
 
             <a href="/serviceLearning/courseManagement"
-               class="nav-link text-white {{'active' if 'serviceLearning' in request.path }}"
+               class="nav-link text-white {{'active' if 'serviceLearning' in request.path}}"
                {{"aria-current='page'"  if 'serviceLearning' in request.path}}>
               Course Proposals
             </a>

--- a/app/templates/sidebar.html
+++ b/app/templates/sidebar.html
@@ -43,8 +43,23 @@
         <a href="/admin"
            class="nav-link text-white {{'active' if request.path =='/admin'}}"
            {{"aria-current='page'" if request.path =='/admin'}}>
-          Admin Management
+          Settings
         </a>
+      </li>
+      <li>
+        <nav class="navbar navbar-dark bg-dark">
+          <div class="container-fluid">
+            <button class="navbar-toggler text-white border-0 fs-6 ps-3" type="button" data-bs-toggle="collapse" data-bs-target="#navbarToggleExternalContent" aria-controls="navbarToggleExternalContent" aria-expanded="false" aria-label="Toggle navigation">
+              Admin
+            </button>
+          </div>
+        </nav>
+        <div class="collapse" id="navbarToggleExternalContent">
+          <div class="bg-dark p-4">
+            <h5 class="text-white h4">Collapsed content</h5>
+            <span class="text-muted">Toggleable via the navbar brand.</span>
+          </div>
+        </div>
       </li>
       <li>
         <a href="/manageServiceLearning" class="nav-link text-white {{ 'active' if request.path =='/manageServiceLearning' }}">


### PR DESCRIPTION
This PR fixes issue #237 

## Summary:
The sidebar structure had become outdated due to new changes to development. Now the sidebar will have an admin drop-down that will include Activity Logs (prev. Admin Logs), Course Proposals (prev. Course Proposal Management), and Settings (prev. Admin Management). This drop-down is not accessible as a Student Admin.  

## To Test:
Go to the CELTS web app as an admin and you will see the admin dropdown and the options held under it. Pay close attention to what happens after you click as the tab will remain actively highlighted but the drop-down will close and hide the options this can easily be reopened but I am not sure your feelings regarding this. Also, the clickable area is noticeably smaller than the regular nav links. Not sure if these differences are okay or if you would like to approach this differently.

## Previous UI:
![image](https://user-images.githubusercontent.com/67805799/164081723-5bbe1386-89ed-42b0-a163-1cc72b18e2e7.png)
