### PR TITLE
Ordered the data by programName when retrieving data with PeeWee

### DIFF
--- a/app/logic/landingPage.py
+++ b/app/logic/landingPage.py
@@ -6,9 +6,9 @@ from app.models.program import Program
 
 def getManagerProgramDict(user):
     if user.isAdmin or user.isBonnerScholar:
-        programs = Program.select()
+        programs = Program.select().order_by(Program.programName)
     else:
-        programs = Program.select().where(Program.isBonnerScholars == False)
+        programs = Program.select().where(Program.isBonnerScholars == False).order_by(Program.programName)
     managerRows = list(ProgramManager.select())
     managerProgramDict = {}
 


### PR DESCRIPTION
When doing the PeeWee query we now sort the data alphabetically when it's being imported for the landing page

Resolves #897 