### PR TITLE
Allow events to be created on past days

### DIFF
--- a/app/logic/events.py
+++ b/app/logic/events.py
@@ -286,7 +286,7 @@ def validateNewEventData(data):
 
     # Validation if we are inserting a new event
     if 'id' not in data:
-        
+
         event = Event.select().where((Event.name == data['name']) &
                                      (Event.location == data['location']) &
                                      (Event.startDate == data['startDate']) &

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -56,13 +56,11 @@ $(document).ready(function() {
   $("#allowPastStart").click(function() {
     var bloo = $("#allowPastStart:checked").val()
     if (bloo == 'on') {
-      // can time travel into the past
       $.datepicker.setDefaults({
         minDate:  new Date('1999/10/25'),
         dateFormat:'mm-dd-yy'
       });
     } else {
-      // can't time travel
       $.datepicker.setDefaults({
         minDate:  new Date($.now()),
         dateFormat:'mm-dd-yy'

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -54,8 +54,8 @@ $(document).ready(function() {
     }
   });
   $("#allowPastStart").click(function() {
-    var bloo = $("#allowPastStart:checked").val()
-    if (bloo == 'on') {
+    var allowPast = $("#allowPastStart:checked").val()
+    if (allowPast == 'on') {
       $.datepicker.setDefaults({
         minDate:  new Date('1999/10/25'),
         dateFormat:'mm-dd-yy'

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -63,6 +63,10 @@ $(document).ready(function() {
       });
     } else {
       // can't time travel
+      $.datepicker.setDefaults({
+        minDate:  new Date($.now()),
+        dateFormat:'mm-dd-yy'
+      });
     }
   });
   // everything except Chrome

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -53,6 +53,18 @@ $(document).ready(function() {
       $("#endDatePicker").prop('required', false);
     }
   });
+  $("#allowPastStart").click(function() {
+    var bloo = $("#allowPastStart:checked").val()
+    if (bloo == 'on') {
+      // can time travel into the past
+      $.datepicker.setDefaults({
+        minDate:  new Date('1999/10/25'),
+        dateFormat:'mm-dd-yy'
+      });
+    } else {
+      // can't time travel
+    }
+  });
   // everything except Chrome
   if (navigator.userAgent.indexOf("Chrome") == -1) {
     $('input.timepicker').timepicker({

--- a/app/templates/admin/createEvent.html
+++ b/app/templates/admin/createEvent.html
@@ -83,6 +83,10 @@
           <input class="form-check-input" type="checkbox" id="checkIsRecurring" name="isRecurring"/>
         </div>
         {% endif %}
+        <div class="form-check form-switch pb-1">
+          <label class="custom-control-label" for='allowPastStart'><strong>Time travel to the past.</strong></label>
+          <input class="form-check-input" type="checkbox" id="allowPastStart"/>
+        </div>
         <!-- Start and End Datepickers -->
         <div class="row col-md-12">
             <div class="form-group col-md-6">

--- a/app/templates/admin/createEvent.html
+++ b/app/templates/admin/createEvent.html
@@ -77,15 +77,21 @@
           <label class="form-label" for='inputEventLocation'><strong>Location</strong></label>
           <input class="form-control" id='inputEventLocation' value="{{eventData.location}}" placeholder="Enter location" name="location" required>
         </div>
-        {% if isNewEvent and template.tag != 'all-volunteer' %}
-        <div class="form-check form-switch pb-1">
-          <label class="custom-control-label" for='checkIsRecurring'><strong>This is a recurring event.</strong></label>
-          <input class="form-check-input" type="checkbox" id="checkIsRecurring" name="isRecurring"/>
-        </div>
-        {% endif %}
-        <div class="form-check form-switch pb-1">
-          <label class="custom-control-label" for='allowPastStart'><strong>Time travel to the past.</strong></label>
-          <input class="form-check-input" type="checkbox" id="allowPastStart"/>
+        <div class="row col-md-12">
+          <div class="form-group col-md-6">
+            <div class="form-check form-switch pb-1">
+              <label class="custom-control-label" for='allowPastStart'><strong>Time travel to the past.</strong></label>
+              <input class="form-check-input" type="checkbox" id="allowPastStart"/>
+            </div>
+          </div>
+          <div class="form-group col-md-6">
+            {% if isNewEvent and template.tag != 'all-volunteer' %}
+            <div class="form-check form-switch pb-1">
+              <label class="custom-control-label" for='checkIsRecurring'><strong>This is a recurring event.</strong></label>
+              <input class="form-check-input" type="checkbox" id="checkIsRecurring" name="isRecurring"/>
+            </div>
+            {% endif %}
+          </div>
         </div>
         <!-- Start and End Datepickers -->
         <div class="row col-md-12">

--- a/app/templates/admin/createEvent.html
+++ b/app/templates/admin/createEvent.html
@@ -77,6 +77,7 @@
           <label class="form-label" for='inputEventLocation'><strong>Location</strong></label>
           <input class="form-control" id='inputEventLocation' value="{{eventData.location}}" placeholder="Enter location" name="location" required>
         </div>
+        {% if isNewEvent %}
         <div class="row col-md-12">
           <div class="form-group col-md-6">
             <div class="form-check form-switch pb-1">
@@ -85,7 +86,7 @@
             </div>
           </div>
           <div class="form-group col-md-6">
-            {% if isNewEvent and template.tag != 'all-volunteer' %}
+            {% if template.tag != 'all-volunteer' %}
             <div class="form-check form-switch pb-1">
               <label class="custom-control-label" for='checkIsRecurring'><strong>This is a recurring event.</strong></label>
               <input class="form-check-input" type="checkbox" id="checkIsRecurring" name="isRecurring"/>
@@ -93,6 +94,7 @@
             {% endif %}
           </div>
         </div>
+        {% endif %}
         <!-- Start and End Datepickers -->
         <div class="row col-md-12">
             <div class="form-group col-md-6">

--- a/app/templates/admin/createEvent.html
+++ b/app/templates/admin/createEvent.html
@@ -80,7 +80,7 @@
         <div class="row col-md-12">
           <div class="form-group col-md-6">
             <div class="form-check form-switch pb-1">
-              <label class="custom-control-label" for='allowPastStart'><strong>Time travel to the past.</strong></label>
+              <label class="custom-control-label" for='allowPastStart'><strong>Allow start date to be in the past.</strong></label>
               <input class="form-check-input" type="checkbox" id="allowPastStart"/>
             </div>
           </div>


### PR DESCRIPTION
Added a new option on the Create Event page: Allow start date to be in the past. When checked it will allow the user to create an event before the current day (in the past).