### PR TITLE
Fixed file input to allow various file types

### DIFF
--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -38,7 +38,7 @@ function format24to12HourTime(timeStr){
  */
 $(document).ready(function() {
     $("#attachmentObject").fileinput({
-        allowedFileExtensions:["pdf","jpg","png","gif", "csv", "docx"]
+        allowedFileExtensions:["pdf","jpg","png","gif", "csv", "docx", "jpg", "jpeg", "jfif"]
     })
   // Disable button when we are ready to submit
   $("#saveEvent").on('submit',function(event) {

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -37,7 +37,9 @@ function format24to12HourTime(timeStr){
  * Run when the webpage is ready for javascript
  */
 $(document).ready(function() {
-    $("#attachmentObject").fileinput()
+    $("#attachmentObject").fileinput({
+        allowedFileExtensions:["pdf","jpg","png","gif", "csv", "docx"]
+    })
   // Disable button when we are ready to submit
   $("#saveEvent").on('submit',function(event) {
       $(this).find("input[type=submit]").prop("disabled", true)


### PR DESCRIPTION
Issue #786  Added the ability to upload various relevant file types. Maybe we should ask them what types of files they mostly would like to upload.  

To Test:
Navigate to edit or create event and try to upload any file type. 
As of now it should only accept files with these extensions: "pdf","jpg","png","gif", "csv", "docx"