### PR TITLE
Add reminder to update dietary restrictions on View Event Page

### DIFF
--- a/app/templates/eventView.html
+++ b/app/templates/eventView.html
@@ -43,7 +43,7 @@
                 <div class="col-md-6">
                     <h3><br>Description</h3><p>{{eventData.description|urlize}}</p><br>
                     {% if eventData.isFoodProvided %}
-                        <p>Food will be provided at this event. <b>Please fill in any dietary restrictions on your "My profile" page.</b></p>
+                        <p>Food will be provided at this event. <a href="/profile/{{g.current_user}}"><b>Please fill in any dietary restrictions on your "My profile" page.</b></a></p>
                     {% endif %}
                     {% if eventData.isService %}
                         <p>This event earns service hours.</p>


### PR DESCRIPTION
This PR resolves issue#811. 

Test: 
Create an event that will provide food. Then view event. 
You should see this: 
<img width="983" alt="HHH" src="https://user-images.githubusercontent.com/59736834/206762965-85e2eba4-cf65-4263-9afa-fdd9199c0557.png">
