### PR TITLE
Fixed the file upload box

### DIFF
--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -72,11 +72,8 @@ function getSelectedFiles(){
 
 
 function hasUniqueFileName(fileName){
-  let nameHolders = $(".fileName").toArray();
-  for (let i = 0; i < nameHolders.length; i++){
-    if (fileName == $(nameHolders[i]).data("filename")) return false;
-  }
-  return true;
+  if ($(".fileName[data-filename='" + fileName + "']").length == 0) { return true }
+  return false;
 }
 
 
@@ -116,27 +113,28 @@ $(document).ready(function() {
             default:
               iconClass = 'bi-file-earmark-arrow-up';
           }
-          $("#attachedObjectContainer").append("<div class='border row p-0 m-0' id='attachedFilesRow" +fileNum+"'></div>")
-          $("#attachedFilesRow"+fileNum).append("<i class='col-auto fs-3 px-3 bi " + iconClass + "'></i>")
-          $("#attachedFilesRow"+fileNum).append("<div id='attachedFile" + fileNum + "' data-filename='" + file.name + "' class='fileName col-auto pt-2'>" + fileName + "</div>");
-          $("#attachedFilesRow"+fileNum).append("<div class='col' style='text-align:right'> \
-                                                  <div class='btn btn-danger fileHolder p-1 my-1 mx-1' id='trash" + fileNum + "'>\
-                                                    <span class='bi bi-trash fs-6'></span>\
-                                                  </div>\
+          $("#attachedObjectContainer").append("<div class='border row p-0 m-0' id='attachedFilesRow" +fileNum+"'> \
+                                                  <i class='col-auto fs-3 px-3 bi " + iconClass + "'></i> \
+                                                  <div id='attachedFile" + fileNum + "' data-filename='" + file.name + "' class='fileName col-auto pt-2'>" + fileName + "</div> \
+                                                  <div class='col' style='text-align:right'> \
+                                                    <div class='btn btn-danger fileHolder p-1 my-1 mx-1' id='trash" + fileNum + "' data-filenum='" + fileNum + "'>\
+                                                      <span class='bi bi-trash fs-6'></span>\
+                                                    </div>\
+                                                  </div> \
                                                 </div>")
           $("#trash"+fileNum).data("file", file);
           $("#trash"+fileNum).on("click", function() {
-            let elementFileNum = $(this).prop("id").split("trash")[1];
+            let elementFileNum = $(this).data('filenum');
             $("#attachedFilesRow" + elementFileNum).remove();
-            $("#attachmentObject").prop('files', getSelectedFiles);
+            $("#attachmentObject").prop('files', getSelectedFiles());
           })
           fileNum++;
         }
         else{
-          msgFlash("File with filename '" + file.name + "' has already been added to this event")
+          msgToast("File with filename '" + file.name + "' has already been added to this event")
         }
       }
-      $("#attachmentObject").prop('files', getSelectedFiles);
+      $("#attachmentObject").prop('files', getSelectedFiles());
     });
 
 

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -72,8 +72,7 @@ function getSelectedFiles(){
 
 
 function hasUniqueFileName(fileName){
-  if ($(".fileName[data-filename='" + fileName + "']").length == 0) { return true }
-  return false;
+  return $(".fileName[data-filename='" + fileName + "']").length == 0;
 }
 
 

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -65,7 +65,7 @@ function format24to12HourTime(timeStr){
 function getSelectedFiles(){
   let _fileHolder = new DataTransfer();
   $(".fileHolder").each(function(){
-    _fileHolder.items.add($(this).val());
+    _fileHolder.items.add($(this).data("file"));
   });
   return _fileHolder.files;
 }
@@ -74,7 +74,7 @@ function getSelectedFiles(){
 function hasUniqueFileName(fileName){
   let nameHolders = $(".fileName").toArray();
   for (let i = 0; i < nameHolders.length; i++){
-    if (fileName == $(nameHolders[i]).val()) return false;
+    if (fileName == $(nameHolders[i]).data("filename")) return false;
   }
   return true;
 }
@@ -86,7 +86,6 @@ function hasUniqueFileName(fileName){
  */
 $(document).ready(function() {
   if ( $("#startDatePicker").val() != $("#endDatePicker").val()){
-
     calculateRecurringEventFrequency();
   }
 
@@ -119,14 +118,13 @@ $(document).ready(function() {
           }
           $("#attachedObjectContainer").append("<div class='border row p-0 m-0' id='attachedFilesRow" +fileNum+"'></div>")
           $("#attachedFilesRow"+fileNum).append("<i class='col-auto fs-3 px-3 bi " + iconClass + "'></i>")
-          $("#attachedFilesRow"+fileNum).append("<div id='attachedFile" + fileNum + "' class='fileName col-auto pt-2'>" + fileName + "</div>");
-          $("#attachedFile"+fileNum).val(file.name);
+          $("#attachedFilesRow"+fileNum).append("<div id='attachedFile" + fileNum + "' data-filename='" + file.name + "' class='fileName col-auto pt-2'>" + fileName + "</div>");
           $("#attachedFilesRow"+fileNum).append("<div class='col' style='text-align:right'> \
-                                                  <div class='btn btn-danger fileHolder p-1 my-1 mx-1' id='trash" + fileNum + "' >\
+                                                  <div class='btn btn-danger fileHolder p-1 my-1 mx-1' id='trash" + fileNum + "'>\
                                                     <span class='bi bi-trash fs-6'></span>\
                                                   </div>\
                                                 </div>")
-          $("#trash"+fileNum).val(file);
+          $("#trash"+fileNum).data("file", file);
           $("#trash"+fileNum).on("click", function() {
             let elementFileNum = $(this).prop("id").split("trash")[1];
             $("#attachedFilesRow" + elementFileNum).remove();

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -60,6 +60,8 @@ function format24to12HourTime(timeStr){
       });
 
   }
+
+
 /*
  * Run when the webpage is ready for javascript
  */
@@ -84,17 +86,41 @@ $(document).ready(function() {
         const file = selectedFiles[i];
         let fileName = (file.name.length > 25) ? file.name.slice(0,10) + '...' + file.name.slice(-10) : file.name;
         let fileExtension = file.name.split(".").pop();
+        let iconClass = '';
+        switch(fileExtension) {
+          case 'jpg': 
+          case 'png':
+          case 'jpeg':
+            iconClass = "bi-file-image";
+            break
+          case 'pdf':
+            iconClass = 'bi-filetype-pdf';
+            break
+          case 'docx':
+            iconClass = 'bi-filetype-docx';
+            break
+          case 'xlsx':
+            iconClass = 'bi-filetype-xlsx';
+            break
+          default:
+            iconClass = 'bi-file-earmark-arrow-up';
+        }
         console.log(fileExtension);
-        $("#attachedObjectContainer").append("<div class='border row p-0 m-0' id='row" +fileNum+ "'></div>")
-        $("#row"+fileNum).append("<i class='col-auto fs-3 px-3 bi bi-filetype-docx'></i>")
-        $("#row"+fileNum).append( "<div id='attachedFile" + fileNum + "' class='attached-file col-auto pt-2' value='" + file.name + "'>" + fileName + "</div>");
-        $("#row"+fileNum).append("<div class='col' style='text-align:right'> \
-                                                <div class='btn btn-danger bi bi-trash deleteFile p-1 my-1 mx-1'></div>\
+        $("#attachedObjectContainer").append("<div class='border row p-0 m-0' id='attachedFilesRow" +fileNum+"'></div>")
+        $("#attachedFilesRow"+fileNum).append("<i class='col-auto fs-3 px-3 bi " + iconClass + "'></i>")
+        $("#attachedFilesRow"+fileNum).append("<div id='attachedFile" + fileNum + "' class='attached-file col-auto pt-2' value='" + file.name + "'>" + fileName + "</div>");
+        $("#attachedFilesRow"+fileNum).append("<div class='col' style='text-align:right'> \
+                                                <div class='btn btn-danger p-1 my-1 mx-1' value='"+fileNum+"' id='trash"+ fileNum +"''>\
+                                                  <span class='bi bi-trash fs-6'></span>\
+                                                </div>\
                                               </div>")
+        $("#trash"+fileNum).on("click", function() {
+          $("#attachedFilesRow"+$(this).val).remove();}
+          // console.log($(this).val); }
+        )
         fileNum++;
         filesDict.items.add(file);
       }
-      $("#attachmentObject").prop("value", '');
       console.log(filesDict);
       $("#attachmentObject").prop('files', filesDict.files);
     });

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -74,19 +74,32 @@ $(document).ready(function() {
     // })
 
     var fileNum = 0;
+    var filesDict = new DataTransfer();
     $("#attachmentObject").on('change', function() {
       const selectedFiles = $("#attachmentObject").prop('files'); // TODO: see if we can append file data by reading the list and appending to it.
+      console.log($("#attachmentObject"));
       
       for (let i = 0; i < selectedFiles.length; i++) {
+        
         const file = selectedFiles[i];
-        const fileName = file.name;
-        console.log(file)
-  
-        $("#attachedObjectContainer").append("<div id='attachedFile" + fileNum + "' class='attached-file col' data-file>" + fileName + "</div>")
-        $("#attachedFile" + fileNum).prop("data-file", file)
+        let fileName = (file.name.length > 25) ? file.name.slice(0,10) + '...' + file.name.slice(-10) : file.name;
+        let fileExtension = file.name.split(".").pop();
+        console.log(fileExtension);
+        $("#attachedObjectContainer").append("<div class='border row p-0 m-0' id='row" +fileNum+ "'></div>")
+        $("#row"+fileNum).append("<i class='col-auto fs-3 px-3 bi bi-filetype-docx'></i>")
+        $("#row"+fileNum).append( "<div id='attachedFile" + fileNum + "' class='attached-file col-auto pt-2' value='" + file.name + "'>" + fileName + "</div>");
+        $("#row"+fileNum).append("<div class='col' style='text-align:right'> \
+                                                <div class='btn btn-danger bi bi-trash deleteFile p-1 my-1 mx-1'></div>\
+                                              </div>")
         fileNum++;
+        filesDict.items.add(file);
       }
+      $("#attachmentObject").prop("value", '');
+      console.log(filesDict);
+      $("#attachmentObject").prop('files', filesDict.files);
     });
+
+
 
     $("#checkRSVP").on("click", function() {
       if ($("#checkRSVP").is(":checked")) {

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -62,6 +62,25 @@ function format24to12HourTime(timeStr){
   }
 
 
+function getSelectedFiles(){
+  let _fileHolder = new DataTransfer();
+  $(".fileHolder").each(function(){
+    _fileHolder.items.add($(this).val());
+  });
+  return _fileHolder.files;
+}
+
+
+function hasUniqueFileName(fileName){
+  let nameHolders = $(".fileName").toArray();
+  for (let i = 0; i < nameHolders.length; i++){
+    if (fileName == $(nameHolders[i]).val()) return false;
+  }
+  return true;
+}
+
+
+
 /*
  * Run when the webpage is ready for javascript
  */
@@ -71,58 +90,55 @@ $(document).ready(function() {
     calculateRecurringEventFrequency();
   }
 
-    // $("#attachmentObject").fileinput({
-    //     allowedFileExtensions:["pdf","jpg","png","gif", "csv", "docx", "jpg", "jpeg", "jfif"]
-    // })
-
     var fileNum = 0;
-    var filesDict = new DataTransfer();
     $("#attachmentObject").on('change', function() {
-      const selectedFiles = $("#attachmentObject").prop('files'); // TODO: see if we can append file data by reading the list and appending to it.
-      console.log($("#attachmentObject"));
-      
+      const selectedFiles = $("#attachmentObject").prop('files');
       for (let i = 0; i < selectedFiles.length; i++) {
-        
         const file = selectedFiles[i];
-        let fileName = (file.name.length > 25) ? file.name.slice(0,10) + '...' + file.name.slice(-10) : file.name;
-        let fileExtension = file.name.split(".").pop();
-        let iconClass = '';
-        switch(fileExtension) {
-          case 'jpg': 
-          case 'png':
-          case 'jpeg':
-            iconClass = "bi-file-image";
-            break
-          case 'pdf':
-            iconClass = 'bi-filetype-pdf';
-            break
-          case 'docx':
-            iconClass = 'bi-filetype-docx';
-            break
-          case 'xlsx':
-            iconClass = 'bi-filetype-xlsx';
-            break
-          default:
-            iconClass = 'bi-file-earmark-arrow-up';
+        if (hasUniqueFileName(file.name)){
+          let fileName = (file.name.length > 25) ? file.name.slice(0,10) + '...' + file.name.slice(-10) : file.name;
+          let fileExtension = file.name.split(".").pop();
+          let iconClass = '';
+          switch(fileExtension) {
+            case 'jpg': 
+            case 'png':
+            case 'jpeg':
+              iconClass = "bi-file-image";
+              break
+            case 'pdf':
+              iconClass = 'bi-filetype-pdf';
+              break
+            case 'docx':
+              iconClass = 'bi-filetype-docx';
+              break
+            case 'xlsx':
+              iconClass = 'bi-filetype-xlsx';
+              break
+            default:
+              iconClass = 'bi-file-earmark-arrow-up';
+          }
+          $("#attachedObjectContainer").append("<div class='border row p-0 m-0' id='attachedFilesRow" +fileNum+"'></div>")
+          $("#attachedFilesRow"+fileNum).append("<i class='col-auto fs-3 px-3 bi " + iconClass + "'></i>")
+          $("#attachedFilesRow"+fileNum).append("<div id='attachedFile" + fileNum + "' class='fileName col-auto pt-2'>" + fileName + "</div>");
+          $("#attachedFile"+fileNum).val(file.name);
+          $("#attachedFilesRow"+fileNum).append("<div class='col' style='text-align:right'> \
+                                                  <div class='btn btn-danger fileHolder p-1 my-1 mx-1' id='trash" + fileNum + "' >\
+                                                    <span class='bi bi-trash fs-6'></span>\
+                                                  </div>\
+                                                </div>")
+          $("#trash"+fileNum).val(file);
+          $("#trash"+fileNum).on("click", function() {
+            let elementFileNum = $(this).prop("id").split("trash")[1];
+            $("#attachedFilesRow" + elementFileNum).remove();
+            $("#attachmentObject").prop('files', getSelectedFiles);
+          })
+          fileNum++;
         }
-        console.log(fileExtension);
-        $("#attachedObjectContainer").append("<div class='border row p-0 m-0' id='attachedFilesRow" +fileNum+"'></div>")
-        $("#attachedFilesRow"+fileNum).append("<i class='col-auto fs-3 px-3 bi " + iconClass + "'></i>")
-        $("#attachedFilesRow"+fileNum).append("<div id='attachedFile" + fileNum + "' class='attached-file col-auto pt-2' value='" + file.name + "'>" + fileName + "</div>");
-        $("#attachedFilesRow"+fileNum).append("<div class='col' style='text-align:right'> \
-                                                <div class='btn btn-danger p-1 my-1 mx-1' value='"+fileNum+"' id='trash"+ fileNum +"''>\
-                                                  <span class='bi bi-trash fs-6'></span>\
-                                                </div>\
-                                              </div>")
-        $("#trash"+fileNum).on("click", function() {
-          $("#attachedFilesRow"+$(this).val).remove();}
-          // console.log($(this).val); }
-        )
-        fileNum++;
-        filesDict.items.add(file);
+        else{
+          msgFlash("File with filename '" + file.name + "' has already been added to this event")
+        }
       }
-      console.log(filesDict);
-      $("#attachmentObject").prop('files', filesDict.files);
+      $("#attachmentObject").prop('files', getSelectedFiles);
     });
 
 
@@ -138,8 +154,7 @@ $(document).ready(function() {
 
   // Disable button when we are ready to submit
   $("#saveEvent").on('submit',function(event) {
-      $(this).find("input[type=submit]").prop("disabled", true);
-
+    $(this).find("input[type=submit]").prop("disabled", true);
   });
 
   $("#checkIsRecurring").click(function() {

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -69,9 +69,24 @@ $(document).ready(function() {
     calculateRecurringEventFrequency();
   }
 
-    $("#attachmentObject").fileinput({
-        allowedFileExtensions:["pdf","jpg","png","gif", "csv", "docx", "jpg", "jpeg", "jfif"]
-    })
+    // $("#attachmentObject").fileinput({
+    //     allowedFileExtensions:["pdf","jpg","png","gif", "csv", "docx", "jpg", "jpeg", "jfif"]
+    // })
+
+    var fileNum = 0;
+    $("#attachmentObject").on('change', function() {
+      const selectedFiles = $("#attachmentObject").prop('files'); // TODO: see if we can append file data by reading the list and appending to it.
+      
+      for (let i = 0; i < selectedFiles.length; i++) {
+        const file = selectedFiles[i];
+        const fileName = file.name;
+        console.log(file)
+  
+        $("#attachedObjectContainer").append("<div id='attachedFile" + fileNum + "' class='attached-file col' data-file>" + fileName + "</div>")
+        $("#attachedFile" + fileNum).prop("data-file", file)
+        fileNum++;
+      }
+    });
 
     $("#checkRSVP").on("click", function() {
       if ($("#checkRSVP").is(":checked")) {

--- a/app/templates/admin/createEvent.html
+++ b/app/templates/admin/createEvent.html
@@ -253,7 +253,7 @@
                   {% for key, value in filepaths.items() %}
                       <tr id="attachment_{{value[1]}}" class="attachmentRow_{{key}}" data-id= "{{key}}">
                           <td class="pr-5">
-                              <a class="mr-5 fileName" value='{{key}}' href="{{value[0]}}" target="_blank">{{key}}</a>
+                              <a class="mr-5 fileName" data-filename='{{key}}' href="{{value[0]}}" target="_blank">{{key}}</a>
                           </td>
                           <td style="text-align:center">
                             <button

--- a/app/templates/admin/createEvent.html
+++ b/app/templates/admin/createEvent.html
@@ -27,7 +27,6 @@
 {% block scripts %}
   {{super()}}
   <script type="module" src="/static/js/createEvents.js"></script>
-  <script src="https://cdn.jsdelivr.net/gh/kartik-v/bootstrap-fileinput@5.5.0/js/fileinput.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/timepicker/1.3.5/jquery.timepicker.min.js"></script>
 
 {% endblock %}
@@ -243,34 +242,33 @@
             </div>
            {% endif %}
             <div class="form-group mb-5">
-                <div class="file-upload-wrapper">
-                <label class="form-label mb-2" for='attachmentObject'><strong>Add Files</strong></label>
-                <input type="file" id="attachmentObject" name="attachmentObject" multiple accept= ".png, .jpg, .pdf, .jpeg, .docx, .xlsx"/>
-                </div>
+              <label class="mb-2" for='attachmentObject'><strong>Add Files</strong></label>
+              <input type="file" class="form-control" id="attachmentObject" name="attachmentObject" multiple accept= ".png, .jpg, .pdf, .jpeg, .docx, .xlsx"/>
+              <div id="attachedObjectContainer"></div>
             </div>
-            {% if filepaths %}
-            <div class="form-group mb-5">
-                <label class="mb-2" for= "eventAttachments"><strong>Event Attachments</strong></label>
-                <table>
-                    {% for key, value in filepaths.items() %}
-                        <tr id="attachment_{{value[1]}}" class="attachmentRow_{{key}}" data-id= "{{key}}">
-                            <td class="pr-5">
-                                <a class="mr-5" href="{{value[0]}}" target="_blank">{{key}}</a>
-                            </td>
-                            <td style="text-align:center">
-                              <button
-                                data-id="{{value[1]}}"
-                                type="button"
-                                class="removeAttachment btn btn-danger btn-sm"
-                                id={{eventData.id}}>
-                                  <i class="bi bi-trash h5 align-middle"></i>
-                              </button>
-                            </td>
-                        </tr>
-                    {% endfor %}
-                </table>
-              </div>
-              {% endif %}
+          {% if filepaths %}
+          <div class="form-group mb-5">
+              <label class="mb-2" for= "eventAttachments"><strong>Event Attachments</strong></label>
+              <table>
+                  {% for key, value in filepaths.items() %}
+                      <tr id="attachment_{{value[1]}}" class="attachmentRow_{{key}}" data-id= "{{key}}">
+                          <td class="pr-5">
+                              <a class="mr-5" href="{{value[0]}}" target="_blank">{{key}}</a>
+                          </td>
+                          <td style="text-align:center">
+                            <button
+                              data-id="{{value[1]}}"
+                              type="button"
+                              class="removeAttachment btn btn-danger btn-sm"
+                              id={{eventData.id}}>
+                                <i class="bi bi-trash h5 align-middle"></i>
+                            </button>
+                          </td>
+                      </tr>
+                  {% endfor %}
+              </table>
+            </div>
+            {% endif %}
           </div>
         </div>
     <div class="row justify-content-left mt-2">

--- a/app/templates/admin/createEvent.html
+++ b/app/templates/admin/createEvent.html
@@ -253,7 +253,7 @@
                   {% for key, value in filepaths.items() %}
                       <tr id="attachment_{{value[1]}}" class="attachmentRow_{{key}}" data-id= "{{key}}">
                           <td class="pr-5">
-                              <a class="mr-5" href="{{value[0]}}" target="_blank">{{key}}</a>
+                              <a class="mr-5 fileName" value='{{key}}' href="{{value[0]}}" target="_blank">{{key}}</a>
                           </td>
                           <td style="text-align:center">
                             <button

--- a/app/templates/admin/createEvent.html
+++ b/app/templates/admin/createEvent.html
@@ -244,7 +244,7 @@
             <div class="form-group mb-5">
               <label class="mb-2" for='attachmentObject'><strong>Add Files</strong></label>
               <input type="file" class="form-control" id="attachmentObject" name="attachmentObject" multiple accept= ".png, .jpg, .pdf, .jpeg, .docx, .xlsx"/>
-              <div id="attachedObjectContainer"></div>
+              <div id="attachedObjectContainer" class="py-0 px-0"></div>
             </div>
           {% if filepaths %}
           <div class="form-group mb-5">

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
     <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
     <link rel="stylesheet" href="{{url_for('static', filename ='css/bootstrap.min.css') }}?u={{lastStaticUpdate}}">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.css">
     <link rel="stylesheet" href="{{url_for('static', filename ='css/base.css') }}?u={{lastStaticUpdate}}">
     <link rel="stylesheet" href="{{url_for('static', filename ='css/sidebar.css') }}?u={{lastStaticUpdate}}">
   {% endblock %}


### PR DESCRIPTION
Issue: The file upload box was a krajee plugin that we were using to take care of the file uploads. Unfortunately, this box was very big and took up too much space on the page. Double unfortunate was that there was no in-house way to resize that file-upload input tag. Therefore, we needed to replace it.

Fix: Chris and I overhauled the previous file upload box and replaced it with our own, superior version. Ours doesn't have the big drag-and-drop bar but still has the functionality. When you add a file, the file appears below the select file bar. The file input doesn't allow duplicate filenames to be uploaded. The file upload box also works on Firefox.

To Test: Create an event and add some attachments of varying file types to verify that the correct file icons appear for different files. Ensure that the files save correctly.