### PR TITLE
Add a student's major and class level to the User table

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -9,6 +9,8 @@ class User(baseModel):
     firstName = CharField()
     lastName  = CharField()
     isStudent = BooleanField(default = False)
+    major = CharField(null = True)
+    classLevel = CharField(null = True)
     isFaculty = BooleanField(default = False)
     isStaff = BooleanField(default = False)
     isCeltsAdmin = BooleanField(default  =False)

--- a/database/import_users.py
+++ b/database/import_users.py
@@ -76,6 +76,8 @@ def getStudentData():
             "firstName": row[2].strip(),
             "lastName": row[3].strip(),
             "isStudent": True,
+            "major": row[6].strip(),
+            "classLevel": row[4].strip()
           }
         for row in c.execute('select * from STUDATA')
     ]

--- a/database/import_users.py
+++ b/database/import_users.py
@@ -34,7 +34,7 @@ def addToDb(userList):
 
         except peewee.IntegrityError as e:
             if user['username']:
-                (User.update(firstName = user['firstName'], lastName = user['lastName'], email = user['email'])
+                (User.update(firstName = user['firstName'], lastName = user['lastName'], email = user['email'], major = user['major'], classLevel = user['classLevel'])
                      .where(user['bnumber'] == User.bnumber)).execute()
             else:
                 print(f"No username for {user['bnumber']}!", user)
@@ -58,6 +58,8 @@ def getFacultyStaffData():
             "isStudent": False,
             "isFaculty": True,
             "isStaff": False,
+            "major": None,
+            "classLevel": None,
           }
         for row in c.execute('select * from STUSTAFF')
     ]

--- a/database/test_data.py
+++ b/database/test_data.py
@@ -46,8 +46,8 @@ users = [
         "isCeltsAdmin": True,
         "isCeltsStudentStaff": False,
         "dietRestriction": "Diary",
-        "major": "",
-        "classLevel": "",
+        "major": None,
+        "classLevel": None,
 
     },
     {
@@ -61,8 +61,8 @@ users = [
         "isFaculty": False,
         "isCeltsAdmin": True,
         "isCeltsStudentStaff": False,
-        "major": "",
-        "classLevel": "",
+        "major": None,
+        "classLevel": None,
     },
     {
         "username": "neillz",
@@ -75,8 +75,8 @@ users = [
         "isFaculty": False,
         "isCeltsAdmin": False,
         "isCeltsStudentStaff": True,
-        "major": "",
-        "classLevel": "",
+        "major": None,
+        "classLevel": None,
     },
 
     {
@@ -90,8 +90,8 @@ users = [
         "isFaculty": True,
         "isCeltsAdmin": False,
         "isCeltsStudentStaff": False,
-        "major": "",
-        "classLevel": "",
+        "major": None,
+        "classLevel": None,
     },
     {
         "username" : "ayisie",
@@ -104,8 +104,8 @@ users = [
         "isFaculty": False,
         "isCeltsAdmin": False,
         "isCeltsStudentStaff": False,
-        "major": "",
-        "classLevel": "",
+        "major": None,
+        "classLevel": None,
 
     },
     {
@@ -119,8 +119,8 @@ users = [
         "isFaculty": False,
         "isCeltsAdmin": False,
         "isCeltsStudentStaff": False,
-        "major": "",
-        "classLevel": "",
+        "major": None,
+        "classLevel": None,
     },
     {
         "username": "bryanta",
@@ -130,8 +130,8 @@ users = [
         "firstName": "Alex",
         "lastName": "Bryant",
         "isStudent": True,
-        "major": "",
-        "classLevel": "",
+        "major": None,
+        "classLevel": None,
     },
     {
         "username": "partont",
@@ -141,8 +141,8 @@ users = [
         "lastName": "Parton",
         "isStudent": True,
         "phoneNumber": "(859)433-1559",
-        "major": "",
-        "classLevel": "",
+        "major": None,
+        "classLevel": None,
     },
     {
         "username": "mupotsal",
@@ -153,8 +153,8 @@ users = [
         "isStudent": True,
         "phoneNumber": "(859)463-1159",
         "isCeltsStudentStaff": True,
-        "major": "",
-        "classLevel": "",
+        "major": None,
+        "classLevel": None,
     },
     {
         "username": "heggens",
@@ -167,8 +167,8 @@ users = [
         "isFaculty": True,
         "isCeltsStudentStaff": False,
         "isStaff": True,
-        "major": "",
-        "classLevel": "",
+        "major": None,
+        "classLevel": None,
     },
      {
         "username": "qasema",
@@ -181,8 +181,8 @@ users = [
         "isFaculty": True,
         "isCeltsStudentStaff": False,
         "isStaff": True,
-        "major": "",
-        "classLevel": "",
+        "major": None,
+        "classLevel": None,
     },
     {
         "username": "stettnera2",
@@ -196,8 +196,8 @@ users = [
         "isStaff": True,
         "isCeltsAdmin": True,
         "isCeltsStudentStaff": False,
-        "major": "",
-        "classLevel": "",
+        "major": None,
+        "classLevel": None,
     },
 ]
 

--- a/database/test_data.py
+++ b/database/test_data.py
@@ -45,7 +45,10 @@ users = [
         "isStaff": True,
         "isCeltsAdmin": True,
         "isCeltsStudentStaff": False,
-        "dietRestriction": "Diary"
+        "dietRestriction": "Diary",
+        "major": "",
+        "classLevel": "",
+
     },
     {
         "username" : "khatts",
@@ -58,6 +61,8 @@ users = [
         "isFaculty": False,
         "isCeltsAdmin": True,
         "isCeltsStudentStaff": False,
+        "major": "",
+        "classLevel": "",
     },
     {
         "username": "neillz",
@@ -70,6 +75,8 @@ users = [
         "isFaculty": False,
         "isCeltsAdmin": False,
         "isCeltsStudentStaff": True,
+        "major": "",
+        "classLevel": "",
     },
 
     {
@@ -83,6 +90,8 @@ users = [
         "isFaculty": True,
         "isCeltsAdmin": False,
         "isCeltsStudentStaff": False,
+        "major": "",
+        "classLevel": "",
     },
     {
         "username" : "ayisie",
@@ -95,6 +104,8 @@ users = [
         "isFaculty": False,
         "isCeltsAdmin": False,
         "isCeltsStudentStaff": False,
+        "major": "",
+        "classLevel": "",
 
     },
     {
@@ -108,6 +119,8 @@ users = [
         "isFaculty": False,
         "isCeltsAdmin": False,
         "isCeltsStudentStaff": False,
+        "major": "",
+        "classLevel": "",
     },
     {
         "username": "bryanta",
@@ -117,6 +130,8 @@ users = [
         "firstName": "Alex",
         "lastName": "Bryant",
         "isStudent": True,
+        "major": "",
+        "classLevel": "",
     },
     {
         "username": "partont",
@@ -126,6 +141,8 @@ users = [
         "lastName": "Parton",
         "isStudent": True,
         "phoneNumber": "(859)433-1559",
+        "major": "",
+        "classLevel": "",
     },
     {
         "username": "mupotsal",
@@ -136,6 +153,8 @@ users = [
         "isStudent": True,
         "phoneNumber": "(859)463-1159",
         "isCeltsStudentStaff": True,
+        "major": "",
+        "classLevel": "",
     },
     {
         "username": "heggens",
@@ -148,6 +167,8 @@ users = [
         "isFaculty": True,
         "isCeltsStudentStaff": False,
         "isStaff": True,
+        "major": "",
+        "classLevel": "",
     },
      {
         "username": "qasema",
@@ -160,6 +181,8 @@ users = [
         "isFaculty": True,
         "isCeltsStudentStaff": False,
         "isStaff": True,
+        "major": "",
+        "classLevel": "",
     },
     {
         "username": "stettnera2",
@@ -173,6 +196,8 @@ users = [
         "isStaff": True,
         "isCeltsAdmin": True,
         "isCeltsStudentStaff": False,
+        "major": "",
+        "classLevel": "",
     },
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,3 +79,4 @@ webdriver-manager==3.4.2
 Werkzeug==2.2.2
 WTForms==2.3.3
 XlsxWriter==3.0.3
+pyodbc==4.0.35


### PR DESCRIPTION
Fixes issue #854 
Did: 
- added "major" and "classLevel" to User table
- configure import_users.py so it can pull these two information from Tracy to our database

Test: 
- reset database
- update the Tracy password in config/default.yml (ask Brian or Sreynit or Fleur for password)
- In database run 'python import_users.py'
- Check the User table. "major and classLevel" for students should be populated with their major and class level.