### PR TITLE
Adjusted requirements.txt to work with Python 3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ Flask-Migrate==3.0.0
 Flask-MySQL==1.5.2
 flask-nav==0.6
 Flask-SQLAlchemy==2.5.1
-greenlet==1.1.0
+greenlet==2.0.2
 humanfriendly==9.1
 idna==2.10
 iniconfig==1.1.1
@@ -47,7 +47,7 @@ packaging==20.9
 peewee==3.14.4
 peewee-migrations==0.3.19
 pluggy==0.13.1
-py==1.10.0
+py==1.11.0
 pycparser==2.20
 Pygments==2.9.0
 PyMySQL==1.0.2


### PR DESCRIPTION
Updated the greenlet version to 2.0.2 and py to 1.11.0 to allow tests to be run and `source setup.py` to successfully execute.