### PR TITLE
Removed the recurring event toggler from All Volunteer Training Page

### DIFF
--- a/app/templates/admin/createEvent.html
+++ b/app/templates/admin/createEvent.html
@@ -77,7 +77,7 @@
           <label class="form-label" for='inputEventLocation'><strong>Location</strong></label>
           <input class="form-control" id='inputEventLocation' value="{{eventData.location}}" placeholder="Enter location" name="location" required>
         </div>
-        {% if isNewEvent %}
+        {% if isNewEvent and template.tag != 'all-volunteer' %}
         <div class="form-check form-switch pb-1">
           <label class="custom-control-label" for='checkIsRecurring'><strong>This is a recurring event.</strong></label>
           <input class="form-check-input" type="checkbox" id="checkIsRecurring" name="isRecurring"/>


### PR DESCRIPTION
Solves issue #653 

Changes made:
* It was an easy fix since I just needed to remove the recurring event toggler from the All-Volunteer Training Page. 