### PR TITLE
Ban modal reloads to the correct accordion.

### DIFF
--- a/app/static/js/userProfile.js
+++ b/app/static/js/userProfile.js
@@ -78,7 +78,7 @@ $(document).ready(function(){
              "endDate":$("#banEndDatepicker").val() //Expected to be a date in this format YYYY-MM-DD
             },
       success: function(response) {
-        location.reload();
+        reloadWithAccordion("programTable")
       }
     });
   });


### PR DESCRIPTION
There is not github issue attached to this PR*

Issue:
The "Programs" accordion tab is not opened/focused after a user is banned/unbanned.

Did:
Before, after a user was banned from a program, the page would be reloaded with a location.reload() which caused it to reload to and open the "Upcoming Events" tab. I changed it to a reloadWithAccordion() so that after the ban was submitted and the page was reloaded to the "Programs" accordion tab like it should. 

To test:
On any user profile go through the ban/unban process and make sure that after the ban/unban the "Programs" accordion is open. 