### PR TITLE
Attendance Limit for RSVP

### DIFF
--- a/app/templates/admin/createEvent.html
+++ b/app/templates/admin/createEvent.html
@@ -222,7 +222,7 @@
                     {% set hide = "" if eventData.isRsvpRequired else "display: none" %}
                     <div class="form-group" id="limitGroup" style= "{{hide}}">
                       <label class="form-label mt-2" for='limitRsvp'><strong>Attendance Limit</strong></label>
-                      <input class="form-control mb-2" type="number" id="limitRsvp" name="rsvpLimit" value="{{eventData.rsvpLimit}}" placeholder="No Limit"></input>
+                      <input class="form-control mb-2" type="number" id="limitRsvp" name="rsvpLimit" value="{{eventData.rsvpLimit}}" min="0" placeholder="No Limit"></input>
                     </div>
                     <label class="custom-control-label" for="checkFood"><strong>This event will provide food.</strong></label>
                     <input class="form-check-input" type="checkbox" id="checkFood" name="isFoodProvided" {{"checked" if eventData.isFoodProvided}}/>

--- a/app/templates/admin/createEvent.html
+++ b/app/templates/admin/createEvent.html
@@ -222,7 +222,7 @@
                     {% set hide = "" if eventData.isRsvpRequired else "display: none" %}
                     <div class="form-group" id="limitGroup" style= "{{hide}}">
                       <label class="form-label mt-2" for='limitRsvp'><strong>Attendance Limit</strong></label>
-                      <input class="form-control mb-2" type="number" id="limitRsvp" name="rsvpLimit" value="{{eventData.rsvpLimit}}" min="0" placeholder="No Limit"></input>
+                      <input class="form-control mb-2" type="number" id="limitRsvp" name="rsvpLimit" value="{{eventData.rsvpLimit}}" min="0" placeholder="No Limit" pattern="^[0-9]+$"></input>
                     </div>
                     <label class="custom-control-label" for="checkFood"><strong>This event will provide food.</strong></label>
                     <input class="form-check-input" type="checkbox" id="checkFood" name="isFoodProvided" {{"checked" if eventData.isFoodProvided}}/>


### PR DESCRIPTION
While creating a new event, the user is able to check the RSVP toggle and add an attendance limit for that event. This pull request addresses the instance where the user chooses a negative number for attendance limit.

Changes:
-add "min" attribute to the code in createEvent.html file to set a limit for attendance limit (which is zero in that case).
-Resolves issue #1017 