### PR TITLE
Saving files for courses and events without duplication

### DIFF
--- a/app/logic/fileHandler.py
+++ b/app/logic/fileHandler.py
@@ -25,6 +25,7 @@ class FileHandler:
         except OSError as e:
             if e.errno != 17:
                 print(f'Fail to create directory: {e}')
+                raise e
         
 
     def getFileFullPath(self, newfilename = ''):

--- a/app/logic/fileHandler.py
+++ b/app/logic/fileHandler.py
@@ -16,11 +16,12 @@ class FileHandler:
             self.path = os.path.join(self.path, app.config['files']['event_attachment_path'])
         
     def makeDirectory(self):
-        # Creating the directory when call in saveFiles
+        # This creates a directory. 
+        # Created to remove duplicates when an event is recurring.
         try:
             extraDir = str(self.eventId) if self.eventId else ""
             os.makedirs(os.path.join(self.path, extraDir))
-        # Occurs when we try to create a directory that already exists
+        # Error 17 Occurs when we try to create a directory that already exists
         except OSError as e:
             if e.errno != 17:
                 print(f'Fail to create directory: {e}')

--- a/app/logic/fileHandler.py
+++ b/app/logic/fileHandler.py
@@ -20,11 +20,10 @@ class FileHandler:
         try:
             extraDir = str(self.eventId) if self.eventId else ""
             os.makedirs(os.path.join(self.path, extraDir))
-        # Passing if the error is 17
+        # Occurs when we try to create a directory that already exists
         except OSError as e:
             if e.errno != 17:
                 pass
-            # Perform additional error handling if needed
         
 
     def getFileFullPath(self, newfilename = ''):
@@ -42,7 +41,7 @@ class FileHandler:
             pass
         except FileExistsError:
             pass
-
+  
         return filePath
 
     def saveFiles(self, saveOriginalFile=None):
@@ -69,13 +68,12 @@ class FileHandler:
                         AttachmentUpload.create(course = self.courseId, fileName = file.filename)
                         saveFileToFilesystem = file.filename
                 
-                # Creating directory and saving file for events and courses
+                # Creating directory and save the file to the filesystem if 'saveFileToFilesystem' is True.
                 if saveFileToFilesystem:
                     self.makeDirectory()
                     file.save(self.getFileFullPath(newfilename = saveFileToFilesystem))        
                         
         except AttributeError: # will pass if there is no attachment to save
-            
             pass
 
     def retrievePath(self,files):

--- a/app/logic/fileHandler.py
+++ b/app/logic/fileHandler.py
@@ -22,9 +22,7 @@ class FileHandler:
             os.makedirs(os.path.join(self.path, extraDir))
         # Occurs when we try to create a directory that already exists
         except OSError as e:
-            if e.errno == 17:
-                pass
-            else:
+            if e.errno != 17:
                 print(f'Fail to create directory: {e}')
         
 

--- a/app/logic/fileHandler.py
+++ b/app/logic/fileHandler.py
@@ -22,8 +22,10 @@ class FileHandler:
             os.makedirs(os.path.join(self.path, extraDir))
         # Occurs when we try to create a directory that already exists
         except OSError as e:
-            if e.errno != 17:
+            if e.errno == 17:
                 pass
+            else:
+                print(f'Fail to create directory: {e}')
         
 
     def getFileFullPath(self, newfilename = ''):
@@ -68,7 +70,6 @@ class FileHandler:
                         AttachmentUpload.create(course = self.courseId, fileName = file.filename)
                         saveFileToFilesystem = file.filename
                 
-                # Creating directory and save the file to the filesystem if 'saveFileToFilesystem' is True.
                 if saveFileToFilesystem:
                     self.makeDirectory()
                     file.save(self.getFileFullPath(newfilename = saveFileToFilesystem))        

--- a/tests/code/test_fileHandler.py
+++ b/tests/code/test_fileHandler.py
@@ -47,9 +47,11 @@ def test_makingdirectory():
     eventFileStorage= [FileStorage(filename= "eventfile.pdf")]
     handledEventAttachment = FileHandler(eventFileStorage, eventId=90)
     handledEventAttachment.makeDirectory()
+    handledEventAttachment.makeDirectory()
     assert os.path.exists('app/static/files/eventattachments/90') == True
     # Deleting the directory
     os.rmdir('app/static/files/eventattachments/90')
+    
     
 @pytest.mark.integration
 def test_saveFiles():

--- a/tests/code/test_fileHandler.py
+++ b/tests/code/test_fileHandler.py
@@ -38,13 +38,19 @@ def test_getFileFullPath():
 @pytest.mark.integration
 def test_makingdirectory():
     #Testing that the file is created and it exists
-        
-    handledEventFile.makeDirectory()
-    handledEventFile.makeDirectory() 
-    assert os.path.exists('app/static/files/eventattachments/15')== True
+    event_id = 90
+    path = 'app/static/files/eventattachments/'
+    # Ensure the directory does not exist before calling makeDirectory
+    assert os.path.exists(os.path.join(path, str(event_id))) == False
     
-
-
+    # Creating directory and making sure it exist
+    eventFileStorage= [FileStorage(filename= "eventfile.pdf")]
+    handledEventAttachment = FileHandler(eventFileStorage, eventId=90)
+    handledEventAttachment.makeDirectory()
+    assert os.path.exists('app/static/files/eventattachments/90') == True
+    # Deleting the directory
+    os.rmdir('app/static/files/eventattachments/90')
+    
 @pytest.mark.integration
 def test_saveFiles():
     with mainDB.atomic() as transaction:

--- a/tests/code/test_fileHandler.py
+++ b/tests/code/test_fileHandler.py
@@ -35,6 +35,16 @@ def test_getFileFullPath():
     filePath = handledCourseFile.getFileFullPath(courseFileStorageObject[0].filename)
     assert filePath == 'app/static/files/courseattachments/1/coursefile.pdf'
 
+@pytest.mark.integration
+def test_makingdirectory():
+    #Testing that the file is created and it exists
+    with mainDB.atomic() as transaction:
+        
+        handledEventFile.makeDirectory()
+        handledEventFile.makeDirectory()
+
+        
+        transaction.rollback()
 
 @pytest.mark.integration
 def test_saveFiles():

--- a/tests/code/test_fileHandler.py
+++ b/tests/code/test_fileHandler.py
@@ -38,13 +38,12 @@ def test_getFileFullPath():
 @pytest.mark.integration
 def test_makingdirectory():
     #Testing that the file is created and it exists
-    with mainDB.atomic() as transaction:
         
-        handledEventFile.makeDirectory()
-        handledEventFile.makeDirectory()
+    handledEventFile.makeDirectory()
+    handledEventFile.makeDirectory() 
+    assert os.path.exists('app/static/files/eventattachments/15')==True
+    
 
-        
-        transaction.rollback()
 
 @pytest.mark.integration
 def test_saveFiles():

--- a/tests/code/test_fileHandler.py
+++ b/tests/code/test_fileHandler.py
@@ -41,7 +41,7 @@ def test_makingdirectory():
         
     handledEventFile.makeDirectory()
     handledEventFile.makeDirectory() 
-    assert os.path.exists('app/static/files/eventattachments/15')==True
+    assert os.path.exists('app/static/files/eventattachments/15')== True
     
 
 


### PR DESCRIPTION
Resolve issue #972 
Did:
-  Check where the attachment is being saved for a recursive event
- Create a function makeDirectory to create the directory when being called to avoid duplicate events and course
- Created a condition to call makeDirectory function and to savefiles
- Created a test to make sure that the file is created and is not duplicated
- Ran tests and all passed
- Remove Comments
- Added Comments