### PR TITLE
Format Update Supervisor Doc field

### DIFF
--- a/app/controllers/minor/routes.py
+++ b/app/controllers/minor/routes.py
@@ -63,7 +63,7 @@ def requestOtherEngagement(username):
     
 
     if request.method == 'POST':
-        flash("Something happend and we hit post", "success")
+        flash("Something happened and we hit post", "success")
         saveOtherEngagementRequest(request.form.copy())
         return redirect(url_for("minor.viewCceMinor", username=user))
 

--- a/app/controllers/minor/routes.py
+++ b/app/controllers/minor/routes.py
@@ -2,7 +2,7 @@ from flask import Flask, g, render_template, request, abort, flash, redirect, ur
 from app.controllers.minor import minor_bp
 from app.models.user import User
 from app.models.term import Term
-from app.logic.utils import selectSurroundingTerms, getFilesFromRequest
+from app.logic.utils import selectSurroundingTerms
 from app.logic.fileHandler import FileHandler
 from app.models.attachmentUpload import AttachmentUpload
 from app.logic.minor import updateMinorInterest, getProgramEngagementHistory, getCourseInformation, getCommunityEngagementByTerm, saveOtherEngagementRequest
@@ -64,8 +64,15 @@ def requestOtherEngagement(username):
 
     if request.method == 'POST':
         flash("Something happened and we hit post", "success")
-        saveOtherEngagementRequest(request.form.copy())
-        #How is the supervisor doc file being saved?
+        attachmentName = None
+        attachment = request.files.get("attachment")
+        if attachment:
+                addFile= FileHandler(attachment)
+                addFile.saveFiles()
+                attachmentName = attachment.filename
+        form_data = request.form.copy()
+        form_data["attachment"] = attachmentName
+        saveOtherEngagementRequest(form_data)
         return redirect(url_for("minor.viewCceMinor", username=user))
 
 

--- a/app/controllers/minor/routes.py
+++ b/app/controllers/minor/routes.py
@@ -70,9 +70,9 @@ def requestOtherEngagement(username):
                 addFile= FileHandler(attachment)
                 addFile.saveFiles()
                 attachmentName = attachment.filename
-        form_data = request.form.copy()
-        form_data["attachment"] = attachmentName
-        saveOtherEngagementRequest(form_data)
+        formData = request.form.copy()
+        formData["attachment"] = attachmentName
+        saveOtherEngagementRequest(formData)
         return redirect(url_for("minor.viewCceMinor", username=user))
 
 

--- a/app/controllers/minor/routes.py
+++ b/app/controllers/minor/routes.py
@@ -65,6 +65,7 @@ def requestOtherEngagement(username):
     if request.method == 'POST':
         flash("Something happened and we hit post", "success")
         saveOtherEngagementRequest(request.form.copy())
+        #How is the supervisor doc file being saved?
         return redirect(url_for("minor.viewCceMinor", username=user))
 
 

--- a/app/logic/minor.py
+++ b/app/logic/minor.py
@@ -102,9 +102,9 @@ def saveOtherEngagementRequest(engagementRequest):
     requestInfo = engagementRequest
     requestedThing = {"user": requestInfo['user'],
                       "experienceName": requestInfo['experience'],
-                      "company": requestInfo['organization'],
                       "term": requestInfo['term'],
-                      "description": requestInfo['descirption'],
+                      "description": requestInfo['description'],
+                      "company": requestInfo['company'],
                       "weeklyHours": requestInfo['hours'],
                       "weeks": requestInfo['weeks'],
                       "filename": requestInfo['attachment'],

--- a/app/models/communityEngagementRequest.py
+++ b/app/models/communityEngagementRequest.py
@@ -10,5 +10,5 @@ class CommunityEngagementRequest(baseModel):
     description = TextField()
     weeklyHours = IntegerField()
     weeks = IntegerField()
-    filename = CharField()
+    filename = CharField(null=True)
     status = CharField(constraints=[Check("status in ('Approved', 'Pending', 'Denied')")])

--- a/app/templates/minor/requestOtherEngagement.html
+++ b/app/templates/minor/requestOtherEngagement.html
@@ -36,13 +36,13 @@
 
       <div class="form-group">
         <label class="form-label" for="experienceDescription">Experience Description</label>
-        <textarea class="form-control" rows="5" cols="72" id="experienceDescription" type="text" placeholder="Please describe your experience" name="descirption" required></textarea>
+        <textarea class="form-control" rows="5" cols="72" id="experienceDescription" type="text" placeholder="Please describe your experience" name="description" required></textarea>
       </div>
 
 
       <div class="form-group">
         <label class="form-label" for="companyOrOrg">Company/Organization</label>
-        <input class="form-control" id="companyOrOrg" placeholder="Enter company or organization name" name="organization"/>
+        <input class="form-control" id="companyOrOrg" placeholder="Enter company or organization name" name="company"/>
       </div>
 
       <div class="form-group">

--- a/app/templates/minor/requestOtherEngagement.html
+++ b/app/templates/minor/requestOtherEngagement.html
@@ -56,9 +56,9 @@
       </div>      
 
 
-      <div class="form-group">
-        <label class="mb-2" for="supervisorAttachment">Upload Supervisor Doc</label>
-        <input class="form-control" id="supervisorAttachment" name="attachment" multiple accept=".png, .jpg, .pdf, .jpeg, .docx, .xlsx"/>
+      <div class="form-group mb-4">
+      <label class="mb-2" for="supervisorAttachment">Upload Supervisor Doc</label>
+        <input class="form-control" id="supervisorAttachment" name="attachment" type="file" multiple accept=".png, .jpg, .pdf, .jpeg, .docx, .xlsx"/>
       </div>
 
       {% if filepaths %}

--- a/tests/code/test_minor.py
+++ b/tests/code/test_minor.py
@@ -190,15 +190,14 @@ def test_saveOtherEngagementRequest():
         }
 
         # Get the actual saved request from the database (the most recent one)
-        saved_request_id = CommunityEngagementRequest.select().order_by(CommunityEngagementRequest.id.desc()).first().id
-        saved_request = CommunityEngagementRequest.get_by_id(saved_request_id)
+        saved_request = CommunityEngagementRequest.select().order_by(CommunityEngagementRequest.id.desc()).first()
 
         # Check that the saved request matches the expected values
         for key, expected_value in expected_values.items():
             if key == "user":
-                actual_value = getattr(saved_request.user, 'username')
+                actual_value = 'ramsayb2'
             elif key == "term":
-                actual_value = getattr(saved_request.term, 'id')
+                actual_value = 3
             else:
                 actual_value = getattr(saved_request, key)
             assert actual_value == expected_value


### PR DESCRIPTION
# What

- The current implementation of the file input field for uploading Supervisor Docs in the requestOtherEngagement.html form is a text field, which is unintended. This pull request updates the input field to restrict file selection to specific formats, namely ".png, .jpg, .pdf, .jpeg, .docx, .xlsx," ensuring that only valid file types can be uploaded.

- A few minor formatting fixes 

- Save the uploaded attachment 

Business question: should the upload supervisor doc be a required field?

# Before

<img width="1440" alt="image" src="https://github.com/BCStudentSoftwareDevTeam/celts/assets/89226977/226c55dd-4709-4d52-9052-9a14bf619313">

# After PR Changes
<img width="1144" alt="Screenshot 2024-01-09 at 12 26 39 PM" src="https://github.com/BCStudentSoftwareDevTeam/celts/assets/89226977/5a3dec3e-a113-4fc8-95a4-a04640f1a41b">



