### PR TITLE
Added rollbacks to tests that did not have them causing them to leave admin logs in the database after the tests had all run

### DIFF
--- a/tests/code/test_serviceLearningCoursesData.py
+++ b/tests/code/test_serviceLearningCoursesData.py
@@ -49,53 +49,58 @@ def test_getServiceLearningCoursesData():
 def test_withdrawProposal():
     '''creates a test course with all foreign key fields. tests if they can
     be deleted'''
-    if 99 in Course.select(Course.id):
-        withdrawProposal(99)
-    course = Course.create(
+    
+    with mainDB.atomic() as transaction:
+
+        if 99 in Course.select(Course.id):
+            withdrawProposal(99)
+        course = Course.create(
+                id= 99,
+                courseName= "Test",
+                term=2,
+                status= 1,
+                courseCredit= "",
+                createdBy= "ramsayb2",
+                isAllSectionsServiceLearning= True,
+                isPermanentlyDesignated= False,
+                )
+        question = CourseQuestion.create(
+            id = 99,
+            course=99,
+            questionContent="Why must I create so much for just one test?",
+            questionNumber=1
+        )
+        note = Note.create(
+            id = 99,
+            createdBy = "neillz",
+            createdOn = "2021-10-12 00:00:00",
+            noteContent = "This is a test note.",
+            isPrivate = False
+        )
+        qnote = QuestionNote.create(
+        id = 99,
+        question = 99,
+        note = 99
+        )
+        instructor = CourseInstructor.create(
             id= 99,
-            courseName= "Test",
-            term=2,
-            status= 1,
-            courseCredit= "",
-            createdBy= "ramsayb2",
-            isAllSectionsServiceLearning= True,
-            isPermanentlyDesignated= False,
-            )
-    question = CourseQuestion.create(
-        id = 99,
-        course=99,
-        questionContent="Why must I create so much for just one test?",
-        questionNumber=1
-    )
-    note = Note.create(
-        id = 99,
-        createdBy = "neillz",
-        createdOn = "2021-10-12 00:00:00",
-        noteContent = "This is a test note.",
-        isPrivate = False
-    )
-    qnote = QuestionNote.create(
-    id = 99,
-    question = 99,
-    note = 99
-    )
-    instructor = CourseInstructor.create(
-        id= 99,
-        course= 99,
-        user= "ramsayb2"
-    )
-    participant = CourseParticipant.create(
-        course= 99,
-        user= "neillz",
-        hoursEarned= 2.0
-    )
+            course= 99,
+            user= "ramsayb2"
+        )
+        participant = CourseParticipant.create(
+            course= 99,
+            user= "neillz",
+            hoursEarned= 2.0
+        )
 
-    with app.test_request_context():
-        g.current_user = "ramsayb2"
-        withdrawProposal(99)
+        with app.test_request_context():
+            g.current_user = "ramsayb2"
+            withdrawProposal(99)
 
-    with pytest.raises(DoesNotExist):
-        Course.get_by_id(99)
+        with pytest.raises(DoesNotExist):
+            Course.get_by_id(99)
+
+        transaction.rollback()
 
 @pytest.mark.integration
 def test_renewProposal():
@@ -120,7 +125,7 @@ def test_renewProposal():
             course= 100,
             user= "ramsayb2"
         )
-        
+
         renewProposal(course.id, 4)
 
         # test and make sure a new course with a different id was created

--- a/tests/code/test_userManagement.py
+++ b/tests/code/test_userManagement.py
@@ -11,45 +11,53 @@ from app.models import mainDB
 
 @pytest.mark.integration
 def test_modifyCeltsAdmin():
-    user = "agliullovak"
-    userInTest = User.get(User.username == user)
-    assert userInTest.isCeltsAdmin == False
-    with app.app_context():
-        g.current_user = "ramsayb2"
-        addCeltsAdmin(userInTest)
-        userInTest = User.get(User.username == user)
-        assert userInTest.isCeltsAdmin == True
-        removeCeltsAdmin(userInTest)
+    with mainDB.atomic() as transaction:
+
+        user = "agliullovak"
         userInTest = User.get(User.username == user)
         assert userInTest.isCeltsAdmin == False
+        with app.app_context():
+            g.current_user = "ramsayb2"
+            addCeltsAdmin(userInTest)
+            userInTest = User.get(User.username == user)
+            assert userInTest.isCeltsAdmin == True
+            removeCeltsAdmin(userInTest)
+            userInTest = User.get(User.username == user)
+            assert userInTest.isCeltsAdmin == False
 
-        with pytest.raises(DoesNotExist):
-            addCeltsAdmin("blahbah")
-        with pytest.raises(DoesNotExist):
-            addCeltsAdmin("ksgvoidsid;")
+            with pytest.raises(DoesNotExist):
+                addCeltsAdmin("blahbah")
+            with pytest.raises(DoesNotExist):
+                addCeltsAdmin("ksgvoidsid;")
+
+        transaction.rollback()
 
 @pytest.mark.integration
 def test_modifyCeltsStudentStaff():
-    user = "mupotsal"
-    userInTest = User.get(User.username == user)
-    assert userInTest.isCeltsAdmin == False
-    with app.app_context():
-        g.current_user = "ramsayb2"
-        addCeltsStudentStaff(userInTest)
-    userInTest = User.get(User.username == user)
-    assert userInTest.isCeltsStudentStaff == True
+    with mainDB.atomic() as transaction:
 
-    with app.app_context():
-        g.current_user = "ramsayb2"
-        removeCeltsStudentStaff(userInTest)
-    userInTest = User.get(User.username == user)
-    assert userInTest.isCeltsStudentStaff == False
-    with app.app_context():
-        g.current_user = "ramsayb2"
-        with pytest.raises(DoesNotExist):
-            addCeltsStudentStaff("asdf")
-        with pytest.raises(DoesNotExist):
-            removeCeltsStudentStaff("1234")
+        user = "mupotsal"
+        userInTest = User.get(User.username == user)
+        assert userInTest.isCeltsAdmin == False
+        with app.app_context():
+            g.current_user = "ramsayb2"
+            addCeltsStudentStaff(userInTest)
+        userInTest = User.get(User.username == user)
+        assert userInTest.isCeltsStudentStaff == True
+
+        with app.app_context():
+            g.current_user = "ramsayb2"
+            removeCeltsStudentStaff(userInTest)
+        userInTest = User.get(User.username == user)
+        assert userInTest.isCeltsStudentStaff == False
+        with app.app_context():
+            g.current_user = "ramsayb2"
+            with pytest.raises(DoesNotExist):
+                addCeltsStudentStaff("asdf")
+            with pytest.raises(DoesNotExist):
+                removeCeltsStudentStaff("1234")
+
+        transaction.rollback()
 
 @pytest.mark.integration
 def test_changeProgramInfo():


### PR DESCRIPTION
Fixes issue #724 

Issue: There were a few Admin Logs being left in the database after all the tests had been run meaning that we were not cleaning up after all of the tests properly. 

Fix: Added transaction rollbacks to the tests that did not have them and were not cleaning up after themselves. 

_____________________________________________________
To test:
1. On the development branch, with a freshly reset database, flask run and look at the Admin Logs we have in there that are a part of base data.
2. Stop flask run the tests wit tests/run_tests.sh, don't use monitor.sh since you will not be rerunning the tests.
3. Flask run again and look at the new Admin Logs that were not there before the tests were run.
4. Checkout the clean-up-tests branch and reset the database again. 
5. Run the tests again while on the clean-up-tests branch.
6. Flask run and see that the Admin Log no longer has the leftover logs from the tests.