### PR TITLE
My Profile in the sidebar highlight

### DIFF
--- a/app/templates/sidebar.html
+++ b/app/templates/sidebar.html
@@ -13,7 +13,7 @@
         </a>
       </li>
       <li>
-        <a href="/profile/{{g.current_user}}" class="nav-link text-white {{'active' if 'profile' in request.path }}" {{"aria-current='page'" if 'profile' in request.path }}>
+        <a href="/profile/{{g.current_user}}" class="nav-link text-white {{'active' if 'profile' and g.current_user.username in request.path }}" {{"aria-current='page'" if 'profile' in request.path }}>
           My Profile
         </a>
       </li>


### PR DESCRIPTION
#375 
The My Profile section of the sidebar used to be highlighted regardless of what profile the user was in. Now, it checks whether or not the current_user's username and "profile" are in the URL in order to highlight it when appropriate

Files changed:
- app/templates/sidebar.html
