### PR TITLE
add the event program field under the training and education tab

### DIFF
--- a/app/templates/events/event_list.html
+++ b/app/templates/events/event_list.html
@@ -59,6 +59,7 @@
         <th scope="col">Date</th>
         <th scope="col">Time</th>
         <th scope="col">Location</th>
+        <th> Event Program </th>
         <th scope="col">Invitation</th>
       </tr>
     </thead>
@@ -69,6 +70,13 @@
             <td>{{event.startDate.strftime('%m-%d-%Y')}}</td>
             <td>{{event.timeStart.strftime('%I:%M %p')}}</td>
             <td>{{event.location}}</td>
+            {% if event.programEvents%}
+            {% for programEvent in event.programEvents%}
+            <td>{{programEvent.program.programName}}</td>
+            {% endfor %}
+            {% else %}
+            <td>This event does not belong to any program</td>
+            {% endif %}
             {% if user.isAdmin %}
               <td>
                 {% if event.isPast %}

--- a/app/templates/events/event_list.html
+++ b/app/templates/events/event_list.html
@@ -71,11 +71,11 @@
             <td>{{event.timeStart.strftime('%I:%M %p')}}</td>
             <td>{{event.location}}</td>
             {% if event.programEvents%}
-            {% for programEvent in event.programEvents%}
-            <td>{{programEvent.program.programName}}</td>
-            {% endfor %}
+              {% for programEvent in event.programEvents%}
+              <td>{{programEvent.program.programName}}</td>
+              {% endfor %}
             {% else %}
-            <td>This event does not belong to any program</td>
+              <td>This event does not belong to any program</td>
             {% endif %}
             {% if user.isAdmin %}
               <td>


### PR DESCRIPTION
fixes issue #394:

Changes made:
We have added a new purpose field under the Training and Education sector which identifies what program an event belongs to.