### PR TITLE
fix service transcript print to print only one page

### DIFF
--- a/app/templates/main/serviceTranscript.html
+++ b/app/templates/main/serviceTranscript.html
@@ -2,7 +2,7 @@
 {% extends "base.html"%}
 
 {% block app_content %}
-
+<div class="w-100 d-print-inline-block">
 <h1 class="text-center mt-5 mb-3">{{userData.firstName}} {{userData.lastName}}</h1>
 <div class="btn-group d-print-none">
   <ul class="nav nav-tabs" role="tab-list">
@@ -109,5 +109,7 @@
 <div class="d-print-none pt-5">
   <p>If there are any corrections that need to be made, contact <a href="mailto:cochranea@berea.edu">Ashley Cochrane</a></p>
 </div>
+</div>
+
 
 {% endblock %}


### PR DESCRIPTION
fix issue #399 

The print button was printing an extra page. Now it displays only the div block content