### PR TITLE
Restricted permissions to the course management page

### DIFF
--- a/app/controllers/serviceLearning/routes.py
+++ b/app/controllers/serviceLearning/routes.py
@@ -26,10 +26,10 @@ def serviceCourseManagement(username=None):
         user = User.get(User.username==username) if username else g.current_user
     except DoesNotExist:
         abort(404)
-
+    
     isRequestingForSelf = g.current_user == user 
     if g.current_user.isCeltsAdmin or (g.current_user.isFaculty and isRequestingForSelf):
-        setRedirectTarget("/serviceLearning/courseManagement")
+        setRedirectTarget(request.full_path)
         courseDict = getServiceLearningCoursesData(user)
         termList = selectSurroundingTerms(g.current_term, prevTerms=0)
         return render_template('serviceLearning/slcManagement.html',

--- a/app/controllers/serviceLearning/routes.py
+++ b/app/controllers/serviceLearning/routes.py
@@ -22,11 +22,11 @@ from app.controllers.serviceLearning import serviceLearning_bp
 @serviceLearning_bp.route('/serviceLearning/courseManagement', methods = ['GET'])
 @serviceLearning_bp.route('/serviceLearning/courseManagement/<username>', methods = ['GET'])
 def serviceCourseManagement(username=None):
-    if g.current_user.isStudent:
-        abort(403)
-    if g.current_user.isCeltsAdmin or g.current_user.isFaculty:
+    user = User.get(User.username==username) if username else g.current_user
+    isRequestingForSelf = g.current_user == user 
+    
+    if g.current_user.isCeltsAdmin or (g.current_user.isFaculty and isRequestingForSelf):
         setRedirectTarget("/serviceLearning/courseManagement")
-        user = User.get(User.username==username) if username else g.current_user
         courseDict = getServiceLearningCoursesData(user)
         termList = selectSurroundingTerms(g.current_term, prevTerms=0)
         return render_template('serviceLearning/slcManagement.html',
@@ -36,6 +36,7 @@ def serviceCourseManagement(username=None):
     else:
         flash("Unauthorized to view page", 'warning')
         return redirect(url_for('main.events', selectedTerm=g.current_term))
+    
 
 @serviceLearning_bp.route('/serviceLearning/viewProposal/<courseID>', methods=['GET'])
 @serviceLearning_bp.route('/serviceLearning/editProposal/upload/<courseID>', methods=['GET'])

--- a/app/controllers/serviceLearning/routes.py
+++ b/app/controllers/serviceLearning/routes.py
@@ -22,9 +22,12 @@ from app.controllers.serviceLearning import serviceLearning_bp
 @serviceLearning_bp.route('/serviceLearning/courseManagement', methods = ['GET'])
 @serviceLearning_bp.route('/serviceLearning/courseManagement/<username>', methods = ['GET'])
 def serviceCourseManagement(username=None):
-    user = User.get(User.username==username) if username else g.current_user
+    try:
+        user = User.get(User.username==username) if username else g.current_user
+    except DoesNotExist:
+        abort(404)
+
     isRequestingForSelf = g.current_user == user 
-    
     if g.current_user.isCeltsAdmin or (g.current_user.isFaculty and isRequestingForSelf):
         setRedirectTarget("/serviceLearning/courseManagement")
         courseDict = getServiceLearningCoursesData(user)
@@ -34,9 +37,8 @@ def serviceCourseManagement(username=None):
             courseDict=courseDict,
             termList=termList)
     else:
-        flash("Unauthorized to view page", 'warning')
-        return redirect(url_for('main.events', selectedTerm=g.current_term))
-    
+        abort(403)
+        
 
 @serviceLearning_bp.route('/serviceLearning/viewProposal/<courseID>', methods=['GET'])
 @serviceLearning_bp.route('/serviceLearning/editProposal/upload/<courseID>', methods=['GET'])


### PR DESCRIPTION
We've changed the permissions for the course management pages for users to be restricted to all administrators and faculty that are attempting to view their own page. Faculty cannot view other faculty's pages and students should not have one so they cannot either.

Fixes issue #929 