### PR TITLE
Fixed a small bug resulted from fixing the extra page on the service learning proposal

### DIFF
--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -64,7 +64,7 @@ function displayCorrectTab(navigateTab) {
   // This function will figure out which tab to display
   let allTabs = $(".tab");
   if (navigateTab == 1 && !validateForm()) return false;
-  if(currentTab != (allTabs.length - 1)){
+  if(currentTab != (allTabs.length - 1) || (navigateTab == -1)){
       $(allTabs[currentTab]).css("display", "none");
   }
 

--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -57,7 +57,7 @@ $("#nextButton").on("click", function() {
 });
 
 $("#cancelButton").on("click", function() {
-  window.location.replace("/manageServiceLearning");
+        window.location.replace("/serviceLearning/courseManagement");
 });
 
 function displayCorrectTab(navigateTab) {


### PR DESCRIPTION
This expands from PR #512 

Changes made: 
Spotted a small bug in the course proposal page where if you click on the previous button after the second page, it will take you back but show two different pages on one page. This solution fixes that now.