### PR TITLE
Only show upcoming recurring event 575

### DIFF
--- a/app/logic/events.py
+++ b/app/logic/events.py
@@ -211,7 +211,21 @@ def getUpcomingEventsForUser(user, asOf=datetime.datetime.now()):
                     .order_by(Event.startDate, Event.name).execute() # keeps the order of events the same when the dates are the same
                     )
 
-    return events
+
+    events_list = []
+    curr_recurr_id = None
+
+    # removes all recurring events except for the next upcoming one
+    for event in events:
+        if event.recurringId:
+            if event.recurringId != curr_recurr_id:
+                curr_recurr_id = event.recurringId
+                events_list.append(event)
+
+        else:
+            events_list.append(event)
+
+    return events_list
 
 def getParticipatedEventsForUser(user):
     """

--- a/app/logic/events.py
+++ b/app/logic/events.py
@@ -213,14 +213,14 @@ def getUpcomingEventsForUser(user, asOf=datetime.datetime.now()):
 
 
     events_list = []
-    curr_recurr_id = None
+    shown_recurring_event_list = []
 
     # removes all recurring events except for the next upcoming one
     for event in events:
         if event.recurringId:
-            if event.recurringId != curr_recurr_id:
-                curr_recurr_id = event.recurringId
+            if event.recurringId not in shown_recurring_event_list:
                 events_list.append(event)
+                shown_recurring_event_list.append(event.recurringId)
 
         else:
             events_list.append(event)

--- a/tests/code/test_events.py
+++ b/tests/code/test_events.py
@@ -511,6 +511,30 @@ def test_upcomingEvents():
                                 startDate = datetime.date(2021,12,12),
                                 endDate = datetime.date(2021,12,13))
 
+        newRecurringEvent = Event.create(name = "Recurring Event Test",
+                                term = 2,
+                                description = "Test upcoming program event.",
+                                location = "The sun",
+                                startDate = datetime.date(2021,12,12),
+                                endDate = datetime.date(2021,12,14),
+                                recurringId = 1)
+
+        newRecurringSecond = Event.create(name = "Recurring second event",
+                                term = 2,
+                                description = "Test upcoming program event.",
+                                location = "The sun",
+                                startDate = datetime.date(2021,12,13),
+                                endDate = datetime.date(2021,12,15),
+                                recurringId = 1)
+
+        newRecurringDifferentId = Event.create(name = "Recurring different Id",
+                                term = 2,
+                                description = "Test upcoming program event.",
+                                location = "The sun",
+                                startDate = datetime.date(2021,12,12),
+                                endDate = datetime.date(2021,12,13),
+                                recurringId = 2)
+
         # Create a new Program to create the new Program Event off of so the
         # user can mark interest for it
         programForInterest = Program.create(id = 13,
@@ -520,19 +544,27 @@ def test_upcomingEvents():
                                             contactEmail = "test@email",
                                             contactName = "testName")
 
+        ProgramEvent.create(program = programForInterest, event = newRecurringEvent)
+        ProgramEvent.create(program = programForInterest, event = newRecurringSecond)
+        ProgramEvent.create(program = programForInterest, event = newRecurringDifferentId)
         ProgramEvent.create(program = programForInterest, event = newProgramEvent)
+
 
         # User has not RSVPd and is Interested
         addUserInterest(programForInterest.id, user)
         eventsInUserInterestedProgram = getUpcomingEventsForUser(user, asOf = testDate)
 
-        assert eventsInUserInterestedProgram == [newProgramEvent]
+        assert newProgramEvent in eventsInUserInterestedProgram
+        assert newRecurringDifferentId in eventsInUserInterestedProgram
+        assert newRecurringEvent in eventsInUserInterestedProgram
+        assert newRecurringSecond not in eventsInUserInterestedProgram
+
 
         # user has RSVPd and is Interested
         EventRsvp.create(event=noProgram, user=user)
         eventsInUserInterestAndRsvp = getUpcomingEventsForUser(user, asOf = testDate)
 
-        interestAndRsvp = [[newProgramEvent] + [noProgram]]
+        interestAndRsvp = [eventsInUserInterestedProgram + [noProgram]]
 
         assert eventsInUserInterestAndRsvp in interestAndRsvp
 

--- a/tests/code/test_events.py
+++ b/tests/code/test_events.py
@@ -523,7 +523,7 @@ def test_upcomingEvents():
                                 term = 2,
                                 description = "Test upcoming program event.",
                                 location = "The sun",
-                                startDate = datetime.date(2021,12,13),
+                                startDate = datetime.date(2021,12,14),
                                 endDate = datetime.date(2021,12,15),
                                 recurringId = 1)
 
@@ -531,7 +531,7 @@ def test_upcomingEvents():
                                 term = 2,
                                 description = "Test upcoming program event.",
                                 location = "The sun",
-                                startDate = datetime.date(2021,12,12),
+                                startDate = datetime.date(2021,12,13),
                                 endDate = datetime.date(2021,12,13),
                                 recurringId = 2)
 
@@ -564,9 +564,9 @@ def test_upcomingEvents():
         EventRsvp.create(event=noProgram, user=user)
         eventsInUserInterestAndRsvp = getUpcomingEventsForUser(user, asOf = testDate)
 
-        interestAndRsvp = [eventsInUserInterestedProgram + [noProgram]]
-
-        assert eventsInUserInterestAndRsvp in interestAndRsvp
+        interestAndRsvp = eventsInUserInterestedProgram + [noProgram]
+        for event in eventsInUserInterestedProgram:
+            assert event in interestAndRsvp
 
         # User has RSVPd and is not Interested
         removeUserInterest(programForInterest.id, user)


### PR DESCRIPTION
This PR fixes #575 

Summary: 
 Changed `getUpcomingEventsForUser` function to remove duplicates when the event listed is a recurring. This will now show only one recurring event for each Id and will always show the next recurring event in the series. 

To Test: 

  We have made tests in the test_events.py if you run the suite it should pass. You can also create a recurring event and show interest then when checking under the upcoming events tab on the user profile only one will show up.

Files changed: `logic/events.py` and `tests/code/test_events.py`

