### PR TITLE
Refactored the model: studentManager to programManager

### DIFF
--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -16,7 +16,7 @@ from app.models.programEvent import ProgramEvent
 from app.models.term import Term
 from app.models.eventRsvp import EventRsvp
 from app.models.note import Note
-from app.models.studentManager import StudentManager
+from app.models.programManager import ProgramManager
 from app.controllers.main import main_bp
 from app.logic.users import addUserInterest, removeUserInterest, banUser, unbanUser, isEligibleForProgram
 from app.logic.participants import userRsvpForEvent, unattendedRequiredEvents, trainedParticipants
@@ -77,8 +77,8 @@ def viewVolunteersProfile(username):
         rsvpedEventsList = EventRsvp.select().where(EventRsvp.user == volunteer)
         rsvpedEvents = [event.event.id for event in rsvpedEventsList]
 
-        studentManagerPrograms = list(StudentManager.select().where(StudentManager.user == volunteer))
-        permissionPrograms = [entry.program.id for entry in studentManagerPrograms]
+        ProgramManagerPrograms = list(ProgramManager.select().where(ProgramManager.user == volunteer))
+        permissionPrograms = [entry.program.id for entry in ProgramManagerPrograms]
 
         allUserEntries = list(BackgroundCheck.select().where(BackgroundCheck.user == volunteer))
         completedBackgroundCheck = {entry.type.id: entry.passBackgroundCheck for entry in allUserEntries}

--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -77,7 +77,7 @@ def viewVolunteersProfile(username):
         rsvpedEventsList = EventRsvp.select().where(EventRsvp.user == volunteer)
         rsvpedEvents = [event.event.id for event in rsvpedEventsList]
 
-        ProgramManagerPrograms = list(ProgramManager.select().where(ProgramManager.user == volunteer))
+        programManagerPrograms = list(ProgramManager.select().where(ProgramManager.user == volunteer))
         permissionPrograms = [entry.program.id for entry in ProgramManagerPrograms]
 
         allUserEntries = list(BackgroundCheck.select().where(BackgroundCheck.user == volunteer))

--- a/app/logic/userManagement.py
+++ b/app/logic/userManagement.py
@@ -1,6 +1,6 @@
 from app.models.user import User
 from app.models.term import Term
-from app.models.studentManager import StudentManager
+from app.models.programManager import ProgramManager
 from app.models.program import Program
 from flask import g, session
 from app.logic.adminLogs import createLog
@@ -46,19 +46,19 @@ def changeCurrentTerm(term):
 
 def addProgramManager(user,program):
     user = User.get_by_id(user)
-    managerEntry = StudentManager.create(user=user,program=program)
+    managerEntry = ProgramManager.create(user=user,program=program)
     managerEntry.save()
     return(f'{user} added as manager')
 
 def removeProgramManager(user,program):
     user = User.get_by_id(user)
-    delQuery = StudentManager.delete().where(StudentManager.user == user,StudentManager.program == program)
+    delQuery = ProgramManager.delete().where(ProgramManager.user == user,ProgramManager.program == program)
     delQuery.execute()
     return (f'{user} removed from managers')
 
 def hasPrivilege(user, program):
     user = User.get_by_id(user)
-    if StudentManager.select().where(StudentManager.user == user, StudentManager.program == program).exists():
+    if ProgramManager.select().where(ProgramManager.user == user, ProgramManager.program == program).exists():
         return True
     else:
         return False
@@ -89,4 +89,4 @@ def addNextTerm():
     return newTerm
 
 def getPrograms(currentUser):
-    return Program.select().join(StudentManager).where(StudentManager.user==currentUser).order_by(Program.programName)
+    return Program.select().join(ProgramManager).where(ProgramManager.user==currentUser).order_by(Program.programName)

--- a/app/models/programManager.py
+++ b/app/models/programManager.py
@@ -2,6 +2,6 @@ from app.models import *
 from app.models.program import Program
 from app.models.user import User
 
-class StudentManager(baseModel):
+class ProgramManager(baseModel):
     user = ForeignKeyField(User)
     program = ForeignKeyField(Program)

--- a/database/migrate_db.sh
+++ b/database/migrate_db.sh
@@ -22,7 +22,7 @@ pem add app.models.courseInstructor.CourseInstructor
 pem add app.models.courseQuestion.CourseQuestion
 pem add app.models.questionNote.QuestionNote
 pem add app.models.eventRsvp.EventRsvp
-pem add app.models.studentManager.StudentManager
+pem add app.models.programManager.ProgramManager
 pem add app.models.emailLog.EmailLog
 pem add app.models.backgroundCheck.BackgroundCheck
 pem add app.models.backgroundCheckType.BackgroundCheckType

--- a/database/test_data.py
+++ b/database/test_data.py
@@ -20,7 +20,7 @@ from app.models.questionNote import QuestionNote
 from app.models.interest import Interest
 from app.models.facilitator import Facilitator
 from app.models.note import Note
-from app.models.studentManager import StudentManager
+from app.models.programManager import ProgramManager
 from app.models.emailTemplate import EmailTemplate
 from app.models.backgroundCheck import BackgroundCheck
 # from app.models.backgroundCheckType import BackgroundCheckType
@@ -820,7 +820,7 @@ facilitators = [
 ]
 Facilitator.insert_many(facilitators).on_conflict_replace().execute()
 
-studentManagerPrograms = [
+programManagerPrograms = [
     {
     'user':'khatts',
     'program':1
@@ -843,7 +843,7 @@ studentManagerPrograms = [
     }
 ]
 
-StudentManager.insert_many(studentManagerPrograms).on_conflict_replace().execute()
+ProgramManager.insert_many(programManagerPrograms).on_conflict_replace().execute()
 
 emailTemplates = [
     {

--- a/tests/code/test_userManagement.py
+++ b/tests/code/test_userManagement.py
@@ -4,7 +4,7 @@ from app import app
 from app.logic.userManagement import *
 from app.models.user import User
 from app.models.term import Term
-from app.models.studentManager import StudentManager
+from app.models.programManager import ProgramManager
 
 from peewee import DoesNotExist
 from flask import g


### PR DESCRIPTION
For Issue #298

This pull request should be accepted before PR #299

Refactored the model from studentManager to programManager and all references to it throughout the code. 

The reason for this refactor was to clarify what a student manager is. There is a difference between student staff and program managers so calling all references to studentManger to programManager was more appropriate and less confusing. 

Locations where refactor occurred;

app/controllers/main/routes.py
app/logic/userManagement.py
database/migrate_db.sh
database/test_data.py
tests/code/test_userManagment.py

Renamed: app/models/studentManager.py -> app/models/programManager.py
