### PR TITLE
Firefox kiosk error

### DIFF
--- a/app/controllers/events/routes.py
+++ b/app/controllers/events/routes.py
@@ -48,6 +48,9 @@ def signinEvent():
     bnumber = request.form["bNumber"]
     programid = ProgramEvent.select(ProgramEvent.program).where(ProgramEvent.event == eventid)
 
+    if not bnumber: # Avoids string index out of range error
+        return "", 500
+
     if bnumber[0]==";" and bnumber[-1]=="?": # scanned bNumber starts with ";" and ends with "?"
         bnumber = "B"+ bnumber[1:9]
     else:


### PR DESCRIPTION
Fixes #753 

I believe I replicated their issue. If you use the kiosk a little too fast, it throws a string index out of range error in the routes file. I suspect it tried to index an empty bnumber string. After adding a check for the bnumber to not be empty, I haven't been able to replicate the problem. 

To test:

Spam the heck out of the kiosk by any means and see if it stops working/throwing failure flashers no matter what. 