### PR TITLE
Typing in time when creating an event - Issue #656

### DIFF
--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -56,7 +56,7 @@ $(document).ready(function() {
   // everything except Chrome
   if (navigator.userAgent.indexOf("Chrome") == -1) {
     $('input.timepicker').timepicker({
-             timeFormat : 'h:mm p',
+             timeFormat : 'hh:mm p',
              scrollbar: true,
              dropdown: true,
              dynamic: true,

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -56,7 +56,7 @@ $(document).ready(function() {
   // everything except Chrome
   if (navigator.userAgent.indexOf("Chrome") == -1) {
     $('input.timepicker').timepicker({
-             timeFormat : 'hh:mm p',
+             timeFormat : 'h:mm p',
              scrollbar: true,
              dropdown: true,
              dynamic: true,

--- a/app/templates/admin/createEvent.html
+++ b/app/templates/admin/createEvent.html
@@ -117,7 +117,7 @@
                 {%else%}
                   {%set start_time = "12:00" %}
                 {% endif %}
-                <input autocomplete="off" type="time" class="form-control timepicker readonly" value="{{start_time}}" name="timeStart" aria-describedby="timeIcon1" placeholder="Pick a start time" onchange="update(this)" id=startTime required />
+                <input autocomplete="off" type="time" class="form-control timepicker" value="{{start_time}}" name="timeStart" aria-describedby="timeIcon1" placeholder="Pick a start time" onchange="update(this)" id=startTime required />
                 <span class="input-group-text timeIcons" id="timeIcon1" hidden><i class="bi bi-clock"></i></span>
               </div>
             </div>
@@ -129,7 +129,7 @@
                 {%else%}
                   {%set end_time = "12:00" %}
                 {% endif %}
-                  <input autocomplete="off" type="time" class="form-control timepicker readonly" value="{{end_time}}" name="timeEnd" aria-describedby="timeIcon2" placeholder="Pick an end time" onchange="update(this)" id=endTime required />
+                  <input autocomplete="off" type="time" class="form-control timepicker" value="{{end_time}}" name="timeEnd" aria-describedby="timeIcon2" placeholder="Pick an end time" onchange="update(this)" id=endTime required />
                   <span class="input-group-text timeIcons" id="timeIcon2" hidden><i class="bi bi-clock"></i></span>
               </div>
             </div>
@@ -141,7 +141,7 @@
             <tbody></tbody>
           </table>
         </div>
-        
+
     </div>
         <div class="col-md-6 form-group">
           <div class="form-group mb-4">


### PR DESCRIPTION
**Issue:** The user cannot modify time by typing it in.
**Solution:** I removed the "readonly" attribute to let the user edit the time if they want to type it in. Also, I changed the time format from 24-hour format to 12-hour format so that the user doesn't have to manually move to the other side when choosing time.
**Testing:** Tested by creating an event and typing in the time I wanted. 
**Issue:** https://github.com/BCStudentSoftwareDevTeam/celts/issues/656