### PR TITLE
1053 Improve logging for import_users.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ app/static/files/
 local-override.yml
 geckodriver.log
 .coverage
+import_users_log.txt
+


### PR DESCRIPTION
Summary of changes:
- fix #1053 
- Updated `import_user.py` script to use the `logging` module instead of print statements.
- When the script is run, log output is directed to both the terminal and a file named `import_users_log.txt`.

Test:
- Switch to the `production` branch.
- Run the `import_user.py` script.
- Verify that an `import_users_log.txt` file is created.
- Check that the content of the `import_users_log.txt` file matches the output from running the `import_user.py` script.

Please note that this change hasn't been tested on prod as it clearly states:
"DO NOT RUN THIS SCRIPT ON PRODUCTION UNLESS YOU REALLY REALLY KNOW WHAT YOU ARE DOING"
PS: I do not know what I am doing. 