### PR TITLE
Fixes the footer in volunteer profile page

### DIFF
--- a/app/templates/main/volunteerProfile.html
+++ b/app/templates/main/volunteerProfile.html
@@ -182,7 +182,7 @@
 <!-- End Background Check Table -->
 
 <!-- Ban or Unban Modal -->
-  <div class="modal fade" id="banModal" tabindex="-1" aria-labelledby="banVolunteerModalLabel" aria-hidden="true" style="width:-60px;">
+<div class="modal fade" id="banModal" tabindex="-1" aria-labelledby="banVolunteerModalLabel" aria-hidden="true" style="width:-60px;">
   <form onsubmit="return validate();">
     <div class="modal-dialog">
       <div class="modal-content">
@@ -207,16 +207,13 @@
             </div>
           </div>
         </div>
-
-		  <div class="modal-footer justify-content-between">
-			<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-			<button id="banButton" type="button" class="btn btn-danger" data-banOrUnban="" >Ban/Unban Volunteer</button>
-		  </div>
+  		  <div class="modal-footer justify-content-between">
+    			<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+    			<button id="banButton" type="button" class="btn btn-danger" data-banOrUnban="" >Ban/Unban Volunteer</button>
+  		  </div>
       </div>
-
     </div>
-  </div>
-</form>
+  </form>
 </div>
 {% endblock %}
 <!-- End Ban or Unban Modal -->


### PR DESCRIPTION
The footer on the volunteer profile page used to cover the background check area because of improperly closed tags. This PR fixes the issue. 