### PR TITLE
Onetime events display138

### DIFF
--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -45,7 +45,7 @@ def events(selectedTerm):
     studentLedProgram = getStudentLedProgram(term)
     trainingProgram = getTrainingProgram(term)
     bonnerProgram = getBonnerProgram(term)
-    nonProgramEvents = getnonProgramEvents(term)
+    nonProgramEvents = getNonProgramEvents(term)
 
     return render_template("/events/event_list.html",
         selectedTerm = term,

--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -45,14 +45,14 @@ def events(selectedTerm):
     studentLedProgram = getStudentLedProgram(term)
     trainingProgram = getTrainingProgram(term)
     bonnerProgram = getBonnerProgram(term)
-    oneTimeEvents = getOneTimeEvents(term)
+    nonProgramEvents = getnonProgramEvents(term)
 
     return render_template("/events/event_list.html",
         selectedTerm = term,
         studentLedProgram = studentLedProgram,
         trainingProgram = trainingProgram,
         bonnerProgram = bonnerProgram,
-        oneTimeEvents = oneTimeEvents,
+        nonProgramEvents = nonProgramEvents,
         listOfTerms = listOfTerms,
         rsvpedEventsID = rsvpedEventsID,
         currentTime = currentTime,

--- a/app/logic/events.py
+++ b/app/logic/events.py
@@ -152,7 +152,7 @@ def getBonnerProgram(term):
                                         Event.term == term))
     return list(bonnerScholarsEvents)
 
-def getnonProgramEvents(term):
+def getNonProgramEvents(term):
     """
     Get the list of the one-time events to be displayed in the Other Events section
     of the Events List page.

--- a/app/logic/events.py
+++ b/app/logic/events.py
@@ -152,18 +152,18 @@ def getBonnerProgram(term):
                                         Event.term == term))
     return list(bonnerScholarsEvents)
 
-def getOneTimeEvents(term):
+def getnonProgramEvents(term):
     """
     Get the list of the one-time events to be displayed in the Other Events section
     of the Events List page.
     :return: A list of One Time Events objects
     """
-    oneTimeEvents = (Event.select()
+    nonProgramEvents = (Event.select()
                         .join(ProgramEvent, JOIN.LEFT_OUTER)
-                        .where(Program.id.alias("program_id") == None,
+                        .where(ProgramEvent.program == None,
                         Event.isTraining == False))
 
-    return list(oneTimeEvents)
+    return list(nonProgramEvents)
 
 def getUpcomingEventsForUser(user,asOf=datetime.datetime.now()):
     """

--- a/app/logic/events.py
+++ b/app/logic/events.py
@@ -1,4 +1,4 @@
-from peewee import DoesNotExist, fn
+from peewee import DoesNotExist, fn, JOIN
 from dateutil import parser
 import datetime
 from werkzeug.datastructures import MultiDict
@@ -153,12 +153,16 @@ def getBonnerProgram(term):
     return list(bonnerScholarsEvents)
 
 def getOneTimeEvents(term):
-    oneTimeEvents = (Event.select(Event, Program.id.alias("program_id"))
-                          .join(ProgramEvent)
-                          .join(Program)
-                          .where(Program.isStudentLed == False,
-                                 Program.isBonnerScholars == False,
-                                 Event.term == term))
+    """
+    Get the list of the one-time events to be displayed in the Other Events section
+    of the Events List page.
+    :return: A list of One Time Events objects
+    """
+    oneTimeEvents = (Event.select()
+                        .join(ProgramEvent, JOIN.LEFT_OUTER)
+                        .where(Program.id.alias("program_id") == None,
+                        Event.isTraining == False))
+
     return list(oneTimeEvents)
 
 def getUpcomingEventsForUser(user,asOf=datetime.datetime.now()):

--- a/app/templates/admin/createSingleEvent.html
+++ b/app/templates/admin/createSingleEvent.html
@@ -26,7 +26,7 @@
         {% elif template.tag == 'all-volunteer' %}
           {% set page_title = 'Create All Volunteer Training' %}
         {% elif template.tag == 'no-program' %}
-          {% set page_title = 'Create One-off Event' %}
+          {% set page_title = 'Create Non-program Event' %}
         {% else %}
           {% set page_title = 'Create ' + template.name + ' Event' %}
         {% endif %}
@@ -181,7 +181,7 @@
             <input class="form-check-input" type="checkbox" id="earnServiceHours" name="isService" {{"checked" if eventData.isService}}/>
           </div>
           {% else %}
-            <div class="mb-4">    
+            <div class="mb-4">
             {% if eventData.isRsvpRequired %}
               <label><strong>This event requires RSVP</strong></label><br>
             {% endif %}

--- a/app/templates/events/event_list.html
+++ b/app/templates/events/event_list.html
@@ -46,7 +46,7 @@
   </li>
   <li class="nav-item" role="presentation">
     <button class="nav-link" id="oneTimeEvents"
-    data-bs-toggle="pill" data-bs-target="#pills-one-time" type="button" role="tab" aria-controls="pills-one-time" aria-selected="false">One-time Events</button>
+    data-bs-toggle="pill" data-bs-target="#pills-one-time" type="button" role="tab" aria-controls="pills-one-time" aria-selected="false">Other Events</button>
   </li>
   </ul>
 </div>

--- a/app/templates/events/event_list.html
+++ b/app/templates/events/event_list.html
@@ -45,7 +45,7 @@
     data-bs-toggle="pill" data-bs-target="#pills-bonner-scholars" type="button" role="tab" aria-controls="pills-bonner-scholars" aria-selected="false">Bonner Scholars</button>
   </li>
   <li class="nav-item" role="presentation">
-    <button class="nav-link" id="oneTimeEvents"
+    <button class="nav-link" id="nonProgramEvents"
     data-bs-toggle="pill" data-bs-target="#pills-one-time" type="button" role="tab" aria-controls="pills-one-time" aria-selected="false">Other Events</button>
   </li>
   </ul>
@@ -172,7 +172,7 @@
     {{createTable(bonnerProgram)}}
   </div>
   <div class="tab-pane fade show" id="pills-one-time" role="tabpanel" aria-labelledby="pills-one-time-tab">
-    {{createTable(oneTimeEvents)}}
+    {{createTable(nonProgramEvents)}}
   </div>
 </div>
 {% include 'emailModal.html' %}

--- a/tests/code/test_event_list.py
+++ b/tests/code/test_event_list.py
@@ -4,7 +4,7 @@ from app.models import mainDB
 from app.models.programEvent import ProgramEvent
 from app.models.event import Event
 from app.models.event import Term
-from app.logic.events import getStudentLedProgram,  getTrainingProgram, getBonnerProgram, getnonProgramEvents
+from app.logic.events import getStudentLedProgram,  getTrainingProgram, getBonnerProgram, getNonProgramEvents
 
 @pytest.mark.integration
 def test_event_list():
@@ -80,7 +80,7 @@ def test_event_list():
         assert bonner in bonnerProgram
         assert Studentled not in bonnerProgram
 
-        nonProgramEvents = getnonProgramEvents(3)
+        nonProgramEvents = getNonProgramEvents(3)
         assert nonProgramEvents
         assert nonProgram not in nonProgramEvents
         assert Studentled not in nonProgramEvents

--- a/tests/code/test_event_list.py
+++ b/tests/code/test_event_list.py
@@ -4,7 +4,7 @@ from app.models import mainDB
 from app.models.programEvent import ProgramEvent
 from app.models.event import Event
 from app.models.event import Term
-from app.logic.events import getStudentLedProgram,  getTrainingProgram, getBonnerProgram, getOneTimeEvents
+from app.logic.events import getStudentLedProgram,  getTrainingProgram, getBonnerProgram, getnonProgramEvents
 
 @pytest.mark.integration
 def test_event_list():
@@ -40,7 +40,7 @@ def test_event_list():
                                 endDate = 2021-12-13)
         bonnerProgramEvent = ProgramEvent.create(program = 5, event = bonner)
 
-        oneTime = Event.create(name = "Test One Time",
+        nonProgram = Event.create(name = "Test Non-program Event",
                                 term = 3,
                                 description = "event for testing",
                                 timeStart = "18:00:00",
@@ -48,7 +48,7 @@ def test_event_list():
                                 location = "basement",
                                 startDate = 2021-12-12,
                                 endDate = 2021-12-13)
-        oneTimeProgramEvent = ProgramEvent.create(program = 6, event = oneTime)
+        nonProgramEvent = ProgramEvent.create(program = 6, event = nonProgram)
 
         newTerm= Term.create(
             description= "Fall 2025",
@@ -80,9 +80,9 @@ def test_event_list():
         assert bonner in bonnerProgram
         assert Studentled not in bonnerProgram
 
-        oneTimeEvents = getOneTimeEvents(3)
-        assert oneTimeEvents
-        assert oneTime in oneTimeEvents
-        assert Studentled not in oneTimeEvents
+        nonProgramEvents = getnonProgramEvents(3)
+        assert nonProgramEvents
+        assert nonProgram not in nonProgramEvents
+        assert Studentled not in nonProgramEvents
 
         transaction.rollback()


### PR DESCRIPTION
Fixes Issue #138 

Created a new query for the getnonProgramEvents function as well as changed this naming throughout the CELTS application (oneTimeEvent --> nonProgramEvent). Changed line 85 of the test suite to pass for now until Anderson changes this file. We also changed the Event List tab name to be "Other Events" and changed the create an event page to display "Create Non-Program Event". 

Files Changed:
- app/controllers/main/routes.py
- app/logic/events.py
- app/templates/admin/createSingleEvent.html
- app/templates/events/event_list.html
- tests/code/test_event_list.py