### PR TITLE
The add volunteers button now focuses on the search bar

### DIFF
--- a/app/static/js/trackVolunteers.js
+++ b/app/static/js/trackVolunteers.js
@@ -64,6 +64,10 @@ $(document).ready(function() {
     }
   $("#selectVolunteerButton").prop('disabled', true);
 
+  $("#addVolunteerModal").on("shown.bs.modal", function() {
+      $('#addVolunteerInput').focus();
+  });
+
   $("#addVolunteerInput").on("input", function() {
     searchUser("addVolunteerInput", callback, true, "addVolunteerModal");
   });


### PR DESCRIPTION
Solves issue #667 

Changes made:
* Made the add volunteer button on the track volunteers page to focus on the search bar so that once you click on it, the user can start typing right away without needing to click on the search bar again.