### PR TITLE
1115 event attachment filenames

### DIFF
--- a/app/static/js/displayFilesMacro.js
+++ b/app/static/js/displayFilesMacro.js
@@ -1,4 +1,5 @@
 $(document).ready(function(){
+    $("a.fileName").tooltip()
     $(".removeAttachment").on("click", function(){
         let fileId=  $(this).data("id")
         let deleteLink = $(this).data("delete-url")

--- a/app/templates/admin/createEvent.html
+++ b/app/templates/admin/createEvent.html
@@ -244,7 +244,8 @@
           {% if filepaths %}
           <div class="form-group mb-5">
             {% from 'displayFilesMacro.html' import displayFiles %}
-            {{ displayFiles(filepaths, 'Event Attachments', '/deleteEventFile', '{{course.id}}') }}
+            <!-- {{eventData.id}} -->
+            {{ displayFiles(filepaths, 'Event Attachments', '/deleteEventFile', eventData.id | string) }}  
           </div>
             {% endif %}
           </div>

--- a/app/templates/admin/createEvent.html
+++ b/app/templates/admin/createEvent.html
@@ -245,7 +245,7 @@
           <div class="form-group mb-5">
             {% from 'displayFilesMacro.html' import displayFiles %}
             <!-- {{eventData.id}} -->
-            {{ displayFiles(filepaths, 'Event Attachments', '/deleteEventFile', eventData.id | string) }}  
+            {{ displayFiles(filepaths, 'Event Attachments', '/deleteEventFile', eventData.id, (eventData.id|string) + "/") }}  
           </div>
             {% endif %}
           </div>

--- a/app/templates/displayFilesMacro.html
+++ b/app/templates/displayFilesMacro.html
@@ -5,13 +5,6 @@
         <td class="py-2 px-3"><strong>{{ titleName }}</strong></td>
     </tr>
     {% for key, value in filepaths.items() %}
-    
-    <!-- beans -->
-    {{filepaths.items() | list}} <br>
-    {{databaseId}}
-
-
-
         <tr id="attachment_{{ value[1] }}" class="attachmentRow_{{ key }}" data-id="{{ key }}">
             <td class="py-2 px-3">
                 {% if value[-1].isDisplayed %}
@@ -26,11 +19,9 @@
                 {% endif %}
             </td>
             <td class="py-2 px-3" >
-                {% set filename = key.removeprefix((databaseId|string) + "/")%} <br>
-                {{(databaseId|string) + "/"}} <br>
-                {{filename}} <br>
-                {% set filename = key[:8] + "..." + key[-10:] if key|length > 25 else key %}
-                <a class="mr-5 fileName" data-filename='{{ key }}' href="{{ value[0] }}" target="_blank">{{ filename }}</a>
+                {% set filename = key.removeprefix((databaseId|string) + "/")%}
+                {% set shortname = filename[:8] + "..." + filename[-10:] if filename|length > 25 else filename %}
+                <a class="mr-5 fileName" data-filename='{{ key }}' href="{{ value[0] }}" target="_blank" data-toggle="tooltip" data-placement="top" title="{{filename}}">{{ shortname }}</a>
             </td>
             <td style="text-align:center">
                 <button

--- a/app/templates/displayFilesMacro.html
+++ b/app/templates/displayFilesMacro.html
@@ -21,7 +21,7 @@
             <td class="py-2 px-3" >
                 {% set filename = key.removeprefix((databaseId|string) + "/")%}
                 {% set shortname = filename[:8] + "..." + filename[-10:] if filename|length > 25 else filename %}
-                <a class="mr-5 fileName" data-filename='{{ key }}' href="{{ value[0] }}" target="_blank" data-toggle="tooltip" data-placement="top" title="{{filename}}">{{ shortname }}</a>
+                <a class="mr-5 fileName" data-filename='{{ filename }}' href="{{ value[0] }}" target="_blank" data-toggle="tooltip" data-placement="top" title="{{filename}}">{{ shortname }}</a>
             </td>
             <td style="text-align:center">
                 <button

--- a/app/templates/displayFilesMacro.html
+++ b/app/templates/displayFilesMacro.html
@@ -1,4 +1,4 @@
-{% macro displayFiles(filepaths, titleName, deleteLink, databaseId)  %}
+{% macro displayFiles(filepaths, titleName, deleteLink, databaseId, prefixToRemove="")  %}
 <table>
     <tr>
         <td class="py-2"><strong>Display</strong></td>
@@ -19,7 +19,7 @@
                 {% endif %}
             </td>
             <td class="py-2 px-3" >
-                {% set filename = key.removeprefix((databaseId|string) + "/")%}
+                {% set filename = key.removeprefix(prefixToRemove) %}
                 {% set shortname = filename[:8] + "..." + filename[-10:] if filename|length > 25 else filename %}
                 <a class="mr-5 fileName" data-filename='{{ filename }}' href="{{ value[0] }}" target="_blank" data-toggle="tooltip" data-placement="top" title="{{filename}}" aria-labelledby="{{filename}}">{{ shortname }}</a>
             </td>

--- a/app/templates/displayFilesMacro.html
+++ b/app/templates/displayFilesMacro.html
@@ -5,6 +5,13 @@
         <td class="py-2 px-3"><strong>{{ titleName }}</strong></td>
     </tr>
     {% for key, value in filepaths.items() %}
+    
+    <!-- beans -->
+    {{filepaths.items() | list}} <br>
+    {{databaseId}}
+
+
+
         <tr id="attachment_{{ value[1] }}" class="attachmentRow_{{ key }}" data-id="{{ key }}">
             <td class="py-2 px-3">
                 {% if value[-1].isDisplayed %}
@@ -19,6 +26,9 @@
                 {% endif %}
             </td>
             <td class="py-2 px-3" >
+                {% set filename = key.removeprefix((databaseId|string) + "/")%} <br>
+                {{(databaseId|string) + "/"}} <br>
+                {{filename}} <br>
                 {% set filename = key[:8] + "..." + key[-10:] if key|length > 25 else key %}
                 <a class="mr-5 fileName" data-filename='{{ key }}' href="{{ value[0] }}" target="_blank">{{ filename }}</a>
             </td>

--- a/app/templates/displayFilesMacro.html
+++ b/app/templates/displayFilesMacro.html
@@ -21,7 +21,7 @@
             <td class="py-2 px-3" >
                 {% set filename = key.removeprefix((databaseId|string) + "/")%}
                 {% set shortname = filename[:8] + "..." + filename[-10:] if filename|length > 25 else filename %}
-                <a class="mr-5 fileName" data-filename='{{ filename }}' href="{{ value[0] }}" target="_blank" data-toggle="tooltip" data-placement="top" title="{{filename}}">{{ shortname }}</a>
+                <a class="mr-5 fileName" data-filename='{{ filename }}' href="{{ value[0] }}" target="_blank" data-toggle="tooltip" data-placement="top" title="{{filename}}" aria-labelledby="{{filename}}">{{ shortname }}</a>
             </td>
             <td style="text-align:center">
                 <button


### PR DESCRIPTION
Issue: Fixes #1115. When files are displayed to the user they are displayed with the event ID as part of the file's path. This ought not to be visible to users and adds too much irrelevant information to the screen. We'd like to remove this event ID and use the original filename. 
Additionally, we abbreviate the filenames of uploaded files for formatting which makes us unable to properly distinguish them later. To fix this, we needed to add a tooltip with the full filename listed.

Solution: I've removed the odd prefix from the filenames by altering the displayFiles macro. Additionally, I've added the tooltip and fixed a small bug where duplicate filenames didn't stop you from adding a file until you saved the page. Now they stop you from uploading a file and it provides you with immediate feedback.

To Test: Go to any event and upload a file. Save the event and ensure that what is displayed is the filename (possibly shortened) without the event ID. Check the tooltip and assert that it correctly displays the unshortened filename. 

Additionally, prepare a different file and upload it once before saving the event. Now that it's saved, try to upload it again and ensure that you can't and that a message is displayed communicating the file duplication as the root cause of the failure.

As there are two places where the display files macro is used, a tester should also navigate to the course proposals page and upload a file to any course proposal. I shouldn't have changed anything here so play with the name and make sure that no prefix is removed from these files.  We only add the folder to the filename behind the scenes for event attachments. If someone wants to upload a weird filename to the slc proposal page we should let them.
