### PR TITLE
Fixing View Button in Eligibility Table - Issue #695

### DIFF
--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -158,10 +158,10 @@
                    <td>
                        {% if row.completedTraining or not trainingList %}
                            <i class="bi bi-check-lg"></i> &nbsp&nbsp
-                           <a class="trainingPopover" id="{{row.program.id}}" href="#" data-toggle="popover" title="Program Trainings" data-content= "{{trainingListView()}}">View</a>
+                           <a class="trainingPopover" id="{{row.program.id}}" href="#!" data-toggle="popover" title="Program Trainings" data-content= "{{trainingListView()}}">View</a>
                        {% else %}
                            <i class="bi bi-x-lg"></i> &nbsp&nbsp
-                           <a class="trainingPopover" id="{{row.program.id}}" href="#" data-toggle="popover" title="Program Trainings" data-content= "{{trainingListView()}}">View</a>
+                           <a class="trainingPopover" id="{{row.program.id}}" href="#!" data-toggle="popover" title="Program Trainings" data-content= "{{trainingListView()}}">View</a>
                        {% endif %}
                    </td>
                  {% if g.current_user.isCeltsAdmin or g.current_user.isCeltsStudentStaff %}

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -158,10 +158,10 @@
                    <td>
                        {% if row.completedTraining or not trainingList %}
                            <i class="bi bi-check-lg"></i> &nbsp&nbsp
-                           <a class="trainingPopover" id="{{row.program.id}}" href="#!" data-toggle="popover" title="Program Trainings" data-content= "{{trainingListView()}}">View</a>
+                           <a class="trainingPopover" id="{{row.program.id}}" href="javascript:void(0);" data-toggle="popover" title="Program Trainings" data-content= "{{trainingListView()}}">View</a>
                        {% else %}
                            <i class="bi bi-x-lg"></i> &nbsp&nbsp
-                           <a class="trainingPopover" id="{{row.program.id}}" href="#!" data-toggle="popover" title="Program Trainings" data-content= "{{trainingListView()}}">View</a>
+                           <a class="trainingPopover" id="{{row.program.id}}" href="javascript:void(0);" data-toggle="popover" title="Program Trainings" data-content= "{{trainingListView()}}">View</a>
                        {% endif %}
                    </td>
                  {% if g.current_user.isCeltsAdmin or g.current_user.isCeltsStudentStaff %}


### PR DESCRIPTION
**Issue:** When clicking on the **View** button, it takes the user to the top of the page.
**Solution:** In href for the **View** button, I prevented the default behavior of the link so that it doesn't go to the top of the page and it doesn't refresh the page  and it doesn't change the link's behavior.
**Testing:** Tested by clinking on the **View** button in the Eligibility table. It does not take the user to the top of the page anymore. Also, when expressing interest in one of the events, the functionality of the "View" button doesn't break anything.
Issue #695 