### PR TITLE
renamed sidebar and page title

### DIFF
--- a/app/templates/main/manageServiceLearningFaculty.html
+++ b/app/templates/main/manageServiceLearningFaculty.html
@@ -16,7 +16,7 @@
 
 {% block app_content %}
 <div id="content">
-  <h1 class="text-center pt-1 pb-4">Course Proposal Management</h1>
+  <h1 class="text-center pt-1 pb-4">Designated Service-Learning Courses</h1>
   <div class="text-center">
     <form id="termSelector" action="" method="post">
       <select class="w-25" id="selectTerm" onchange="formSubmit(this.value)">

--- a/app/templates/sidebar.html
+++ b/app/templates/sidebar.html
@@ -63,7 +63,7 @@
               Settings
             </a>
             <a href="/manageServiceLearning" class="nav-link text-white {{ 'active' if request.path =='/manageServiceLearning' }}">
-              Service-Learning
+              Course Management
             </a>
           </div>
         </div>


### PR DESCRIPTION
- renamed side bar to "course management" and title to "Designated Service-Learning Courses"

fix issue #647 