### PR TITLE
Removed rows from canceled course proposals

### DIFF
--- a/app/controllers/serviceLearning/routes.py
+++ b/app/controllers/serviceLearning/routes.py
@@ -93,7 +93,7 @@ def slcCancelProposal():
     courseID = request.form.get('courseID')
     course = Course.get_by_id(courseID)
     if not course.courseName and not course.courseAbbreviation:
-        CourseQuestion.delete().where(CourseQuestion.course_id == courseID).execute()
+        CourseQuestion.delete().where(CourseQuestion.course == course).execute()
         course.delete_instance()
     return "Proposal Canceled"
           

--- a/app/controllers/serviceLearning/routes.py
+++ b/app/controllers/serviceLearning/routes.py
@@ -17,7 +17,6 @@ from app.logic.serviceLearningCourses import getSLProposalInfoForUser, withdrawP
 from app.logic.downloadFile import *
 from app.logic.utils import getRedirectTarget, setRedirectTarget
 from app.controllers.serviceLearning import serviceLearning_bp
-global courseIDGLOBAL
 
 @serviceLearning_bp.route('/serviceLearning/courseManagement', methods = ['GET'])
 @serviceLearning_bp.route('/serviceLearning/courseManagement/<username>', methods = ['GET'])
@@ -94,7 +93,7 @@ def slcCancelProposal():
     courseID = request.form.get('courseID')
     course = Course.get_by_id(courseID)
     if not course.courseName and not course.courseAbbreviation:
-        CourseQuestion.delete().where(CourseQuestion.course_id == courseID).execute()
+        CourseQuestion.delete().where(CourseQuestion.course == course)
         course.delete_instance()
     return "Proposal Canceled"
           

--- a/app/controllers/serviceLearning/routes.py
+++ b/app/controllers/serviceLearning/routes.py
@@ -13,11 +13,11 @@ from app.models.courseQuestion import CourseQuestion
 from app.models.attachmentUpload import AttachmentUpload
 from app.logic.utils import selectSurroundingTerms, getFilesFromRequest
 from app.logic.fileHandler import FileHandler
-from app.logic.serviceLearningCourses import getSLProposalInfoForUser, withdrawProposal, renewProposal, updateCourse, createCourse, approvedCourses
+from app.logic.serviceLearningCourses import getSLProposalInfoForUser, withdrawProposal, renewProposal, updateCourse, createCourse, approvedCourses, deleteCourseObject
 from app.logic.downloadFile import *
 from app.logic.utils import getRedirectTarget, setRedirectTarget
 from app.controllers.serviceLearning import serviceLearning_bp
-
+global courseIDGLOBAL
 
 @serviceLearning_bp.route('/serviceLearning/courseManagement', methods = ['GET'])
 @serviceLearning_bp.route('/serviceLearning/courseManagement/<username>', methods = ['GET'])
@@ -87,9 +87,15 @@ def slcEditProposal(courseID):
 def slcCreateCourse():
     """will give a new course ID so that it can redirect to an edit page"""
     course = createCourse(g.current_user)
-
     return redirect(url_for('serviceLearning.slcEditProposal', courseID = course.id))
 
+@serviceLearning_bp.route('/serviceLearning/canceledProposal', methods=['POST'])
+def slcCancelProposal():
+    courseID = request.form.get('courseID')
+    print('##########################################', courseID, '##########################################')
+
+    return 0
+          
 
 @serviceLearning_bp.route('/serviceLearning/exit', methods=['GET'])
 def slcExitView():

--- a/app/controllers/serviceLearning/routes.py
+++ b/app/controllers/serviceLearning/routes.py
@@ -93,7 +93,7 @@ def slcCancelProposal():
     courseID = request.form.get('courseID')
     course = Course.get_by_id(courseID)
     if not course.courseName and not course.courseAbbreviation:
-        CourseQuestion.delete().where(CourseQuestion.course == course)
+        CourseQuestion.delete().where(CourseQuestion.course_id == courseID).execute()
         course.delete_instance()
     return "Proposal Canceled"
           

--- a/app/controllers/serviceLearning/routes.py
+++ b/app/controllers/serviceLearning/routes.py
@@ -92,9 +92,11 @@ def slcCreateCourse():
 @serviceLearning_bp.route('/serviceLearning/canceledProposal', methods=['POST'])
 def slcCancelProposal():
     courseID = request.form.get('courseID')
-    print('##########################################', courseID, '##########################################')
-
-    return 0
+    course = Course.get_by_id(courseID)
+    if not course.courseName and not course.courseAbbreviation:
+        CourseQuestion.delete().where(CourseQuestion.course_id == courseID).execute()
+        course.delete_instance()
+    return "Proposal Canceled"
           
 
 @serviceLearning_bp.route('/serviceLearning/exit', methods=['GET'])

--- a/app/logic/serviceLearningCourses.py
+++ b/app/logic/serviceLearningCourses.py
@@ -189,7 +189,12 @@ def withdrawProposal(courseID) -> None:
     except DoesNotExist:
         print(f"File, {AttachmentUpload.fileName}, does not exist.")
 
-    # delete course object
+    # deletes course
+    deletedCourse = deleteCourseObject(courseID=courseID)
+
+    createActivityLog(f"Withdrew SLC proposal: {deletedCourse}")
+
+def deleteCourseObject(courseID):
     course: Course = Course.get(Course.id == courseID)
     courseName: str = course.courseName
     questions: List[CourseQuestion] = CourseQuestion.select().where(CourseQuestion.course == course)
@@ -200,8 +205,7 @@ def withdrawProposal(courseID) -> None:
     course.delete_instance(recursive=True)
     for note in notes:
         note.delete_instance()
-
-    createActivityLog(f"Withdrew SLC proposal: {courseName}")
+    return courseName
 
 def createCourse(creator: str="No user provided") -> Course:
     """

--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -78,19 +78,15 @@ $(document).ready(function(e) {
   });
 
   $("#cancelButton").on("click", function() {
-    $.ajax({
-      url: '/serviceLearning/canceledProposal',
-      method: 'POST',
-      data: {courseID : document.getElementById('courseID').value},
-      success: function(response) {
-          msgFlash("Proposal Canceled", "Successfully canceled the proposal edit/creation.")
-      },
-      error: function(error) {
-          msgFlash('Error: ', error)
-          
-      }
-  });
-      window.location.replace($(this).val());
+    var cancelButtonContext = this
+      $.ajax({
+        url: '/serviceLearning/canceledProposal',
+        method: 'POST',
+        data: {courseID : document.getElementById('courseID').value},
+        success: function(response) {
+            window.location.replace($(cancelButtonContext).val());
+        }
+      })
   });
 
   $("#saveContinue").on("click", function() {

--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -78,13 +78,13 @@ $(document).ready(function(e) {
   });
 
   $("#cancelButton").on("click", function() {
-    var cancelButtonContext = this
+    var cancelButton = $(this)
       $.ajax({
         url: '/serviceLearning/canceledProposal',
         method: 'POST',
         data: {courseID : document.getElementById('courseID').value},
         success: function(response) {
-            window.location.replace($(cancelButtonContext).val());
+            window.location.replace(cancelButton.val());
         }
       })
   });

--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -83,7 +83,7 @@ $(document).ready(function(e) {
       method: 'POST',
       data: {courseID : document.getElementById('courseID').value},
       success: function(response) {
-          msgToast("Proposal Canceled", "Successfully canceled the proposal edit/creation.")
+          msgFlash("Proposal Canceled", "Successfully canceled the proposal edit/creation.")
       },
       error: function(error) {
           msgFlash('Error: ', error)

--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -78,7 +78,22 @@ $(document).ready(function(e) {
   });
 
   $("#cancelButton").on("click", function() {
-      window.location.replace($(this).val());
+    $.ajax({
+      url: '/serviceLearning/canceledProposal',
+      method: 'POST',
+      data: {courseID : document.getElementById('courseID').value},
+      success: function(response) {
+          alert('Successfully canceled the proposal')
+          msgToast("Proposal Canceled ", "Successfully canceled the proposal edit/creation.")
+      },
+      error: function(error) {
+          alert('Didnt successfully canceled the proposal :(')
+          msgFlash(error)
+          console.log(error)
+          
+      }
+  });
+      // window.location.replace($(this).val());
   });
 
   $("#saveContinue").on("click", function() {

--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -83,17 +83,14 @@ $(document).ready(function(e) {
       method: 'POST',
       data: {courseID : document.getElementById('courseID').value},
       success: function(response) {
-          alert('Successfully canceled the proposal')
-          msgToast("Proposal Canceled ", "Successfully canceled the proposal edit/creation.")
+          msgToast("Proposal Canceled", "Successfully canceled the proposal edit/creation.")
       },
       error: function(error) {
-          alert('Didnt successfully canceled the proposal :(')
-          msgFlash(error)
-          console.log(error)
+          msgFlash('Error: ', error)
           
       }
   });
-      // window.location.replace($(this).val());
+      window.location.replace($(this).val());
   });
 
   $("#saveContinue").on("click", function() {

--- a/app/templates/serviceLearning/slcProposal.html
+++ b/app/templates/serviceLearning/slcProposal.html
@@ -198,5 +198,5 @@
       </div>
     </div>
   </div>
-  <input value={{course.id}} name="courseID" hidden/>
+  <input value={{course.id}} id="courseID" name="courseID" hidden/>
 </div>


### PR DESCRIPTION
We added an ajax request onto the cancelButton event handler that routes to a new route 'canceledProposal'. If the proposal has no course name and abbreviation, then the course row is deleted in the database as well as the dependent row from the course questions table. 

Resolves #1210