### PR TITLE
Can now create nonProgram events

### DIFF
--- a/app/templates/admin/createEvent.html
+++ b/app/templates/admin/createEvent.html
@@ -158,15 +158,17 @@
         <div class="mb-4">
           <div class="row col-md-12" >
             <div class="form-group">
-            {% if eventData['program'].isBonnerScholars %}
-              <label class="form-label fw-bold" for="requirement">Bonner Requirement</label>
-              <select class="form-select" name="certRequirement">
-                  <option>None</option>
-              {% for req in requirements %}
-                  {% set selected = "selected" if eventData['certRequirement'] == req else "" %}
-                  <option value="{{req.id}}" {{selected}}>{{req.name}}</option>
-              {% endfor %}
-              </select>
+            {% if eventData.get("program", None) %}
+              {% if eventData['program'].isBonnerScholars %}
+                <label class="form-label fw-bold" for="requirement">Bonner Requirement</label>
+                <select class="form-select" name="certRequirement">
+                    <option>None</option>
+                {% for req in requirements %}
+                    {% set selected = "selected" if eventData['certRequirement'] == req else "" %}
+                    <option value="{{req.id}}" {{selected}}>{{req.name}}</option>
+                {% endfor %}
+                </select>
+              {% endif %}
             {% endif %}
             </div>
           </div>

--- a/app/templates/admin/createEvent.html
+++ b/app/templates/admin/createEvent.html
@@ -158,8 +158,7 @@
         <div class="mb-4">
           <div class="row col-md-12" >
             <div class="form-group">
-            {% if eventData.get("program", None) %}
-              {% if eventData['program'].isBonnerScholars %}
+              {% if 'program' in eventData and eventData['program'].isBonnerScholars %}
                 <label class="form-label fw-bold" for="requirement">Bonner Requirement</label>
                 <select class="form-select" name="certRequirement">
                     <option>None</option>
@@ -169,7 +168,6 @@
                 {% endfor %}
                 </select>
               {% endif %}
-            {% endif %}
             </div>
           </div>
         </div>


### PR DESCRIPTION
*There is no Github issue attached to this PR

Issue:
When a user attempted to create a non-program event they were thrown an error from the dict object since it was looking for program in the event data but since there is no program in non-program events the didn't know what to do. 

Did:
Added a new conditional to check whether or not there was a program in the event data. If there was a program then continue on to the existing logic and if there was no program then it would just skip it. 

To test:
- Run the test suite with a freshly reset database and make sure all tests pass (things were only changed in the HTML so the  had better pass) 
- Run the application and make sure that you are able to create non-program events
- With the application running verify that the requirements dropdown appears as it should on the Bonner event creation page but not on any of the other pages. 