### PR TITLE
Removed call to program.id which should have been program.

### DIFF
--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -45,7 +45,7 @@ def landingPage():
 
 
     eventsInTerm = list(Event.select().where(Event.term == g.current_term))
-    programsWithEventsList = [program.program for program in eventsInTerm if not program.isPast]
+    programsWithEventsList = [event.program for event in eventsInTerm if not event.isPast]
 
     return render_template("/main/landingPage.html", managerProgramDict = managerProgramDict,
                                                      term = g.current_term,

--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -45,7 +45,7 @@ def landingPage():
 
 
     eventsInTerm = list(Event.select().where(Event.term == g.current_term))
-    programsWithEventsList = [program.program for program in eventsInTerm]
+    programsWithEventsList = [program.program for program in eventsInTerm if not program.isPast]
 
     return render_template("/main/landingPage.html", managerProgramDict = managerProgramDict,
                                                      term = g.current_term,

--- a/app/templates/main/landingPage.html
+++ b/app/templates/main/landingPage.html
@@ -28,14 +28,14 @@
       </div>
       <div class="card-footer text-center">
         {% if not program.isBonnerScholars %}
-          {% if program.id in programsWithEventsList %}
+          {% if program in programsWithEventsList %}
             <a class="btn btn-primary m-auto eventsListButton" data-term="{{term.id}}" data-program_id="{{program.id}}">View Events</a>
           {% else %}
             <a class="btn btn-secondary m-auto disabled">No Upcoming Events</a>
           {% endif %}
         {% else %}
           {% if g.current_user.isBonnerScholar %}
-            {% if program.id in programsWithEventsList %}
+            {% if program in programsWithEventsList %}
               <a class="btn btn-primary m-auto eventsListButton" data-term="{{term.id}}" data-program_id="{{program.id}}">View Events</a>
             {% else %}
               <a class="btn btn-secondary m-auto disabled">No Upcoming Events</a>

--- a/app/templates/main/landingPage.html
+++ b/app/templates/main/landingPage.html
@@ -29,14 +29,14 @@
       <div class="card-footer text-center">
         {% if not program.isBonnerScholars %}
           {% if program in programsWithEventsList %}
-            <a class="btn btn-primary m-auto eventsListButton" data-term="{{term.id}}" data-program_id="{{program.id}}">View Events</a>
+            <a class="btn btn-primary m-auto eventsListButton" data-term="{{term.id}}" data-program_id="{{program.id}}">View Upcoming Events</a>
           {% else %}
             <a class="btn btn-secondary m-auto disabled">No Upcoming Events</a>
           {% endif %}
         {% else %}
           {% if g.current_user.isBonnerScholar %}
             {% if program in programsWithEventsList %}
-              <a class="btn btn-primary m-auto eventsListButton" data-term="{{term.id}}" data-program_id="{{program.id}}">View Events</a>
+              <a class="btn btn-primary m-auto eventsListButton" data-term="{{term.id}}" data-program_id="{{program.id}}">View Upcoming Events</a>
             {% else %}
               <a class="btn btn-secondary m-auto disabled">No Upcoming Events</a>
             {% endif %}


### PR DESCRIPTION
Issue: The issue was that upcoming events weren't showing up on the landing page. There was an incorrect call to the program.id instead of program.

Fix: Changed call from program.id to program. Additionally added check to see if event was in past in the list comprehension passed to the landing page.

Test: Add new events in the future and ensure that they display appropriately.

Resolves #1002 