### PR TITLE
upgrade flask to 2.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ distlib==0.3.1
 docopt==0.6.2
 dominate==2.6.0
 filelock==3.0.12
-Flask==2.0.1
+Flask==2.2.2
 Flask-Admin==1.5.8
 Flask-Login==0.5.0
 Flask-Mail==0.9.1
@@ -39,7 +39,7 @@ inspecta==0.1.3
 itsdangerous==2.0.1
 Jinja2==3.0.1
 Mako==1.1.4
-MarkupSafe==2.0.1
+MarkupSafe==2.1.1
 more-itertools==8.8.0
 mybad==0.1.4
 ordered-set==4.0.2
@@ -76,6 +76,6 @@ visitor==0.1.3
 watchdog==2.1.2
 wcwidth==0.2.5
 webdriver-manager==3.4.2
-Werkzeug==2.0.1
+Werkzeug==2.2.2
 WTForms==2.3.3
 XlsxWriter==3.0.3


### PR DESCRIPTION
Fix issue #799  upgrade flask to 2.2.2 which depends on werkzeug 2.2.2, and werkzeug 2.2.2 depends on MarkupSafe==2.1. So I upgraded only these three libraries 