### PR TITLE
Activity log query issue 292

### DIFF
--- a/app/controllers/admin/routes.py
+++ b/app/controllers/admin/routes.py
@@ -191,7 +191,7 @@ def addParticipants():
 @admin_bp.route('/adminLogs', methods = ['GET', 'POST'])
 def adminLogs():
     if g.current_user.isCeltsAdmin:
-        allLogs = AdminLogs.select(AdminLogs, User.firstName, User.lastName).join(User).order_by(AdminLogs.createdOn.desc()).objects()
+        allLogs = AdminLogs.select(AdminLogs, User).join(User).order_by(AdminLogs.createdOn.desc())
         return render_template("/admin/adminLogs.html",
                                 allLogs = allLogs)
     else:

--- a/app/controllers/admin/routes.py
+++ b/app/controllers/admin/routes.py
@@ -191,7 +191,7 @@ def addParticipants():
 @admin_bp.route('/adminLogs', methods = ['GET', 'POST'])
 def adminLogs():
     if g.current_user.isCeltsAdmin:
-        allLogs = AdminLogs.select(adminLogs, User.firstName, User.lastName).join(User).order_by(AdminLogs.createdOn.desc()).objects()
+        allLogs = AdminLogs.select(AdminLogs, User.firstName, User.lastName).join(User).order_by(AdminLogs.createdOn.desc()).objects()
         return render_template("/admin/adminLogs.html",
                                 allLogs = allLogs)
     else:

--- a/app/controllers/admin/routes.py
+++ b/app/controllers/admin/routes.py
@@ -191,7 +191,7 @@ def addParticipants():
 @admin_bp.route('/adminLogs', methods = ['GET', 'POST'])
 def adminLogs():
     if g.current_user.isCeltsAdmin:
-        allLogs = AdminLogs.select().order_by(AdminLogs.createdOn.desc())
+        allLogs = AdminLogs.select(adminLogs, User.firstName, User.lastName).join(User).order_by(AdminLogs.createdOn.desc()).objects()
         return render_template("/admin/adminLogs.html",
                                 allLogs = allLogs)
     else:

--- a/app/templates/admin/adminLogs.html
+++ b/app/templates/admin/adminLogs.html
@@ -27,7 +27,7 @@
   {% for entry in allLogs%}
   <tr>
     <td>{{entry.createdOn}}</td>
-    <td>{{entry.firstName+ " "+ entry.lastName}}</td>
+    <td>{{entry.createdBy.firstName+ " "+ entry.createdBy.lastName}}</td>
     <td>{{entry.logContent}}</td>
 
  </tr>

--- a/app/templates/admin/adminLogs.html
+++ b/app/templates/admin/adminLogs.html
@@ -27,7 +27,7 @@
   {% for entry in allLogs%}
   <tr>
     <td>{{entry.createdOn}}</td>
-    <td>{{entry.createdBy.firstName+ " "+ entry.createdBy.lastName}}</td>
+    <td>{{entry.firstName+ " "+ entry.lastName}}</td>
     <td>{{entry.logContent}}</td>
 
  </tr>


### PR DESCRIPTION
Fixed the problem where the activity log was spitting out a query for every row in the table. Updated query so that it joined User and AdminLogs to not require an extra query upon iteration through the table.
Fixes issue #292 
Closes issue #292 