### PR TITLE
Links Course Proposals Admin view and link add course button to creation page.

### DIFF
--- a/app/controllers/admin/routes.py
+++ b/app/controllers/admin/routes.py
@@ -194,20 +194,22 @@ def courseManagement(term = None):
     '''
     Renders the page for admins to manage Course Proposals
     '''
+    if g.current_user.isCeltsAdmin:
+        term = Term.get_or_none(Term.id == term)
+        if not term:
+            term = g.current_term
 
-    term = Term.get_or_none(Term.id == term)
-    if not term:
-        term = g.current_term
+        pending = pendingCourses(term)
+        approved = approvedCourses(term)
+        terms = selectSurroundingTerms(g.current_term)
 
-    pending = pendingCourses(term)
-    approved = approvedCourses(term)
-    terms = selectSurroundingTerms(g.current_term)
-
-    return render_template('/admin/courseManagement.html',
-                            pendingCourses = pending,
-                            approvedCourses = approved,
-                            terms = terms,
-                            term = term)
+        return render_template('/admin/courseManagement.html',
+                                pendingCourses = pending,
+                                approvedCourses = approved,
+                                terms = terms,
+                                term = term)
+    else:
+        abort(403)
 @admin_bp.route('/adminLogs', methods = ['GET', 'POST'])
 def adminLogs():
     if g.current_user.isCeltsAdmin:

--- a/app/templates/admin/courseManagement.html
+++ b/app/templates/admin/courseManagement.html
@@ -26,7 +26,7 @@
     <div class="col">
       <div class="float-end">
         <button type="button" class="btn btn-primary btn-sm">Send To Faculty Fellow</button>
-        <button type="button" class="btn btn-success btn-sm">Add Course</button>
+        <a type="button" href="/serviceLearning/newProposal" class="btn btn-success btn-sm">Add Course</a>
       </div>
     </div>
   </div>

--- a/app/templates/sidebar.html
+++ b/app/templates/sidebar.html
@@ -40,6 +40,13 @@
         </a>
       </li>
       <li>
+        <a href="/serviceLearning/courseManagement"
+           class="nav-link text-white {{'active' if request.path =='/serviceLearning/courseManagement'}}"
+           {{"aria-current='page'" if request.path =='/serviceLearning/courseManagement'}}>
+          Course Proposals
+        </a>
+      </li>
+      <li>
       {% if g.current_user.isCeltsAdmin %}
         <nav class="navbar navbar-dark bg-dark">
           <div class="container-fluid">
@@ -48,7 +55,7 @@
             </button>
           </div>
         </nav>
-        <div class="{{ 'collapse-show' if request.path =='/adminLogs' or request.path =='/manageServiceLearning' or request.path =='/admin' or 'serviceLearning' in request.path else 'collapse'}}" id="navbarToggleExternalContent">
+        <div class="{{ 'collapse-show' if request.path =='/adminLogs' or request.path =='/manageServiceLearning' or request.path =='/admin' or request.path == '/courseManagement' else 'collapse'}}" id="navbarToggleExternalContent">
           <div class="bg-dark ps-3">
             <a href="/adminLogs" class="nav-link text-white {{ 'active' if request.path =='/adminLogs' }}">
               Activity Logs
@@ -61,10 +68,10 @@
             <a href="/manageServiceLearning" class="nav-link text-white {{ 'active' if request.path =='/manageServiceLearning' }}">
               Service Learning
 
-            <a href="/serviceLearning/courseManagement"
-               class="nav-link text-white {{'active' if 'serviceLearning' in request.path}}"
-               {{"aria-current='page'"  if 'serviceLearning' in request.path}}>
-              Course Proposals
+            <a href="/courseManagement"
+               class="nav-link text-white {{'active' if request.path == '/courseManagement'}}"
+               {{"aria-current='page'"  if request.path == '/courseManagement'}}>
+              Proposal Management
             </a>
           </div>
         </div>


### PR DESCRIPTION
This PR fixes issues #231 and fixes #233 

## Summary:
There was a mixup of what courseManagement page belongs under the Admin dropdown. I have corrected the mixup as well as linked the Faculty Course Proposal page to the sidebar. I have also linked the `Add a Course` button to the create a course page. 

## To test: 
Click the course proposal page that is on the sidebar and you will see the correct view, click the Admin dropdown and click Proposal Management from there and you will see the view is different and from there you are also able to test that the `Add a Course` button will lead you to the correct page.