### PR TITLE
Banned permissions

### DIFF
--- a/app/logic/events.py
+++ b/app/logic/events.py
@@ -251,10 +251,11 @@ def getUpcomingEventsForUser(user, asOf=datetime.datetime.now()):
                        .join(EventRsvp, JOIN.LEFT_OUTER, on=(Event.id == EventRsvp.event))
                        .where(Event.startDate >= asOf,
                               (Interest.user == user) | (EventRsvp.user == user),
-                              ProgramBan.user.is_null(True) | (ProgramBan.endDate.is_null(False) & (ProgramBan.endDate < asOf)))
+                              ProgramBan.user.is_null(True) | (ProgramBan.endDate < asOf))
                        .distinct() # necessary because of multiple programs
                        .order_by(Event.startDate, Event.name)
                      )
+
     events_list = []
     shown_recurring_event_list = []
 

--- a/app/logic/events.py
+++ b/app/logic/events.py
@@ -274,7 +274,12 @@ def getUpcomingEventsForUser(user, asOf=datetime.datetime.now()):
 
 def getBannedEventsForUser(user, asOf=datetime.datetime.now()):
     """
-        Get all of the events a user is banned from.
+        Returns a list of events that a user is banned of as of whatever
+        the current day is.
+        :param user: a username or User object
+        :param asOf: The date to use when determining future and past events.
+                      Used in testing, defaults to the current timestamp.
+        :return: A list of Event objects
     """
     bannedEvents = list(Event.select()
                              .join(ProgramEvent)

--- a/app/logic/events.py
+++ b/app/logic/events.py
@@ -254,15 +254,6 @@ def getUpcomingEventsForUser(user, asOf=datetime.datetime.now()):
                     .order_by(Event.startDate, Event.name).execute() # keeps the order of events the same when the dates are the same
                     )
 
-    bannedEvents = list(Event.select()
-                             .join(ProgramEvent)
-                             .join(Program)
-                             .join(ProgramBan)
-                             .where(ProgramEvent.program_id == ProgramBan.program_id,
-                                    ProgramBan.user == user,
-                                    ProgramBan.unbanNote == None,
-                                    Event.startDate >= asOf))
-
     events_list = []
     shown_recurring_event_list = []
 
@@ -276,10 +267,25 @@ def getUpcomingEventsForUser(user, asOf=datetime.datetime.now()):
         else:
             events_list.append(event)
 
-    # Remove all events the user is banned from from their upcoming events
-    events_list = [event for event in events_list if event not in bannedEvents]
+    banned_events_list = getBannedEventsForUser(user, asOf)
+    events_list = [event for event in events_list if event not in banned_events_list]
 
     return events_list
+
+def getBannedEventsForUser(user, asOf=datetime.datetime.now()):
+    """
+        Get all of the events a user is banned from.
+    """
+    bannedEvents = list(Event.select()
+                             .join(ProgramEvent)
+                             .join(Program)
+                             .join(ProgramBan)
+                             .where(ProgramEvent.program_id == ProgramBan.program_id,
+                                    ProgramBan.user == user,
+                                    ProgramBan.unbanNote == None,
+                                    Event.startDate >= asOf))
+
+    return bannedEvents
 
 def getParticipatedEventsForUser(user):
     """

--- a/tests/code/test_events.py
+++ b/tests/code/test_events.py
@@ -20,7 +20,7 @@ from app.models.note import Note
 from app.logic.events import *
 from app.logic.volunteers import addVolunteerToEventRsvp, updateEventParticipants
 from app.logic.participants import addPersonToEvent
-from app.logic.users import addUserInterest, removeUserInterest, banUser, unbanUser
+from app.logic.users import addUserInterest, removeUserInterest, banUser
 
 @pytest.mark.integration
 def test_event_model():
@@ -534,11 +534,11 @@ def test_upcomingEvents():
         # Create a Program Event to show up when the user marks interest in a
         # new program
         newProgramEvent = Event.create(name = "Upcoming event with program",
-                                      term = 2,
-                                      description = "Test upcoming program event.",
-                                      location = "The sun",
-                                      startDate = testDate,
-                                      endDate = testDate + timedelta(days=1))
+                                       term = 2,
+                                       description = "Test upcoming program event.",
+                                       location = "The sun",
+                                       startDate = testDate,
+                                       endDate = testDate + timedelta(days=1))
 
         newBannedProgramEvent = Event.create(name = "Upcoming event with banned program",
                                              term = 2,
@@ -556,12 +556,12 @@ def test_upcomingEvents():
                                          recurringId = 1)
 
         newRecurringSecond = Event.create(name = "Recurring second event",
-                                         term = 2,
-                                         description = "Test upcoming program event.",
-                                         location = "The sun",
-                                         startDate = datetime.date(2021,12,14),
-                                         endDate = datetime.date(2021,12,15),
-                                         recurringId = 1)
+                                          term = 2,
+                                          description = "Test upcoming program event.",
+                                          location = "The sun",
+                                          startDate = datetime.date(2021,12,14),
+                                          endDate = datetime.date(2021,12,15),
+                                          recurringId = 1)
 
         newRecurringDifferentId = Event.create(name = "Recurring different Id",
                                                term = 2,
@@ -595,7 +595,7 @@ def test_upcomingEvents():
         # User has not RSVPd and is Interested
         addUserInterest(programForInterest.id, user)
         addUserInterest(programForBanning.id, user)
-        eventsInUserInterestedProgram = getUpcomingEventsForUser(user, testDate)
+        eventsInUserInterestedProgram = getUpcomingEventsForUser(user, asOf = testDate)
 
         assert newProgramEvent in eventsInUserInterestedProgram
         assert newRecurringDifferentId in eventsInUserInterestedProgram
@@ -605,7 +605,7 @@ def test_upcomingEvents():
         # Programs the user is banned from do not have their events showing up in
         # their upcoming events
         banUser(programForBanning.id, user.username, "Test banned program", testDate, "ramsayb2")
-        eventsUserNotBannedFrom = getUpcomingEventsForUser(user, testDate)
+        eventsUserNotBannedFrom = getUpcomingEventsForUser(user, asOf = testDate)
         assert newBannedProgramEvent in eventsInUserInterestedProgram
         assert newBannedProgramEvent not in eventsUserNotBannedFrom
 
@@ -620,11 +620,11 @@ def test_upcomingEvents():
                    .where(ProgramBan.program == programForBanning.id,
                           ProgramBan.user == user.username).execute())
 
-        assert newBannedProgramEvent in getUpcomingEventsForUser(user, testDate)
+        assert newBannedProgramEvent in getUpcomingEventsForUser(user, asOf = testDate)
 
         # user has RSVPd and is Interested
         EventRsvp.create(event=noProgram, user=user)
-        eventsInUserInterestAndRsvp = getUpcomingEventsForUser(user, testDate)
+        eventsInUserInterestAndRsvp = getUpcomingEventsForUser(user, asOf = testDate)
 
         interestAndRsvp = eventsInUserInterestedProgram + [noProgram]
         for event in eventsInUserInterestedProgram:

--- a/tests/code/test_events.py
+++ b/tests/code/test_events.py
@@ -632,37 +632,52 @@ def test_upcomingEvents():
 def test_bannedEventsForUser():
     with mainDB.atomic() as transaction:
         testDate = datetime.datetime.strptime("2021-08-01 05:00","%Y-%m-%d %H:%M")
-        # Create a test User to ban/unban from events
+        # Create a test User
         testUser = User.create(username = 'usrtst',
                                firstName = 'Test',
                                lastName = 'User',
                                bnumber = '03522492',
                                email = 'usert@berea.deu',
                                isStudent = True)
-
+        # Create program event the test user will be banned from
         newProgramEvent = Event.create(name = "Ban testUser from this program event",
                                        term = 2,
-                                       description = "Test upcoming program event.",
+                                       description = "Test banned event.",
                                        location = "The sun",
                                        startDate = datetime.date(2021,12,13),
-                                       endDate = datetime.date(2021,12,13),
-                                       recurringId = 2)
-
-
+                                       endDate = datetime.date(2021,12,13))
+        # Create a program event the test user will not be banned from
+        notBannedEvent = Event.create(name = "Program event test user will not be banned from",
+                                       term = 2,
+                                       description = "Test not banned event.",
+                                       location = "The moon",
+                                       startDate = datetime.date(2021,12,14),
+                                       endDate = datetime.date(2021,12,14))
+        # Create test program the test user will be banned from
         newProgram = Program.create(id = 13,
                                     programName = "testUser is Banned from this program",
                                     isStudentLed = False,
                                     isBonnerScholars = False,
                                     contactEmail = "test@email",
                                     contactName = "testName")
+        # Create test program the test user will not be banned from
+        notBannedProgram = Program.create(id = 14,
+                                          programName = "testUser is Banned from this program",
+                                          isStudentLed = False,
+                                          isBonnerScholars = False,
+                                          contactEmail = "test@email",
+                                          contactName = "testName")
 
         ProgramEvent.create(program = newProgram, event = newProgramEvent)
+        ProgramEvent.create(program = notBannedProgram, event =  notBannedEvent)
         addUserInterest(newProgram.id, testUser)
+        addUserInterest(notBannedProgram.id, testUser)
 
         bannedEvents = getBannedEventsForUser(testUser, asOf = testDate)
         upcomingEvents = getUpcomingEventsForUser(testUser, asOf = testDate)
         assert bannedEvents == []
         assert newProgramEvent in upcomingEvents
+        assert notBannedEvent in upcomingEvents
 
         banUser(newProgram.id, testUser.username, "test Banned Event", "2022-11-29", "ramsayb2")
         bannedEvents = getBannedEventsForUser(testUser, asOf = testDate)
@@ -670,6 +685,7 @@ def test_bannedEventsForUser():
         assert bannedEvents != []
         assert newProgramEvent in bannedEvents
         assert newProgramEvent not in upcomingEvents
+        assert notBannedEvent in upcomingEvents
 
         transaction.rollback()
 

--- a/tests/code/test_events.py
+++ b/tests/code/test_events.py
@@ -546,28 +546,28 @@ def test_upcomingEvents():
                                              endDate = datetime.date(2021,12,13))
 
         newRecurringEvent = Event.create(name = "Recurring Event Test",
-                                term = 2,
-                                description = "Test upcoming program event.",
-                                location = "The sun",
-                                startDate = datetime.date(2021,12,12),
-                                endDate = datetime.date(2021,12,14),
-                                recurringId = 1)
+                                         term = 2,
+                                         description = "Test upcoming program event.",
+                                         location = "The sun",
+                                         startDate = datetime.date(2021,12,12),
+                                         endDate = datetime.date(2021,12,14),
+                                         recurringId = 1)
 
         newRecurringSecond = Event.create(name = "Recurring second event",
-                                term = 2,
-                                description = "Test upcoming program event.",
-                                location = "The sun",
-                                startDate = datetime.date(2021,12,14),
-                                endDate = datetime.date(2021,12,15),
-                                recurringId = 1)
+                                         term = 2,
+                                         description = "Test upcoming program event.",
+                                         location = "The sun",
+                                         startDate = datetime.date(2021,12,14),
+                                         endDate = datetime.date(2021,12,15),
+                                         recurringId = 1)
 
         newRecurringDifferentId = Event.create(name = "Recurring different Id",
-                                term = 2,
-                                description = "Test upcoming program event.",
-                                location = "The sun",
-                                startDate = datetime.date(2021,12,13),
-                                endDate = datetime.date(2021,12,13),
-                                recurringId = 2)
+                                               term = 2,
+                                               description = "Test upcoming program event.",
+                                               location = "The sun",
+                                               startDate = datetime.date(2021,12,13),
+                                               endDate = datetime.date(2021,12,13),
+                                               recurringId = 2)
 
         # Create a new Program to create the new Program Event off of so the
         # user can mark interest for it
@@ -626,7 +626,50 @@ def test_upcomingEvents():
         eventsInUserRsvp = getUpcomingEventsForUser(user, asOf = testDate)
         assert eventsInUserRsvp == [noProgram]
 
+        transaction.rollback()
 
+@pytest.mark.integration
+def test_bannedEventsForUser():
+    with mainDB.atomic() as transaction:
+        testDate = datetime.datetime.strptime("2021-08-01 05:00","%Y-%m-%d %H:%M")
+        # Create a test User to ban/unban from events
+        testUser = User.create(username = 'usrtst',
+                               firstName = 'Test',
+                               lastName = 'User',
+                               bnumber = '03522492',
+                               email = 'usert@berea.deu',
+                               isStudent = True)
+
+        newProgramEvent = Event.create(name = "Ban testUser from this program event",
+                                       term = 2,
+                                       description = "Test upcoming program event.",
+                                       location = "The sun",
+                                       startDate = datetime.date(2021,12,13),
+                                       endDate = datetime.date(2021,12,13),
+                                       recurringId = 2)
+
+
+        newProgram = Program.create(id = 13,
+                                    programName = "testUser is Banned from this program",
+                                    isStudentLed = False,
+                                    isBonnerScholars = False,
+                                    contactEmail = "test@email",
+                                    contactName = "testName")
+
+        ProgramEvent.create(program = newProgram, event = newProgramEvent)
+        addUserInterest(newProgram.id, testUser)
+
+        bannedEvents = getBannedEventsForUser(testUser, asOf = testDate)
+        upcomingEvents = getUpcomingEventsForUser(testUser, asOf = testDate)
+        assert bannedEvents == []
+        assert newProgramEvent in upcomingEvents
+
+        banUser(newProgram.id, testUser.username, "test Banned Event", "2022-11-29", "ramsayb2")
+        bannedEvents = getBannedEventsForUser(testUser, asOf = testDate)
+        upcomingEvents = getUpcomingEventsForUser(testUser, asOf = testDate)
+        assert bannedEvents != []
+        assert newProgramEvent in bannedEvents
+        assert newProgramEvent not in upcomingEvents
 
         transaction.rollback()
 

--- a/tests/code/test_events.py
+++ b/tests/code/test_events.py
@@ -611,14 +611,14 @@ def test_upcomingEvents():
 
         # Programs the user has been unbanned from do have their events showing up
         # in their upcoming events
-        noteForUnban = (Note.create(createdBy = "ramsayb2",
-                                    createdOn = dayBeforeTestDate,
-                                    noteContent = "The test user is unbanned.",
-                                    isPrivate = 0))
+        noteForUnban = Note.create(createdBy = "ramsayb2",
+                                   createdOn = dayBeforeTestDate,
+                                   noteContent = "The test user is unbanned.",
+                                   isPrivate = 0)
         (ProgramBan.update(endDate = dayBeforeTestDate,
                            unbanNote = noteForUnban)
                    .where(ProgramBan.program == programForBanning.id,
-                          ProgramBan.user == user.username))
+                          ProgramBan.user == user.username).execute())
 
         assert newBannedProgramEvent in getUpcomingEventsForUser(user, testDate)
 


### PR DESCRIPTION
Issue: If a user is banned from a program do not show events from that program in their Upcoming Events on their User Profile. 

Did: Added the bannedEvents query to getUpcomingEventsForUser. Compared the list that is gotten from the new query to events_list and removed all events from events_list that also appeared in the bannedEvents list. Added the new test cases to the upcoming events test.

To test:
- Run the test suite.
- Create events under different programs that will happen within the day, then, go look at the user profile.
- Mark an interest in the programs you created events in and make sure they appear in the upcoming events section.
- Ban the person you are looking at from the programs you have created events under and make sure those events no longer appear in their upcoming events section.
- Unban the person you are looking at and make sure the events return to their upcoming events section.