### PR TITLE
Dynamically Hides Sidebar

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -23,7 +23,7 @@
 {% block content %}
 <div>
   <div class="row g-0">
-    <div class="col-md-auto d-print-none d-lg-block">
+    <div class="col-md-auto d-print-none d-none d-lg-block">
       <div style="margin-right: 280px">
         <nav class="position-fixed float-start">
           {% block sidebar %}


### PR DESCRIPTION
The sidebar doesn't remain on the page when you resize it beneath a large size. Now, when the page is large and bigger the static sidebar remains but when the page is smaller than large, the sidebar button appears and provides a smoother experience for our users.

Resolves #908