### PR TITLE
Allow Student Staff to be added as CELTS-Link Admin through the UI

### DIFF
--- a/app/controllers/admin/userManagement.py
+++ b/app/controllers/admin/userManagement.py
@@ -23,29 +23,29 @@ def manageUsers():
         return ("danger", 500)
 
     if method == "addCeltsAdmin":
-        if user.isStudent:
-            flash(user.firstName + " " + user.lastName + " cannot be added as a Celts admin", 'danger')
+        if user.isStudent and not user.isCeltsStudentStaff: 
+            flash(user.firstName + " " + user.lastName + " cannot be added as a CELTS-Link admin", 'danger')
         else:
             if user.isCeltsAdmin:
-                flash(user.firstName + " " + user.lastName + " is already a Celts Admin", 'danger')
-            else:
+                flash(user.firstName + " " + user.lastName + " is already a CELTS-Link Admin", 'danger')
+            else: 
                 addCeltsAdmin(user)
-                flash(user.firstName + " " + user.lastName + " has been added as a Celts Admin", 'success')
+                flash(user.firstName + " " + user.lastName + " has been added as a CELTS-Link Admin", 'success')
     elif method == "addCeltsStudentStaff":
         if not user.isStudent:
-            flash(username + " cannot be added as Celts Student Staff", 'danger')
+            flash(username + " cannot be added as CELTS Student Staff", 'danger')
         else:
             if user.isCeltsStudentStaff:
-                flash(user.firstName + " " + user.lastName + " is already a Celts Student Staff", 'danger')
+                flash(user.firstName + " " + user.lastName + " is already a CELTS Student Staff", 'danger')
             else:
                 addCeltsStudentStaff(user)
-                flash(user.firstName + " " + user.lastName + " has been added as a Celts Student Staff", 'success')
+                flash(user.firstName + " " + user.lastName + " has been added as a CELTS Student Staff", 'success')
     elif method == "removeCeltsAdmin":
         removeCeltsAdmin(user)
-        flash(user.firstName + " " + user.lastName + " is no longer a Celts Admin ", 'success')
+        flash(user.firstName + " " + user.lastName + " is no longer a CELTS Admin ", 'success')
     elif method == "removeCeltsStudentStaff":
         removeCeltsStudentStaff(user)
-        flash(user.firstName + " " + user.lastName + " is no longer a Celts Student Staff", 'success')
+        flash(user.firstName + " " + user.lastName + " is no longer a CELTS Student Staff", 'success')
     return ("success")
 
 @admin_bp.route('/addProgramManagers', methods=['POST'])
@@ -75,10 +75,10 @@ def updateProgramInfo(programID):
     if g.current_user.isCeltsAdmin:
         try:
             changeProgramInfo(programInfo["programName"],  #calls logic function to add data to database
-                                    programInfo["contactEmail"],
-                                    programInfo["contactName"],
-                                    programInfo["location"],
-                                    programID)
+                              programInfo["contactEmail"],
+                              programInfo["contactName"],
+                              programInfo["location"],
+                              programID)
 
             flash("Program updated", "success")
             return redirect(url_for("admin.userManagement", accordion="program"))

--- a/app/logic/searchUsers.py
+++ b/app/logic/searchUsers.py
@@ -22,6 +22,8 @@ def searchUsers(query, category=None):
         userWhere = (User.isCeltsAdmin)
     elif category == "studentstaff":
         userWhere = (User.isCeltsStudentStaff)
+    elif category == "celtsLinkAdmin":
+        userWhere = (User.isFaculty | User.isStaff | User.isCeltsStudentStaff)
     else:
         userWhere = (User.isStudent)
 

--- a/app/static/js/userManagement.js
+++ b/app/static/js/userManagement.js
@@ -9,7 +9,7 @@ function callbackStudentStaff(selected){
 $(document).ready(function(){
   // Admin Management
   $("#searchCeltsAdminInput").on("input", function(){
-      searchUser("searchCeltsAdminInput", callbackAdmin, false, null, "instructor")
+      searchUser("searchCeltsAdminInput", callbackAdmin, false, null, "celtsLinkAdmin")
   });
   $("#searchCeltsStudentStaffInput").on("input", function(){
       searchUser("searchCeltsStudentStaffInput", callbackStudentStaff, false, null, "student")

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,7 @@ pytest-metadata==1.10.0
 pytest-watch==4.2.0
 python-dateutil==2.8.2
 python-editor==1.0.4
-PyYAML==5.4.1
+PyYAML==6.0.1
 regex ==2023.6.3
 requests==2.25.1
 selenium==3.141.0

--- a/tests/code/test_search.py
+++ b/tests/code/test_search.py
@@ -50,17 +50,19 @@ def test_searchUser_categories():
     assert len(searchResults) == 0
     searchResults = searchUsers('sreyn', 'studentstaff')
     assert len(searchResults) == 0
+    searchResults = searchUsers('sreyn', 'celtsLinkAdmin')
+    assert len(searchResults) == 0
 
     # tests that the search categories include properly
     searchResults = searchUsers('sco', 'instructor') # faculty
     assert searchResults['heggens'] == model_to_dict(User.get_by_id('heggens'))
     searchResults = searchUsers('bri', 'instructor') # staff
     assert searchResults['ramsayb2'] == model_to_dict(User.get_by_id('ramsayb2'))
-
     searchResults = searchUsers('brian', 'admin')
     assert searchResults['ramsayb2'] == model_to_dict(User.get_by_id('ramsayb2'))
-
     searchResults = searchUsers('zach', 'studentstaff')
+    assert searchResults['neillz'] == model_to_dict(User.get_by_id('neillz'))
+    searchResults = searchUsers('za', 'celtsLinkAdmin')
     assert searchResults['neillz'] == model_to_dict(User.get_by_id('neillz'))
 
     # Make sure we are getting into these cases for a non-default category


### PR DESCRIPTION
Issue (there is not GitHub issue associated with this pr): We have been asked fairly regularly to add students as admin so I have allowed student staff to be added by a user without having to ask us for a manual database change. 

Also, there was an outdated dependency that caused GitHub Actions to fail for python versions 10 and 11 so I updated it. 