### PR TITLE
 Saves the admin logs for background checks in accordance with the new status 

### DIFF
--- a/app/logic/volunteers.py
+++ b/app/logic/volunteers.py
@@ -92,10 +92,12 @@ def addUserBackgroundCheck(user, bgType, bgStatus, dateCompleted):
         if not dateCompleted:
             dateCompleted = None
         update = BackgroundCheck.create(user=user, type=bgType, backgroundCheckStatus=bgStatus, dateCompleted=dateCompleted)
-        if bool(bgStatus):
+        if bgStatus == 'Submitted':
+            createLog(f"Marked {user.firstName} {user.lastName}'s background check for {bgType} as submitted.")
+        elif bgStatus == 'Passed':
             createLog(f"Marked {user.firstName} {user.lastName}'s background check for {bgType} as passed.")
         else:
-            createLog(f"Marked {user.firstName} {user.lastName}'s background check for {bgType} as not passed.")
+            createLog(f"Marked {user.firstName} {user.lastName}'s background check for {bgType} as failed.")
 
 
 def setProgramManager(username, program_id, action):

--- a/app/static/js/userProfile.js
+++ b/app/static/js/userProfile.js
@@ -88,7 +88,7 @@ $(document).ready(function(){
     let bgStatus = $("[data-id=" + bgCheckType + "]").val()
 
     if (bgStatus == '' && bgDate != '') {
-        displayMessage("Passed<br>Empty!", "danger")
+        displayMessage("Status<br>Empty!", "danger")
         return
     }
     if (bgStatus != '' && bgDate == '' ) {


### PR DESCRIPTION
Solves issue #686 

Changes made: Refactored the code so that the admin logs for background checks save correctly in correspondence with the new statuses: submitted, passed and failed.