### PR TITLE
Add missing package to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
  * python3-dev
  * python3-pip
  * python3-venv
+ * libffi-dev
  * mysql-server
 
 


### PR DESCRIPTION
`libffi-dev` was required but not in the README