### PR TITLE
Changed Image

### DIFF
--- a/app/templates/serviceLearning/slcFormPrint.html
+++ b/app/templates/serviceLearning/slcFormPrint.html
@@ -7,7 +7,7 @@
 {% block app_content %}
 <div class= "w-100 d-print-block">
   <div class="text-center">
-    <img src="{{url_for('static', filename='images/logos/slc_prop_download_celts_logo.png')}}" height="85" width ="90">
+    <img src="{{url_for('static', filename='images/logos/celts_logo.png')}}" width ="269" height="90">
     <h6>
       <br><b>Service-Learning Course Designation/<br>Active Learning Experience (ALE) Requirements Met Through Service-Learning</b>
     </h6>


### PR DESCRIPTION
We've updated which CELTS logo that's used when you print out a class proposal. We've reduced the size of the raw image by a factor of 9 and that seems to look the best out of the sizes we've looked at. 

Resolves #900