### PR TITLE
Display Next Event Data of Recurring Events

### DIFF
--- a/app/controllers/admin/routes.py
+++ b/app/controllers/admin/routes.py
@@ -156,8 +156,9 @@ def eventDisplay(eventId):
         eventData["startDate"] = event.startDate.strftime("%m/%d/%Y")
         # List below is to identify the last event in the series
         eventSeriesList = list(Event.select().where(Event.recurringId == event.recurringId))
-        if event.recurringId and not eventSeriesList[-1] == event:
-            eventData["nextRecurringEvent"] = Event.select().where(Event.id > event.id, Event.recurringId == event.recurringId).get()
+        eventIndex = eventSeriesList.index(event)
+        if event.recurringId and len(eventSeriesList) != (eventIndex + 1):
+            eventData["nextRecurringEvent"] = eventSeriesList[eventIndex + 1]
         programManager = ProgramManager.get_or_none(program=program)
         userParticipatedEvents = getUserParticipatedEvents(program, g.current_user, g.current_term)
         return render_template("eventView.html",

--- a/app/controllers/admin/routes.py
+++ b/app/controllers/admin/routes.py
@@ -154,7 +154,7 @@ def eventDisplay(eventId):
         eventData['timeStart'] = event.timeStart.strftime("%-I:%M %p")
         eventData['timeEnd'] = event.timeEnd.strftime("%-I:%M %p")
         eventData["startDate"] = event.startDate.strftime("%m/%d/%Y")
-        # List below is to identify the last event in the series
+        # List below is to identify the next event in the series
         eventSeriesList = list(Event.select().where(Event.recurringId == event.recurringId))
         eventIndex = eventSeriesList.index(event)
         if event.recurringId and len(eventSeriesList) != (eventIndex + 1):

--- a/app/controllers/admin/routes.py
+++ b/app/controllers/admin/routes.py
@@ -154,6 +154,7 @@ def eventDisplay(eventId):
         eventData['timeStart'] = event.timeStart.strftime("%-I:%M %p")
         eventData['timeEnd'] = event.timeEnd.strftime("%-I:%M %p")
         eventData["startDate"] = event.startDate.strftime("%m/%d/%Y")
+        eventData["nextRecurringEvent"] = nextRecurringEvent = Event.select().where(Event.id > event.id, Event.recurringId == event.recurringId).get()
         programManager = ProgramManager.get_or_none(program=program)
         userParticipatedEvents = getUserParticipatedEvents(program, g.current_user, g.current_term)
         return render_template("eventView.html",

--- a/app/templates/eventView.html
+++ b/app/templates/eventView.html
@@ -51,7 +51,7 @@
                     {% if eventData.recurringId %}
                         <p>This event is a recurring event.
                             {% if eventData.nextRecurringEvent %}
-                            The next event in the series occurs on <b>{{eventData.nextRecurringEvent.startDate.strftime("%B %d")}}</b>.
+                            The next event in the series occurs on <b>{{eventData.nextRecurringEvent.startDate.strftime("%B %-d")}}</b>.
                             <a href="/eventsList/{{eventData.nextRecurringEvent.id}}/view">Click here for more information.</a>
                             {% else %}
                             <b>However, this is the last event in the series.</b>

--- a/app/templates/eventView.html
+++ b/app/templates/eventView.html
@@ -51,7 +51,7 @@
                     {% if eventData.recurringId %}
                         <p>This event is a recurring event.
                             {% if eventData.nextRecurringEvent %}
-                            The next event in the series occurs on {{eventData.nextRecurringEvent.startDate.strftime("%m/%d/%Y")}}.
+                            The next event in the series occurs on <b>{{eventData.nextRecurringEvent.startDate.strftime("%B %d")}}</b>.
                             <a href="/eventsList/{{eventData.nextRecurringEvent.id}}/view">Click here for more information.</a>
                             {% else %}
                             <b>However, this is the last event in the series.</b>

--- a/app/templates/eventView.html
+++ b/app/templates/eventView.html
@@ -50,6 +50,8 @@
                         {% endif %}
                         {% if eventData.recurringId %}
                             This event is a recurring event.
+                            The next event in the series occurs on {{eventData.nextRecurringEvent.startDate.strftime("%m/%d/%Y")}}.
+                            <a href="/eventsList/{{eventData.nextRecurringEvent.id}}/view">Click here for more information.</a>
                         {% endif %}
                         {% if eventData.isTraining %}
                             This event is a training.


### PR DESCRIPTION
Waiting on PR #590 
In the event view page, next to the sentence that specifies if an event is a recurring event, there is a short sentence showing when the next event in the series in, as well as a link to the event view page of said next event.