### PR TITLE
made area for responses in slc course proposal accept links

### DIFF
--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -100,12 +100,12 @@ function disableInput() {
     $("input").prop("disabled", true);
     $("select").prop("disabled", true);
     $("textarea").prop("disabled", true);
-    $("#one").replaceWith( "<p>" + $( "#one" ).text() + "</p>" );
-    $("#two").replaceWith( "<p>" + $( "#two" ).text() + "</p>" );
-    $("#three").replaceWith( "<p>" + $( "#three" ).text() + "</p>" );
-    $("#four").replaceWith( "<p>" + $( "#four" ).text() + "</p>" );
-    $("#five").replaceWith( "<p>" + $( "#five" ).text() + "</p>" );
-    $("#six").replaceWith( "<p>" + $( "#six" ).text() + "</p>" );
+    $("#one").replaceWith( "<ul>" + $( "#one" ).text() + "</ul>" );
+    $("#two").replaceWith( "<ul>" + $( "#two" ).text() + "</ul>" );
+    $("#three").replaceWith( "<ul>" + $( "#three" ).text() + "</ul>" );
+    $("#four").replaceWith( "<ul>" + $( "#four" ).text() + "</ul>" );
+    $("#five").replaceWith( "<ul>" + $( "#five" ).text() + "</ul>" );
+    $("#six").replaceWith( "<ul>" + $( "#six" ).text() + "</ul>" );
     $(".view").prop("disabled", true);
     $("#submitAndApproveButton").hide();
     $(".editButton").hide()

--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -100,6 +100,12 @@ function disableInput() {
     $("input").prop("disabled", true);
     $("select").prop("disabled", true);
     $("textarea").prop("disabled", true);
+    $("#one").replaceWith( "<p>" + $( "#one" ).text() + "</p>" );
+    $("#two").replaceWith( "<p>" + $( "#two" ).text() + "</p>" );
+    $("#three").replaceWith( "<p>" + $( "#three" ).text() + "</p>" );
+    $("#four").replaceWith( "<p>" + $( "#four" ).text() + "</p>" );
+    $("#five").replaceWith( "<p>" + $( "#five" ).text() + "</p>" );
+    $("#six").replaceWith( "<p>" + $( "#six" ).text() + "</p>" );
     $(".view").prop("disabled", true);
     $("#submitAndApproveButton").hide();
     $(".editButton").hide()

--- a/app/templates/serviceLearning/slcNewProposal.html
+++ b/app/templates/serviceLearning/slcNewProposal.html
@@ -19,7 +19,7 @@
   <div class="tab">
       {% include "serviceLearning/slcProposal.html" %}
   </div>
-  <div class="tab">
+  <div class="tab text-break">
       {% include "serviceLearning/slcQuestionnaire.html" %}
   </div>
   <div class="row align-items-end pt-5 pb-5">

--- a/app/templates/serviceLearning/slcQuestionnaire.html
+++ b/app/templates/serviceLearning/slcQuestionnaire.html
@@ -1,40 +1,39 @@
 {%set title = "SLC Questionnaire"%}
 {% set isViewSlc = 'view' in request.path %}
-{%set isUrl = questionanswers[0]|urlize if questionanswers%}
 
 <h2 class="text-center pt-4">New Service-Learning Course</h2>
   <p class="text-center fw-bold"> Please review the <a class="guidelines" href="#">service-learning course guidelines</a> before completing this form </p>
 <div class="pt-4">
-  <label>
+  <strong>
     1. Indicate the specific course learning objective(s) that will be addressed by the service-learning component.
-  </label>
+  </strong>
   <textarea id="one" class="form-control" aria-label="With textarea" name="1">{{questionanswers[0]|urlize if isViewSlc else questionanswers[0] if questionanswers}}</textarea>
-  <label>
+  <strong>
     2. Describe the method of structured, critical reflection you will use in order to connect the service
     activity or activities to the learning objective(s) of the course.
-  </label>
+  </strong>
   <textarea id="two"class="form-control" aria-label="With textarea" name="2">{{questionanswers[1]|urlize if isViewSlc else questionanswers[1] if questionanswers}}</textarea>
-  <label>
+  <strong>
     3. Describe the service-learning activity or activities. Indicate the approximate number of hours or
     days of service experience. There is no formal requirement, but the activity must be substantial and
     sustained throughout the semester.
-  </label>
+  </strong>
   <textarea id="three" class="form-control" aria-label="With textarea" name="3">{{questionanswers[2]|urlize if isViewSlc else questionanswers[2] if questionanswers}}</textarea>
-  <label>
+  <strong>
     4. Identify the community partner(s) with whom you will collaborate in order to structure this
     service-learning experience.  How will the community partner(s) be involved in planning, implementation,
     and evaluation?
-  </label>
+  </strong>
   <textarea id="four" class="form-control" aria-label="With textarea" name="4">{{questionanswers[3]|urlize if isViewSlc else questionanswers[3] if questionanswers}}</textarea>
-  <label>
+  <strong>
     5. Describe the final product to be completed by the students. How will this benefit the community?
-  </label>
+  </strong>
   <textarea id="five" class="form-control" aria-label="With textarea" name="5">{{questionanswers[4]|urlize if isViewSlc else questionanswers[4] if questionanswers}}</textarea>
-  <label>
+  <strong>
     6. Indicate how you will assess student learning related to the identified course objective(s) that will
     be enhanced by the service-learning experience. Identify what percentage of the final grade will be based
     on the assessment of reflection, the final product, and other forms of assessment related to the identified
     course objective(s).
-  </label>
+  </strong>
   <textarea id="six" class="form-control" aria-label="With textarea" name="6">{{questionanswers[5]|urlize if isViewSlc else questionanswers[5] if questionanswers}}</textarea>
 </div>

--- a/app/templates/serviceLearning/slcQuestionnaire.html
+++ b/app/templates/serviceLearning/slcQuestionnaire.html
@@ -1,37 +1,40 @@
 {%set title = "SLC Questionnaire"%}
+{% set isViewSlc = 'view' in request.path %}
+{%set isUrl = questionanswers[0]|urlize if questionanswers%}
+
 <h2 class="text-center pt-4">New Service-Learning Course</h2>
   <p class="text-center fw-bold"> Please review the <a class="guidelines" href="#">service-learning course guidelines</a> before completing this form </p>
 <div class="pt-4">
   <label>
-    1. Indicate the specific course learning objective(s) that will be addressed by the service-learning component
+    1. Indicate the specific course learning objective(s) that will be addressed by the service-learning component.
   </label>
-  <textarea class="form-control" aria-label="With textarea" name="1">{{questionanswers[0] if questionanswers}}</textarea>
+  <textarea id="one" class="form-control" aria-label="With textarea" name="1">{{questionanswers[0]|urlize if isViewSlc else questionanswers[0] if questionanswers}}</textarea>
   <label>
     2. Describe the method of structured, critical reflection you will use in order to connect the service
     activity or activities to the learning objective(s) of the course.
   </label>
-  <textarea class="form-control" aria-label="With textarea" name="2">{{questionanswers[1] if questionanswers}}</textarea>
+  <textarea id="two"class="form-control" aria-label="With textarea" name="2">{{questionanswers[1]|urlize if isViewSlc else questionanswers[1] if questionanswers}}</textarea>
   <label>
     3. Describe the service-learning activity or activities. Indicate the approximate number of hours or
     days of service experience. There is no formal requirement, but the activity must be substantial and
     sustained throughout the semester.
   </label>
-  <textarea class="form-control" aria-label="With textarea" name="3">{{questionanswers[2] if questionanswers}}</textarea>
+  <textarea id="three" class="form-control" aria-label="With textarea" name="3">{{questionanswers[2]|urlize if isViewSlc else questionanswers[2] if questionanswers}}</textarea>
   <label>
     4. Identify the community partner(s) with whom you will collaborate in order to structure this
     service-learning experience.  How will the community partner(s) be involved in planning, implementation,
     and evaluation?
   </label>
-  <textarea class="form-control" aria-label="With textarea" name="4">{{questionanswers[3] if questionanswers}}</textarea>
+  <textarea id="four" class="form-control" aria-label="With textarea" name="4">{{questionanswers[3]|urlize if isViewSlc else questionanswers[3] if questionanswers}}</textarea>
   <label>
     5. Describe the final product to be completed by the students. How will this benefit the community?
   </label>
-  <textarea class="form-control" aria-label="With textarea" name="5">{{questionanswers[4] if questionanswers}}</textarea>
+  <textarea id="five" class="form-control" aria-label="With textarea" name="5">{{questionanswers[4]|urlize if isViewSlc else questionanswers[4] if questionanswers}}</textarea>
   <label>
     6. Indicate how you will assess student learning related to the identified course objective(s) that will
     be enhanced by the service-learning experience. Identify what percentage of the final grade will be based
     on the assessment of reflection, the final product, and other forms of assessment related to the identified
     course objective(s).
   </label>
-  <textarea class="form-control" aria-label="With textarea" name="6">{{questionanswers[5] if questionanswers}}</textarea>
+  <textarea id="six" class="form-control" aria-label="With textarea" name="6">{{questionanswers[5]|urlize if isViewSlc else questionanswers[5] if questionanswers}}</textarea>
 </div>


### PR DESCRIPTION
#652 

Did:
- Made the textarea in slc proposal responses turn text into links 
- Bolded the questions
- indented the responses

Test:
- Go to course proposal and create a new proposal
- Enter the information and press continue
- When you get to the 6 questions, add a link in the response such as "www.google.com"  and click submit
- Go back to the course proposal page and select "view" on the created proposal, the response should be indented and any links in the text should be linkified.