### PR TITLE
Change of flash message for multiple added volunteers

### DIFF
--- a/app/controllers/admin/volunteers.py
+++ b/app/controllers/admin/volunteers.py
@@ -142,16 +142,33 @@ def addVolunteer(eventId):
     usernameList = request.form.getlist("volunteer[]")
 
     successfullyAddedVolunteer = False
+    alreadyAddedList = []
+    addedSuccessfullyList = []
+    errorList = []
+    
     for user in usernameList:
         userObj = User.get_by_id(user)
         successfullyAddedVolunteer = addPersonToEvent(userObj, event)
         if successfullyAddedVolunteer == "already in":
-            flash(f"{userObj.fullName} already in table.", "warning")
+            alreadyAddedList.append(userObj.fullName)
         else:
             if successfullyAddedVolunteer:
-                flash(f"{userObj.fullName} added successfully.", "success")
+                addedSuccessfullyList.append(userObj.fullName)
             else:
-                flash(f"Error when adding {userObj.fullName} to event." ,"danger")
+                errorList.append(userObj.fullName)
+
+    volunteers = ""
+    if alreadyAddedList:
+        volunteers = ", ".join(vol for vol in alreadyAddedList)
+        flash(f"{volunteers} already in table.", "warning")
+
+    if addedSuccessfullyList:
+        volunteers = ", ".join(vol for vol in addedSuccessfullyList)
+        flash(f"{volunteers} added successfully.", "success")
+    
+    if errorList:
+        volunteers = ", ".join(vol for vol in errorList)
+        flash(f"{volunteers} to event.", "danger")
 
     if 'ajax' in request.form and request.form['ajax']:
         return ''

--- a/app/controllers/admin/volunteers.py
+++ b/app/controllers/admin/volunteers.py
@@ -168,7 +168,7 @@ def addVolunteer(eventId):
     
     if errorList:
         volunteers = ", ".join(vol for vol in errorList)
-        flash(f"{volunteers} to event.", "danger")
+        flash(f"Error when adding {volunteers} to event.", "danger")
 
     if 'ajax' in request.form and request.form['ajax']:
         return ''


### PR DESCRIPTION
If multiple volunteers were added for an event, there will be multiple flash messages whose numbers are tantamount to that of the volunteers. 
This pull request ensures that there is a single flash message, regardless of the number of volunteers who were added. Hence, the user will be able to see all the names of the volunteers in a single flash message that will displayed at the top of the screen.

- Changes volunteer.py file by using three lists that keep track of volunteers and triggering three conditional statements for this PR objective.
- Resolves issue #1020 