### PR TITLE
Turn email on View Events page into mailtolink

### DIFF
--- a/app/templates/eventView.html
+++ b/app/templates/eventView.html
@@ -122,7 +122,7 @@
                 <div class="col-md-6">
                     {% if eventData.contactName and eventData.contactEmail %}
                         <h3>Contact Information:</h3>
-                        <div>{{eventData.contactName}} - {{eventData.contactEmail}}</div>
+                        <div>{{eventData.contactName}} - <a href="mailto:{{eventData.contactEmail}}" class="text-dark">{{eventData.contactEmail}}</a></div>
                     {% endif %}
                     <br>
                 </div>


### PR DESCRIPTION
This pull request enhances the user experience by converting plain email in View Events Page into a clickable "mailto" link. This allows users to access the main contact of a specific event whenever that is needed. 

Changes:
- Modify the code in eventView.html file and add link tag
- Insert contact email inside link tag as a target for the mailtolink
- Resolves issue #1028  