### PR TITLE
Fixed All Volunteer and Other CELTS Events event creation

### DIFF
--- a/app/controllers/admin/routes.py
+++ b/app/controllers/admin/routes.py
@@ -74,8 +74,7 @@ def createEvent(templateid, programid=None):
     # Get the data from the form or from the template
     eventData = template.templateData
 
-    if program:
-        eventData['program'] = program
+    eventData['program'] = program
 
     if request.method == "GET":
         eventData['contactName'] = "CELTS Admin"
@@ -125,7 +124,7 @@ def createEvent(templateid, programid=None):
     futureTerms = selectSurroundingTerms(g.current_term, prevTerms=0)
 
     requirements, bonnerCohorts = [], []
-    if 'program' in eventData and eventData['program'].isBonnerScholars:
+    if eventData['program'] is not None and eventData['program'].isBonnerScholars:
         requirements = getCertRequirements(Certification.BONNER)
         bonnerCohorts = getBonnerCohorts(limit=5)
     return render_template(f"/admin/{template.templateFile}",

--- a/app/logic/events.py
+++ b/app/logic/events.py
@@ -108,7 +108,7 @@ def attemptSaveEvent(eventData, attachmentFiles = None):
 
         return events, " "
     except Exception as e:
-        print(e)
+        print(f'Failed attemptSaveEvent() with Exception:{e}')
         return False, e
 
 def saveEventToDb(newEventData):

--- a/app/templates/eventNav.html
+++ b/app/templates/eventNav.html
@@ -6,7 +6,7 @@
 
     <{{bigh}} class="mb-0" id="title">{{page_title}}</{{bigh}}>
     {% if not isNewEvent %}
-        {% set programName = "CELTS-Sponsored" if "program" not in eventData else eventData["program"].programName %}
+        {% set programName = "CELTS-Sponsored" if eventData["program"] == None else eventData["program"].programName %}
         {% set prefix = "An" if programName[0] in 'aeiouAEIOU' else "A" %}
         <{{smallh}} class="text-muted">{{prefix}} {{ programName }} Event</{{smallh}}>
     {% endif %}

--- a/database/base_data.py
+++ b/database/base_data.py
@@ -46,7 +46,7 @@ templates = [
         "id": 2,
         "name": "All Volunteer Training",
         "tag": "all-volunteer",
-        "templateJSON": '{"name": "All Volunteer Training","description": "Training for all CELTS programs", "isTraining": true, "isService": false, "isRequired": true, "isAllVolunteerTraining": true}',
+        "templateJSON": '{"name": "All Volunteer Training","description": "Training for all CELTS programs", "isTraining": true, "isService": false, "isRequired": true, "isAllVolunteerTraining": true, "rsvpLimit": ""}',
         "templateFile": "createEvent.html",
         "isVisible": True
     },
@@ -54,7 +54,7 @@ templates = [
         "id": 3,
         "name": "CELTS-Sponsored Event",
         "tag": "no-program",
-        "templateJSON": "{}",
+        "templateJSON":'{}',
         "templateFile": "createEvent.html",
         "isVisible": True
     },


### PR DESCRIPTION
## Issue: 
- Got `'rsvpLimit'` error when creating All Volunteer Event and `'program'` error when creating an All Volunteer Event or a CELTS-Sponsored Event. 

## Did: 
- Added a default of null to `rsvpLimit` on All Volunteer Event template in `base_data.py`. 
- Removed `if program:` check in the `/create` route in `admin/routes.py` and just set `eventData["program"]` = to the program. 
- Added specificity to the error print of the `attemptSaveEvent()` function in `logic/events.py`.
- Fixed the checks that broke due to the removal of the check in `admin/routes.py` since they could not deal with an `eventData["program"]` of NULL.

## To Test:
- Checkout fixOtherCeltsEvents branch and run `source setup.sh`
- Run `datababase/reset_database.sh test` and `tests/run_tests.sh` and verify nothing is broken. 
- Run `flask run`
- Create All Volunteer Training events and CELTS-Sponsored Events and verify they are created as expected and all the event pages function correctly. 