### PR TITLE
Removed the banned column on the Volunteer Tracker for event

### DIFF
--- a/app/static/js/trackVolunteers.js
+++ b/app/static/js/trackVolunteers.js
@@ -1,6 +1,7 @@
 import searchUser from './searchUser.js'
 
 $(document).ready(function() {
+  $('[data-toggle="tooltip"]').tooltip();
   var iconShowing = false
   var table =  $('#trackVolunteerstable').DataTable({
   "fnDrawCallback": function(oSettings) {
@@ -11,8 +12,6 @@ $(document).ready(function() {
       }
     }
   });
-
-  $('[data-toggle="tooltip"]').tooltip();
 
   // Search functionalities from the volunteer table in the UI
     $("#trackVolunteersInput").on("keyup", function() {
@@ -116,7 +115,7 @@ $(document).ready(function() {
       type: "GET",
       success: function(response){
         if (response.banned){
-          $("#addVolunteerElements"+index).append("<span class='ms-1 text-danger bi bi-x-circle-fill'></span>")
+          $("#addVolunteerElements"+index).append("<a href='#' data-toggle='tooltip' data-placement='top' title='User is banned from this program.'><span class='bi bi-x-circle-fill text-danger'></span></a>")
           if (!iconShowing){
             $("#banned-message").removeAttr("hidden")
             iconShowing = true

--- a/app/static/js/trackVolunteers.js
+++ b/app/static/js/trackVolunteers.js
@@ -116,7 +116,7 @@ $(document).ready(function() {
       type: "GET",
       success: function(response){
         if (response.banned){
-          $("#addVolunteerElements"+index).append("<span class='ms-1 text-danger bi bi-slash-circle-fill'></span>")
+          $("#addVolunteerElements"+index).append("<span class='ms-1 text-danger bi bi-x-circle-fill'></span>")
           if (!iconShowing){
             $("#banned-message").removeAttr("hidden")
             iconShowing = true

--- a/app/templates/events/trackVolunteers.html
+++ b/app/templates/events/trackVolunteers.html
@@ -62,7 +62,6 @@
         <th>Email</th>
         <th>Phone Number</th>
         <th class="noSort">Completed Trainings</th>
-        <th class="noSort">Banned</th>
         {% if event.isPast %}
           <th class="noSort">Total Hours</th>
           <th class="noSort">Attended</th>
@@ -88,6 +87,9 @@
               id="{{participant.user.username}}"
               value="{{participant.user}}" />
               {{participant.user.firstName}} {{participant.user.lastName}}
+              {% if participant.user in bannedUsers %} 
+                <span class="bi bi-x-circle-fill text-danger"></span>
+              {% endif %}
             </td>
             <td>{{participant.user.email}}</td>
             <td>{{participant.user.phoneNumber}}</td>
@@ -96,13 +98,6 @@
                 <span class="bi bi-x-lg" aria-label="Did not complete all trainings."></span>
               {% else %}
                 <span class="bi bi-check-lg" aria-label="Completed all trainings."></span>
-              {% endif %}
-            </td>
-            <td style="text-align:center">
-              {% if participant.user not in bannedUsers %}
-                <span class="bi bi-x-lg" aria-label="Not banned."></span>
-              {% else %}
-                <span class="bi bi-check-lg" aria-label="Banned."></span>
               {% endif %}
             </td>
             {% if event.isPast %}
@@ -173,7 +168,7 @@
         <h5>Selected Volunteers</h5>
         <ul class="list-unstyled" id= "addVolunteerList">
         </ul>
-        <p id="banned-message" hidden><span class="bi bi-slash-circle-fill text-danger"></span> → Banned</p>
+        <p id="banned-message" hidden><span class="bi bi-x-circle-fill text-danger"></span> → Banned</p>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary me-auto" data-bs-dismiss="modal">Close</button>

--- a/app/templates/events/trackVolunteers.html
+++ b/app/templates/events/trackVolunteers.html
@@ -87,8 +87,10 @@
               id="{{participant.user.username}}"
               value="{{participant.user}}" />
               {{participant.user.firstName}} {{participant.user.lastName}}
-              {% if participant.user in bannedUsers %} 
-                <span class="bi bi-x-circle-fill text-danger"></span>
+              {% if participant.user in bannedUsers %}
+                <a href="#" data-toggle="tooltip" data-placement="top" title="User is banned from this program.">
+                  <span class="bi bi-x-circle-fill text-danger"></span>
+                </a>
               {% endif %}
             </td>
             <td>{{participant.user.email}}</td>
@@ -168,7 +170,6 @@
         <h5>Selected Volunteers</h5>
         <ul class="list-unstyled" id= "addVolunteerList">
         </ul>
-        <p id="banned-message" hidden><span class="bi bi-x-circle-fill text-danger"></span> → Banned</p>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary me-auto" data-bs-dismiss="modal">Close</button>


### PR DESCRIPTION
Fixes issue #809 
## Changes
- Removed the banned column
- Substituted the red slash icon with a red x instead
- If a volunteer is banned, put x next to name to indicate ban.