### PR TITLE
Allow the creator of the Course Proposal to renew it

### DIFF
--- a/app/controllers/serviceLearning/routes.py
+++ b/app/controllers/serviceLearning/routes.py
@@ -201,8 +201,9 @@ def renewCourse(courseID, termID):
     """
     instructors = CourseInstructor.select().where(CourseInstructor.course==courseID)
     courseInstructors = [instructor.user for instructor in instructors]
+    isCourseCreator = Course.select().where(Course.createdBy == g.current_user, Course.id==courseID).exists()
     try:
-        if g.current_user.isCeltsAdmin or g.current_user in courseInstructors:
+        if g.current_user.isCeltsAdmin or g.current_user in courseInstructors or isCourseCreator:
             renewedProposal = renewProposal(courseID, termID)
             flash("Course successfully renewed", 'success')
             return str(renewedProposal.id)

--- a/app/static/js/slcManagement.js
+++ b/app/static/js/slcManagement.js
@@ -3,9 +3,6 @@ $(document).ready(function() {
   $('#withdrawModal').on('hidden.bs.modal', function () {
     $('.form-select').val('---');
   });
-  $("#withdrawBtn").on("click", function() {
-    withdraw();
-  });
   var statusKey = $(".status-key");
   statusKey.popover({
     trigger: "hover",

--- a/app/static/js/slcManagement.js
+++ b/app/static/js/slcManagement.js
@@ -51,7 +51,7 @@ function changeAction(action){
 }
 function renew(){
     courseID = $("#courseID").val();
-    termID = $('rMTermSelect').find(":selected").val()
+    termID = $('#rMTermSelect').find(":selected").val()
     $.ajax({
       url: `/serviceLearning/renew/${courseID}/${termID}/`,
       type: "POST",

--- a/app/static/js/slcManagement.js
+++ b/app/static/js/slcManagement.js
@@ -30,7 +30,6 @@ function updateRenewModal(courseID){
   $("#rMStatusCell").text($("#status-" + courseID).text())
 }
 function changeAction(action){
-  console.log(action)
   courseID = action.id;
   // decides what to do based on selection
   if (action.value == "Renew"){

--- a/app/static/js/slcManagement.js
+++ b/app/static/js/slcManagement.js
@@ -5,9 +5,11 @@ $(document).ready(function() {
   });
   $('#renewTerm').on('change', function(){
     if ($('#renewTerm').value != "---"){
-      $('#renewButton').prop('disabled', false);
+      $('#renewBtn').prop('disabled', false);
     }
-  })
+  });
+  $("#withdrawBtn").on("click", withdraw);
+  $("#renewBtn").on("click", renew);
   var statusKey = $(".status-key");
   statusKey.popover({
     trigger: "hover",
@@ -27,7 +29,7 @@ $(document).ready(function() {
 
 function resetAllSelections(){
   $('.form-select').val('---');
-  $('#renewButton').prop('disabled', true);
+  $('#renewBtn').prop('disabled', true);
 }
 function updateRenewModal(courseID){
   // updates renewModal with the course's information

--- a/app/static/js/slcManagement.js
+++ b/app/static/js/slcManagement.js
@@ -23,12 +23,20 @@ $(document).ready(function() {
   });
 });
 
+function updateRenewModal(courseID){
+  // updates renewModal with the course's information
+  $("#rMCourseNameCell").text($("#name-" + courseID).text())
+  $("#rMFacultyCell").text($("#faculty-" + courseID).text())
+  $("#rMStatusCell").text($("#status-" + courseID).text())
+}
 function changeAction(action){
+  console.log(action)
   courseID = action.id;
   // decides what to do based on selection
   if (action.value == "Renew"){
     $('#courseID').val(courseID);
-    $("#course-" + courseID).modal('show')
+    updateRenewModal(courseID)
+    $("#renewModal").modal('show')
   } else if (action.value == "View"){
     location = '/serviceLearning/viewProposal/' + courseID;
   } else if (action.value == "Withdraw"){
@@ -44,7 +52,7 @@ function changeAction(action){
 }
 function renew(){
     courseID = $("#courseID").val();
-    termID = $('#renewCourse-'+courseID).find(":selected").val()
+    termID = $('rMTermSelect').find(":selected").val()
     $.ajax({
       url: `/serviceLearning/renew/${courseID}/${termID}/`,
       type: "POST",

--- a/app/static/js/slcManagement.js
+++ b/app/static/js/slcManagement.js
@@ -3,9 +3,8 @@ $(document).ready(function() {
   $('.modal').on('hidden.bs.modal', function () {
     resetAllSelections()
   });
-  $('#rMTermSelect').on('change', function(){
-    if ($('#rMTermSelect').value != "---"){
-      console.log("This should enable the thing!")
+  $('#renewTerm').on('change', function(){
+    if ($('#renewTerm').value != "---"){
       $('#renewButton').prop('disabled', false);
     }
   })
@@ -32,9 +31,9 @@ function resetAllSelections(){
 }
 function updateRenewModal(courseID){
   // updates renewModal with the course's information
-  $("#rMCourseNameCell").text($("#name-" + courseID).text())
-  $("#rMFacultyCell").text($("#faculty-" + courseID).text())
-  $("#rMStatusCell").text($("#status-" + courseID).text())
+  $("#renewName").text($("#name-" + courseID).text())
+  $("#renewFaculty").text($("#faculty-" + courseID).text())
+  $("#renewStatus").text($("#status-" + courseID).text())
 }
 function changeAction(action){
   courseID = action.id;
@@ -63,7 +62,7 @@ function changeAction(action){
 }
 function renew(){
     courseID = $("#courseID").val();
-    termID = $('#rMTermSelect').find(":selected").val()
+    termID = $('#renewTerm').find(":selected").val()
     $.ajax({
       url: `/serviceLearning/renew/${courseID}/${termID}/`,
       type: "POST",

--- a/app/static/js/slcManagement.js
+++ b/app/static/js/slcManagement.js
@@ -74,6 +74,7 @@ function renew(){
           console.log(status,error);
       }
     })
+    resetAllSelections()
 }
 function withdraw(){
   // uses hidden label to withdraw course

--- a/app/static/js/slcManagement.js
+++ b/app/static/js/slcManagement.js
@@ -3,6 +3,12 @@ $(document).ready(function() {
   $('.modal').on('hidden.bs.modal', function () {
     resetAllSelections()
   });
+  $('#rMTermSelect').on('change', function(){
+    if ($('#rMTermSelect').value != "---"){
+      console.log("This should enable the thing!")
+      $('#renewButton').prop('disabled', false);
+    }
+  })
   var statusKey = $(".status-key");
   statusKey.popover({
     trigger: "hover",
@@ -22,6 +28,7 @@ $(document).ready(function() {
 
 function resetAllSelections(){
   $('.form-select').val('---');
+  $('#renewButton').prop('disabled', true);
 }
 function updateRenewModal(courseID){
   // updates renewModal with the course's information
@@ -50,7 +57,7 @@ function changeAction(action){
     reviewCourses(courseID)
   }
   // leave these two selected until the modal is closed
-  if (courseAction != "Renew" || courseAction != "Withdraw"){
+  if (courseAction != "Renew" && courseAction != "Withdraw"){
     resetAllSelections()
   }
 }

--- a/app/static/js/slcManagement.js
+++ b/app/static/js/slcManagement.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
   // if they decide not to withdraw, change selection back to "select action"
-  $('#withdrawModal').on('hidden.bs.modal', function () {
-    $('.form-select').val('---');
+  $('.modal').on('hidden.bs.modal', function () {
+    resetAllSelections()
   });
   var statusKey = $(".status-key");
   statusKey.popover({
@@ -20,6 +20,9 @@ $(document).ready(function() {
   });
 });
 
+function resetAllSelections(){
+  $('.form-select').val('---');
+}
 function updateRenewModal(courseID){
   // updates renewModal with the course's information
   $("#rMCourseNameCell").text($("#name-" + courseID).text())
@@ -28,22 +31,27 @@ function updateRenewModal(courseID){
 }
 function changeAction(action){
   courseID = action.id;
+  courseAction = action.value
   // decides what to do based on selection
-  if (action.value == "Renew"){
+  if (courseAction == "Renew"){
     $('#courseID').val(courseID);
     updateRenewModal(courseID)
     $("#renewModal").modal('show')
-  } else if (action.value == "View"){
+  } else if (courseAction == "View"){
     location = '/serviceLearning/viewProposal/' + courseID;
-  } else if (action.value == "Withdraw"){
+  } else if (courseAction == "Withdraw"){
     $('#courseID').val(courseID);
     $('#withdrawModal').modal('show');
-  } else if(action.value == "Edit"){
+  } else if(courseAction == "Edit"){
     location = '/serviceLearning/editProposal/' + courseID;
-  } else if(action.value == "Print"){
+  } else if(courseAction == "Print"){
     slcPrintPDF(courseID)
-  } else if (action.value == "Review"){
+  } else if (courseAction == "Review"){
     reviewCourses(courseID)
+  }
+  // leave these two selected until the modal is closed
+  if (courseAction != "Renew" || courseAction != "Withdraw"){
+    resetAllSelections()
   }
 }
 function renew(){

--- a/app/templates/serviceLearning/slcManagement.html
+++ b/app/templates/serviceLearning/slcManagement.html
@@ -76,7 +76,7 @@
       </div>
       <div class="modal-footer justify-content-between">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-        <button type="button" class="btn btn-primary" id="withdrawBtn">Withdraw</button>
+        <button type="button" class="btn btn-primary" id="withdrawBtn" onclick="withdraw()">Withdraw</button>
       </div>
     </div>
   </div>

--- a/app/templates/serviceLearning/slcManagement.html
+++ b/app/templates/serviceLearning/slcManagement.html
@@ -109,7 +109,7 @@
         <select class="form-select courseRenewal" id="rMTermSelect">
           <option value="---" disabled selected>Select Term</option>
           {% for term in termList %}
-          <option id="termSelect" value="{{term}}">{{term.description}}</option>
+          <option value="{{term}}">{{term.description}}</option>
           {% endfor %}
         </select>
       </div>

--- a/app/templates/serviceLearning/slcManagement.html
+++ b/app/templates/serviceLearning/slcManagement.html
@@ -51,7 +51,7 @@
       {% endfor %}
     </tbody>
   </table>
-  <input id="courseID" type="hidden" value="">
+  <input id="courseID" type="hidden">
   {% if not courseDict %}
     <p class="text-center">{{user.firstName}} {{user.lastName}} has no associated course proposals.</p>
   {% endif %}
@@ -76,7 +76,7 @@
       </div>
       <div class="modal-footer justify-content-between">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-        <button type="button" class="btn btn-primary" id="withdrawBtn" onclick="withdraw()">Withdraw</button>
+        <button type="button" class="btn btn-primary" id="withdrawBtn">Withdraw</button>
       </div>
     </div>
   </div>
@@ -115,7 +115,7 @@
       </div>
       <div class="modal-footer justify-content-between">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-        <button type="button" class="btn btn-primary" onclick="renew()" id="renewButton" disabled>Renew</button>
+        <button type="button" class="btn btn-primary" id="renewBtn" disabled>Renew</button>
       </div>
     </div>
   </div>

--- a/app/templates/serviceLearning/slcManagement.html
+++ b/app/templates/serviceLearning/slcManagement.html
@@ -29,10 +29,10 @@
     <tbody>
       {% for course in courseDict %}
         <tr>
-          <td>{{courseDict[course]['name']}}</td>
-          <td>{{courseDict[course]['creator']}}</td>
-          <td>{{courseDict[course]['faculty']|join(", ")}}</td>
-          <td>{{courseDict[course]['term'].description}}</td>
+          <td id="name-{{courseDict[course]['id']}}">{{courseDict[course]['name']}}</td>
+          <td id="creator-{{courseDict[course]['id']}}">{{courseDict[course]['creator']}}</td>
+          <td id="faculty-{{courseDict[course]['id']}}">{{courseDict[course]['faculty']|join(", ")}}</td>
+          <td id="term-{{courseDict[course]['id']}}">{{courseDict[course]['term'].description}}</td>
           <td>
             <a class="status-key text-dark" id="statusKey" href="javascript:void(0);" data-toggle="popover" title="Status" data-content="{{courseDict[course]['status']}}">{{courseDict[course]['status']}}</a>
           </td>
@@ -81,8 +81,8 @@
     </div>
   </div>
 </div>
-{% for course in courseDict %}
-<div class="modal fade" id="course-{{courseDict[course]['id']}}" tabindex="-1" aria-labelledby="renewModalLabel" aria-hidden="true">
+<!-- modal -->
+<div class="modal fade" id="renewModal" tabindex="-1" aria-labelledby="renewModalLabel" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
@@ -94,25 +94,27 @@
             <tbody id="facultyTable">
               <tr>
                 <td class="fw-bold">Course Name</td>
-                <td> {{courseDict[course]['name']}}</td>
+                <td id="rMCourseNameCell"> 
+                  <!-- courseDict[course]['name'] -->
+                </td>
               </tr>
               <tr>
                 <td class="fw-bold"> Instructor(s)</td>
-                <td>
-                  {{courseDict[course]['faculty']|join(", ")}}
+                <td id="rMFacultyCell">
+                  <!-- courseDict[course]['faculty']|join(", ") -->
                 </td>
               </tr>
               <tr>
                 <td class="fw-bold">Status</td>
-                <td>
-                  {{courseDict[course]['status']}}
+                <td id="rMStatusCell">
+                  <!-- courseDict[course]['status'] -->
                 </td>
               </tr>
             </tbody>
           </table>
         <input id="courseID" type="hidden" value="">
         <p>Choose a term for the new course:</p>
-        <select class="form-select courseRenewal" id="renewCourse-{{courseDict[course]['id']}}">
+        <select class="form-select courseRenewal" id="rMTermSelect">
           <option value="---" disabled selected>Select Term</option>
           {% for term in termList %}
           <option id="termSelect" value="{{term}}">{{term.description}}</option>
@@ -126,5 +128,4 @@
     </div>
   </div>
 </div>
-{% endfor %}
 {% endblock %}

--- a/app/templates/serviceLearning/slcManagement.html
+++ b/app/templates/serviceLearning/slcManagement.html
@@ -51,6 +51,7 @@
       {% endfor %}
     </tbody>
   </table>
+  <input id="courseID" type="hidden" value="">
   {% if not courseDict %}
     <p class="text-center">{{user.firstName}} {{user.lastName}} has no associated course proposals.</p>
   {% endif %}
@@ -68,7 +69,6 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <input id="courseID" type="hidden" value="">
         <p>Are you sure you want to withdraw this service-learning course proposal?<br><br>
           <span class="text-danger bi bi-exclamation-triangle-fill"></span>
           <b>Note: This action is irreversible. Once withdrawn, the proposal will be forever deleted.</b>
@@ -81,7 +81,6 @@
     </div>
   </div>
 </div>
-<!-- modal -->
 <div class="modal fade" id="renewModal" tabindex="-1" aria-labelledby="renewModalLabel" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
@@ -94,25 +93,18 @@
             <tbody id="facultyTable">
               <tr>
                 <td class="fw-bold">Course Name</td>
-                <td id="rMCourseNameCell"> 
-                  <!-- courseDict[course]['name'] -->
-                </td>
+                <td id="rMCourseNameCell"></td>
               </tr>
               <tr>
                 <td class="fw-bold"> Instructor(s)</td>
-                <td id="rMFacultyCell">
-                  <!-- courseDict[course]['faculty']|join(", ") -->
-                </td>
+                <td id="rMFacultyCell"></td>
               </tr>
               <tr>
                 <td class="fw-bold">Status</td>
-                <td id="rMStatusCell">
-                  <!-- courseDict[course]['status'] -->
-                </td>
+                <td id="rMStatusCell"></td>
               </tr>
             </tbody>
           </table>
-        <input id="courseID" type="hidden" value="">
         <p>Choose a term for the new course:</p>
         <select class="form-select courseRenewal" id="rMTermSelect">
           <option value="---" disabled selected>Select Term</option>

--- a/app/templates/serviceLearning/slcManagement.html
+++ b/app/templates/serviceLearning/slcManagement.html
@@ -115,7 +115,7 @@
       </div>
       <div class="modal-footer justify-content-between">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-        <button type="button" class="btn btn-primary" onclick="renew()">Renew</button>
+        <button type="button" class="btn btn-primary" onclick="renew()" id="renewButton" disabled>Renew</button>
       </div>
     </div>
   </div>

--- a/app/templates/serviceLearning/slcManagement.html
+++ b/app/templates/serviceLearning/slcManagement.html
@@ -34,7 +34,7 @@
           <td id="faculty-{{courseDict[course]['id']}}">{{courseDict[course]['faculty']|join(", ")}}</td>
           <td id="term-{{courseDict[course]['id']}}">{{courseDict[course]['term'].description}}</td>
           <td>
-            <a class="status-key text-dark" id="statusKey" href="javascript:void(0);" data-toggle="popover" title="Status" data-content="{{courseDict[course]['status']}}">{{courseDict[course]['status']}}</a>
+            <a class="status-key text-dark" id="status-{{courseDict[course]['id']}}" href="javascript:void(0);" data-toggle="popover" title="Status" data-content="{{courseDict[course]['status']}}">{{courseDict[course]['status']}}</a>
           </td>
           <td>
             <select class="form-select courseData" id="{{courseDict[course]['id']}}" onchange='changeAction(this)'>

--- a/app/templates/serviceLearning/slcManagement.html
+++ b/app/templates/serviceLearning/slcManagement.html
@@ -93,20 +93,20 @@
             <tbody id="facultyTable">
               <tr>
                 <td class="fw-bold">Course Name</td>
-                <td id="rMCourseNameCell"></td>
+                <td id="renewName"></td>
               </tr>
               <tr>
                 <td class="fw-bold"> Instructor(s)</td>
-                <td id="rMFacultyCell"></td>
+                <td id="renewFaculty"></td>
               </tr>
               <tr>
                 <td class="fw-bold">Status</td>
-                <td id="rMStatusCell"></td>
+                <td id="renewStatus"></td>
               </tr>
             </tbody>
           </table>
         <p>Choose a term for the new course:</p>
-        <select class="form-select courseRenewal" id="rMTermSelect">
+        <select class="form-select courseRenewal" id="renewTerm">
           <option value="---" disabled selected>Select Term</option>
           {% for term in termList %}
           <option value="{{term}}">{{term.description}}</option>


### PR DESCRIPTION
Check whether the current user has created the course and allow him to renew a Course Proposal.
We were unable to recreate the bug where faculty members could not renew proposals for which they were among the faculty. 
This feature was working properly and looks fine in the code. 

Resolves #891