### PR TITLE
Recurring end date

### DIFF
--- a/app/templates/admin/createEvent.html
+++ b/app/templates/admin/createEvent.html
@@ -96,9 +96,9 @@
             </div>
             <div class="form-group col-md-6 d-none" id ="endDateStyle">
             <!--datePicker for End date-->
-                <label class="form-label" for="endDatePicker"><strong>End Date</strong></label>
+                <label class="form-label me-2" for="endDatePicker"><strong>End Date</strong></label>
                 <div class='input-group date' id="endDate">
-                  <input autocomplete="off" type='text' class="form-control datePicker readonly" id='endDatePicker' value="{{eventData.endDate.strftime('%m-%d-%Y') if eventData.endDate and eventData.endDate.strftime else eventData.endDate}}" name="endDate" placeholder="Pick an end date" {{"readonly" if not isEditable}}>
+                  <input autocomplete="off" type='text' class="form-control datePicker" id='endDatePicker' value="{{eventData.endDate.strftime('%m-%d-%Y') if eventData.endDate and eventData.endDate.strftime else eventData.endDate}}" name="endDate" placeholder="Pick an end date">
                   <div class="input-group-text" id="calendarIconEnd">
                     <span><i class="bi bi-calendar-plus-fill"></i></span>
                   </div>


### PR DESCRIPTION
Gaston and I accidentally branched off another branch instead of development. Here's the new PR with the old comment verbatim. 

Fixes #723 

Fix: Removed the readonly of the input to match the start date and end date.

To test:
Go the URL: IP_Address/eventTemplates/1/1/create. Click on "This is a recurring event slider." End Date automatically shows up with the matching UI look as Start Date as white. Not grayed out.