### PR TITLE
Events that have no requirements now display a check instead of an X

### DIFF
--- a/app/templates/events/manageVolunteers.html
+++ b/app/templates/events/manageVolunteers.html
@@ -140,7 +140,7 @@
                       <td style="text-align:center">
                         {% set isTrained = participant.user in trainedParticipantsForProgramAndTerm %}
                         {% set trainingStatus = 'Completed all trainings.' if isTrained else 'Did not complete all trainings.' %}
-                        <span class="bi bi-{{'check' if isTrained else 'x'}}-lg" aria-label="{{trainingStatus}}"></span> &nbsp&nbsp
+                        <span class="bi bi-{{'check' if isTrained or not participationStatusForTrainings[participant.user.username] else 'x'}}-lg" aria-label="{{trainingStatus}}"></span> &nbsp&nbsp
                         <a class="trainingPopover" href="javascript:void(0);" data-toggle="popover" title="Program Trainings" data-content= "{{trainingsHover(participationStatusForTrainings[participant.user.username])}}">View</a>
                       </td>
                     {% endif %}
@@ -220,7 +220,7 @@
                   <td style="text-align:center">
                     {% set isTrained = participant.user in trainedParticipantsForProgramAndTerm %}
                     {% set trainingStatus = 'Completed all trainings.' if isTrained else 'Did not complete all trainings.' %}
-                    <span class="bi bi-{{'check' if isTrained else 'x'}}-lg" aria-label="{{trainingStatus}}"></span> &nbsp&nbsp
+                    <span class="bi bi-{{'check' if isTrained or not participationStatusForTrainings[participant.user.username] else 'x'}}-lg" aria-label="{{trainingStatus}}"></span> &nbsp&nbsp
                     <a class="trainingPopover" href="javascript:void(0);" data-toggle="popover" title="Program Trainings" data-content= "{{trainingsHover(participationStatusForTrainings[participant.user.username])}}">View</a>
                   </td>
                   <td style="text-align:center">

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -189,7 +189,7 @@
                   <td><input class="form-check-input notifyInput" id="notifyInput" type="checkbox" data-programid="{{row.program.id}}" data-username="{{volunteer.username}}" {{checked}}></td>
                   <td>
                     {% set hasCompletedAllTrainings = row.completedTraining %}
-                    <i class="bi bi-{{'check' if hasCompletedAllTrainings else 'x'}}-lg"></i> &nbsp&nbsp
+                    <i class="bi bi-{{'check' if hasCompletedAllTrainings or not trainingList else 'x'}}-lg"></i> &nbsp&nbsp
                     <a class="trainingPopover" id="{{row.program.id}}" href="javascript:void(0);" data-toggle="popover" title="Program Trainings" data-content= "{{trainingsHover(trainingList)}}">View</a>
                   </td>
                   {% if g.current_user.isCeltsAdmin or g.current_user.isCeltsStudentStaff %}


### PR DESCRIPTION
## Issue
Resolves issue #1159 
Previously if there were no program trainings for an event or a program it would display an X, which didn't make much sense.

## Changes
- Check in `userProfile.html` and `manageVolunteers.html` if there are no program trainings. If there aren't we display a check.

## To Test
- checkout 'development'
- delete the All Volunteer Training in Fall 2021.
- Go to Manage Volunteers and User Profile and make sure that for programs with no trainings an x is displayed instead of a check (doesn't make sense).
- checkout `1159_program_trainings_bug`
- those Xs should now be checks