### PR TITLE
Improved the header on the 'Course Proposals' page and added a period to the recurring event selector on the create event page.

### DIFF
--- a/app/templates/admin/createSingleEvent.html
+++ b/app/templates/admin/createSingleEvent.html
@@ -100,7 +100,7 @@
         </div>
         {% if isNewEvent %}
         <div class="form-check form-switch pb-1">
-          <label class="custom-control-label" for='checkIsRecurring'><strong>This is a recurring event</strong></label>
+          <label class="custom-control-label" for='checkIsRecurring'><strong>This is a recurring event.</strong></label>
           <input class="form-check-input" type="checkbox" id="checkIsRecurring" name="isRecurring"/>
         </div>
         {% endif %}

--- a/app/templates/serviceLearning/slcManagment.html
+++ b/app/templates/serviceLearning/slcManagment.html
@@ -7,7 +7,7 @@
 
 {% block app_content %}
 <input id="username" type="hidden" value='{{user.username}}'>
-<h1 class="text-center mt-5 mb-2">{{user.firstName}} {{user.lastName}}</h1>
+<h1 class="text-center mt-5 mb-2">{{user.firstName}} {{user.lastName}}'s SLC Proposals</h1>
 <div align="right">
   <a class="btn btn-primary" href="/serviceLearning/newProposal" role="button">Create Course Proposal</a>
 </div>


### PR DESCRIPTION
fixes issue #439 

- Changed header on the "Course Proposal" page from  "_Name_" to "_Name's SLC Proposals_"
- On the "Create Event" page: added a period to "This is a recurring event" 