### PR TITLE
Import courses

### DIFF
--- a/app/logic/serviceLearningCourses.py
+++ b/app/logic/serviceLearningCourses.py
@@ -73,10 +73,11 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
             termCheck = Term.get(Term.id == termObj)
 
             checkTermOrder = termCheck.termOrder
+            #dosnt work
+            CurrentTermOrder = Term.termOrder
 
-            print("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$")
 
-            print(checkTermOrder)
+            
 
             check_for_Existing_Courses = list((Course.select()
                                         .join(Term, on =(Course.term == Term.id))
@@ -84,8 +85,10 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
                                         .order_by(Course.term.desc())
                                         .limit(1)))
 
-          
-            if not check_for_Existing_Courses:
+   
+            if not check_for_Existing_Courses :
+
+                
 
                 courseObj: Course = Course.create(courseName = "",
                                 sectionDesignation = "",
@@ -96,10 +99,15 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
                                 createdBy = g.current_user,
                                 serviceLearningDesignatedSections = "",
                                 previouslyApprovedDescription = "" )
-
-            elif Term.termOrder == checkTermOrder :
-
-                print("###################################################")
+                
+            #peewee dosnt throw an error, always returns true
+            elif CurrentTermOrder == checkTermOrder:
+                print('################################################')
+                print(CurrentTermOrder)
+                print(checkTermOrder)
+                courseObj : Course = Course.get( courseAbbreviation = course,
+                                                 term = termObj)    
+            
 
             else:
 

--- a/app/logic/serviceLearningCourses.py
+++ b/app/logic/serviceLearningCourses.py
@@ -63,39 +63,32 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
             data = Course.select().where(Course.courseAbbreviation == course).order_by(Course.term.desc()).limit(1)
             get_existing_info = list(data.dicts())
 
-
             if not get_existing_info:
-<<<<<<< HEAD
                 print("########################################################")
-                courseObj: Course = Course.get_or_create(
-=======
-                print("############################################################################################")
-                courseObj: Course = Course.create(
->>>>>>> 40fcba960e38fa07d49f286d05fd9f740784423d
-                    defaults = {"CourseName" : "",
-                                "sectionDesignation" : "",
-                                "courseCredit" : "1",
-                                "term" : termObj,
-                                "status" : 4,
-                                "createdBy" : g.current_user,
-                                "serviceLearningDesignatedSections" : "",
-                                "previouslyApprovedDescription" : "" })[0]
+                print(course)
+                courseObj: Course = Course.create(courseName = "",
+                                sectionDesignation = "",
+                                courseAbbreviation = course,
+                                courseCredit = "1",
+                                term = termObj,
+                                status = 4,
+                                createdBy = g.current_user,
+                                serviceLearningDesignatedSections = "",
+                                previouslyApprovedDescription = "" )
             
             else :
                 existing_info_dict = get_existing_info[0]
-                print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-                print(existing_info_dict['courseName'])
-                courseObj: Course = Course.get_or_create(
-                    #  courseAbbreviation = course,
-                    #  term = termObj, 
-                    defaults = {"CourseName" : existing_info_dict['courseName'],
-                                "sectionDesignation" : "",
-                                "courseCredit" : "1",
-                                "term" : termObj,
-                                "status" : 4,
-                                "createdBy" : g.current_user,
-                                "serviceLearningDesignatedSections" : "",
-                                "previouslyApprovedDescription" : "" })[0]
+                print("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")
+                print(existing_info_dict)
+                courseObj: Course = Course.create(courseName = existing_info_dict['courseName'],
+                                courseAbbreviation = existing_info_dict['courseAbbreviation'],
+                                sectionDesignation = existing_info_dict['sectionDesignation'],
+                                courseCredit = 1,
+                                term = termObj,
+                                status = 4,
+                                createdBy = g.current_user, 
+                                serviceLearningDesignatedSections = existing_info_dict['serviceLearningDesignatedSections'],
+                                previouslyApprovedDescription = existing_info_dict['previouslyApprovedDescription'])
 
             for userDict in courseInfo['students']:
                 if userDict['errorMsg']:

--- a/app/logic/serviceLearningCourses.py
+++ b/app/logic/serviceLearningCourses.py
@@ -86,26 +86,21 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
                                             .limit(1)))
 
             if not existingCourses :
-
-                    courseObj: Course = Course.create(courseName = "",
-                                    sectionDesignation = "",
-                                    courseAbbreviation = course,
-                                    courseCredit = "1",
-                                    term = courseTerm,
-                                    status = CourseStatus.IN_PROGRESS,
-                                    createdBy = g.current_user,
-                                    serviceLearningDesignatedSections = "",
-                                    previouslyApprovedDescription = "")
-                    
-                    CourseQuestion.create(course = courseObj.id,
-                                    questionContent= " ",
-                                    questionNumber=" ")
-                    
-                    CourseInstructor.create(course = courseObj.id,
-                                        user = "ramsayb2")
-                    
-
-            
+                
+                courseObj: Course = Course.create(courseName = "",
+                                sectionDesignation = "",
+                                courseAbbreviation = course,
+                                courseCredit = "1",
+                                term = courseTerm,
+                                status = CourseStatus.IN_PROGRESS,
+                                createdBy = g.current_user,
+                                serviceLearningDesignatedSections = "",
+                                previouslyApprovedDescription = "")
+                CourseQuestion.create(course = courseObj.id,
+                                questionContent= " ",
+                                questionNumber=" ")
+                CourseInstructor.create(course = courseObj.id,
+                                    user = 'ramsayb2')
             else:
                 previousMatchedCourse = existingCourses[0]
 
@@ -115,6 +110,7 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
                     courseObj : Course = previousMatchedCourse
                 
                 else:
+            
                     courseObj: Course = Course.create(courseName = previousMatchedCourse.courseName,
                                     courseAbbreviation = previousMatchedCourse.courseAbbreviation,
                                     sectionDesignation = previousMatchedCourse.sectionDesignation,
@@ -125,13 +121,16 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
                                     serviceLearningDesignatedSections = previousMatchedCourse.serviceLearningDesignatedSections,
                                     previouslyApprovedDescription = previousMatchedCourse.previouslyApprovedDescription)
                     
-                    questions: List[CourseQuestion] = list(CourseQuestion.select().where(CourseQuestion.course==courseObj.id))
+                    questions: List[CourseQuestion] = list(CourseQuestion.select().where(CourseQuestion.course == previousMatchedCourse.id))
+
                     for question in questions:
-                        CourseQuestion.create(course = previousMatchedCourse.id,
+                        CourseQuestion.create(course = courseObj.id,
                                         questionContent= question.questionContent,
                                         questionNumber=question.questionNumber)
                     
-                    instructors = CourseInstructor.select().where(CourseInstructor.course==courseObj.id)
+                    instructors = CourseInstructor.select().where(CourseInstructor.course == previousMatchedCourse.id)
+                    print('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
+                    print(instructors)
                     for instructor in instructors:
                         CourseInstructor.create(course = courseObj.id,
                                             user = instructor.user)

--- a/app/logic/serviceLearningCourses.py
+++ b/app/logic/serviceLearningCourses.py
@@ -62,20 +62,33 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
                 continue
             data = Course.select().where(Course.courseAbbreviation == course).order_by(Course.term.desc()).limit(1)
             get_existing_info = list(data.dicts())
-            existing_info_dict = get_existing_info[0]
-            print("#########################################################")
-            print(existing_info_dict['courseName'])
-            courseObj: Course = Course.create(
-                #  courseAbbreviation = course,
-                #  term = termObj, 
-                 defaults = {"CourseName" : existing_info_dict['courseName'],
-                             "sectionDesignation" : "",
-                             "courseCredit" : "1",
-                             "term" : termObj,
-                             "status" : 4,
-                             "createdBy" : g.current_user,
-                             "serviceLearningDesignatedSections" : "",
-                             "previouslyApprovedDescription" : "" })[0]
+
+            if not get_existing_info:
+                courseObj: Course = Course.create(
+                    defaults = {"CourseName" : "",
+                                "sectionDesignation" : "",
+                                "courseCredit" : "1",
+                                "term" : termObj,
+                                "status" : 4,
+                                "createdBy" : g.current_user,
+                                "serviceLearningDesignatedSections" : "",
+                                "previouslyApprovedDescription" : "" })[0]
+            
+            else :
+                existing_info_dict = get_existing_info[0]
+                print("#########################################################")
+                print(existing_info_dict['courseName'])
+                courseObj: Course = Course.create(
+                    #  courseAbbreviation = course,
+                    #  term = termObj, 
+                    defaults = {"CourseName" : existing_info_dict['courseName'],
+                                "sectionDesignation" : "",
+                                "courseCredit" : "1",
+                                "term" : termObj,
+                                "status" : 4,
+                                "createdBy" : g.current_user,
+                                "serviceLearningDesignatedSections" : "",
+                                "previouslyApprovedDescription" : "" })[0]
 
             for userDict in courseInfo['students']:
                 if userDict['errorMsg']:

--- a/app/logic/serviceLearningCourses.py
+++ b/app/logic/serviceLearningCourses.py
@@ -86,7 +86,7 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
                                     questionNumber=" ")
                     
                     CourseInstructor.create(course = courseObj.id,
-                                        user = " ")
+                                        user = "ramsayb2")
                     
 
             
@@ -96,7 +96,7 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
                 currentTerm = Term.get(Term.id == previousMatchedCourse.term)
                 
                 if currentTerm == currentTermObj:
-                    courseObj : Course = previousMatchedCourse 
+                    courseObj : Course = previousMatchedCourse
                 
                 else:
                     courseObj: Course = Course.create(courseName = previousMatchedCourse.courseName,
@@ -108,6 +108,18 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
                                     createdBy = g.current_user, 
                                     serviceLearningDesignatedSections = previousMatchedCourse.serviceLearningDesignatedSections,
                                     previouslyApprovedDescription = previousMatchedCourse.previouslyApprovedDescription)
+                    
+                    questions: List[CourseQuestion] = list(CourseQuestion.select().where(CourseQuestion.course==courseObj.id))
+                    for question in questions:
+                        CourseQuestion.create(course = previousMatchedCourse.id,
+                                        questionContent= question.questionContent,
+                                        questionNumber=question.questionNumber)
+                    
+                    instructors = CourseInstructor.select().where(CourseInstructor.course==courseObj.id)
+                    for instructor in instructors:
+                        CourseInstructor.create(course = courseObj.id,
+                                            user = instructor.user)
+                
 
         for userDict in courseInfo['students']:
             if userDict['errorMsg']:

--- a/app/logic/serviceLearningCourses.py
+++ b/app/logic/serviceLearningCourses.py
@@ -61,13 +61,10 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
                 print(f"Unable to save course {course}. {courseInfo['errorMsg']}")
                 continue
 
-            data = list((Course.select().where(Course.courseAbbreviation == course ).order_by(Course.term.desc()).limit(1)))
+            check_for_Existing_Courses = list((Course.select().where(Course.courseAbbreviation == course ).order_by(Course.term.desc()).limit(1)))
 
-            print("#################################################################LOOKIE")
-            
-            
 
-            if not data :
+            if not check_for_Existing_Courses :
 
                 courseObj: Course = Course.create(courseName = "",
                                 sectionDesignation = "",
@@ -79,21 +76,23 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
                                 serviceLearningDesignatedSections = "",
                                 previouslyApprovedDescription = "" )
             
+            elif termObj == check_for_Existing_Courses[0].term: 
+
+                print("The course already exists")
+
             else :
 
-                print("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")
+                previous_data = check_for_Existing_Courses[0]
 
-                existing_data =data[0]
-                
-                courseObj: Course = Course.create(courseName = existing_data.courseName,
-                                courseAbbreviation = existing_data.courseAbbreviation,
-                                sectionDesignation = existing_data.sectionDesignation,
+                courseObj: Course = Course.create(courseName = previous_data.courseName,
+                                courseAbbreviation = previous_data.courseAbbreviation,
+                                sectionDesignation = previous_data.sectionDesignation,
                                 courseCredit = 1,
                                 term = termObj,
                                 status = 4,
                                 createdBy = g.current_user, 
-                                serviceLearningDesignatedSections = existing_data.serviceLearningDesignatedSections,
-                                previouslyApprovedDescription = existing_data.previouslyApprovedDescription)
+                                serviceLearningDesignatedSections = previous_data.serviceLearningDesignatedSections,
+                                previouslyApprovedDescription = previous_data.previouslyApprovedDescription)
 
             for userDict in courseInfo['students']:
                 if userDict['errorMsg']:

--- a/app/logic/serviceLearningCourses.py
+++ b/app/logic/serviceLearningCourses.py
@@ -74,21 +74,17 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
 
             checkTermOrder = termCheck.termOrder
             #dosnt work
-            CurrentTermOrder = Term.termOrder
-
-
-            
-
+                        
             check_for_Existing_Courses = list((Course.select()
                                         .join(Term, on =(Course.term == Term.id))
-                                        .where((Course.courseAbbreviation == course) & (Term.termOrder < checkTermOrder))
+                                        .where((Course.courseAbbreviation == course) & (Term.termOrder <= checkTermOrder))
                                         .order_by(Course.term.desc())
                                         .limit(1)))
+            
+            
 
    
             if not check_for_Existing_Courses :
-
-                
 
                 courseObj: Course = Course.create(courseName = "",
                                 sectionDesignation = "",
@@ -98,30 +94,28 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
                                 status = 4,
                                 createdBy = g.current_user,
                                 serviceLearningDesignatedSections = "",
-                                previouslyApprovedDescription = "" )
-                
-            #peewee dosnt throw an error, always returns true
-            elif CurrentTermOrder == checkTermOrder:
-                print('################################################')
-                print(CurrentTermOrder)
-                print(checkTermOrder)
-                courseObj : Course = Course.get( courseAbbreviation = course,
-                                                 term = termObj)    
-            
-
+                                previouslyApprovedDescription = "")
+        
             else:
-
                 previous_data = check_for_Existing_Courses[0]
 
-                courseObj: Course = Course.create(courseName = previous_data.courseName,
-                                courseAbbreviation = previous_data.courseAbbreviation,
-                                sectionDesignation = previous_data.sectionDesignation,
-                                courseCredit = 1,
-                                term = termObj,
-                                status = 4,
-                                createdBy = g.current_user, 
-                                serviceLearningDesignatedSections = previous_data.serviceLearningDesignatedSections,
-                                previouslyApprovedDescription = previous_data.previouslyApprovedDescription)
+                currentTerm = Term.get(Term.id == previous_data.term)
+                
+                
+                if (currentTerm.termOrder) == checkTermOrder:
+                    print("##########################################################################")
+                    courseObj : Course = Course.get( courseAbbreviation = course, term = termObj) 
+               
+                else:
+                    courseObj: Course = Course.create(courseName = previous_data.courseName,
+                                    courseAbbreviation = previous_data.courseAbbreviation,
+                                    sectionDesignation = previous_data.sectionDesignation,
+                                    courseCredit = 1,
+                                    term = termObj,
+                                    status = 4,
+                                    createdBy = g.current_user, 
+                                    serviceLearningDesignatedSections = previous_data.serviceLearningDesignatedSections,
+                                    previouslyApprovedDescription = previous_data.previouslyApprovedDescription)
 
             for userDict in courseInfo['students']:
                 if userDict['errorMsg']:

--- a/app/logic/serviceLearningCourses.py
+++ b/app/logic/serviceLearningCourses.py
@@ -60,23 +60,22 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
             if 'errorMsg' in courseInfo and courseInfo['errorMsg']:
                 print(f"Unable to save course {course}. {courseInfo['errorMsg']}")
                 continue
-            
-            data = Course.select().where(Course.courseAbbreviation == course)
-            existing_Course_Info = data.dicts()
-
-            print('@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@')
-            print(existing_Course_Info)
-            courseObj: Course = Course.get_or_create(
-            courseAbbreviation = course,
-            term = termObj,
-            defaults = {"CourseName" : "",
-                        "sectionDesignation" : "",
-                        "courseCredit" : "1",
-                        "term" : termObj,
-                        "status" : 4,
-                        "createdBy" : g.current_user,
-                        "serviceLearningDesignatedSections" : "",
-                        "previouslyApprovedDescription" : "" })[0]
+            data = Course.select().where(Course.courseAbbreviation == course).order_by(Course.term.desc()).limit(1)
+            get_existing_info = list(data.dicts())
+            existing_info_dict = get_existing_info[0]
+            print("#########################################################")
+            print(existing_info_dict['courseName'])
+            courseObj: Course = Course.create(
+                #  courseAbbreviation = course,
+                #  term = termObj, 
+                 defaults = {"CourseName" : existing_info_dict['courseName'],
+                             "sectionDesignation" : "",
+                             "courseCredit" : "1",
+                             "term" : termObj,
+                             "status" : 4,
+                             "createdBy" : g.current_user,
+                             "serviceLearningDesignatedSections" : "",
+                             "previouslyApprovedDescription" : "" })[0]
 
             for userDict in courseInfo['students']:
                 if userDict['errorMsg']:
@@ -440,4 +439,6 @@ def parseUploadedFile(filePath):
             
         elif cellVal: # but didn't match the regex
             errors.append((f'ERROR: "{cellVal}" in row {cellRow} of the Excel document does not appear to be a term, course, or valid B#.',1))
+        
+
     return result, errors

--- a/app/logic/serviceLearningCourses.py
+++ b/app/logic/serviceLearningCourses.py
@@ -64,7 +64,8 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
             get_existing_info = list(data.dicts())
 
             if not get_existing_info:
-                courseObj: Course = Course.create(
+                print("########################################################")
+                courseObj: Course = Course.get_or_create(
                     defaults = {"CourseName" : "",
                                 "sectionDesignation" : "",
                                 "courseCredit" : "1",
@@ -78,7 +79,7 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
                 existing_info_dict = get_existing_info[0]
                 print("#########################################################")
                 print(existing_info_dict['courseName'])
-                courseObj: Course = Course.create(
+                courseObj: Course = Course.get_or_create(
                     #  courseAbbreviation = course,
                     #  term = termObj, 
                     defaults = {"CourseName" : existing_info_dict['courseName'],

--- a/app/logic/serviceLearningCourses.py
+++ b/app/logic/serviceLearningCourses.py
@@ -60,18 +60,23 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
             if 'errorMsg' in courseInfo and courseInfo['errorMsg']:
                 print(f"Unable to save course {course}. {courseInfo['errorMsg']}")
                 continue
+            
+            data = Course.select().where(Course.courseAbbreviation == course)
+            existing_Course_Info = data.dicts()
 
+            print('@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@')
+            print(existing_Course_Info)
             courseObj: Course = Course.get_or_create(
-                 courseAbbreviation = course,
-                 term = termObj, 
-                 defaults = {"CourseName" : "",
-                             "sectionDesignation" : "",
-                             "courseCredit" : "1",
-                             "term" : termObj,
-                             "status" : 4,
-                             "createdBy" : g.current_user,
-                             "serviceLearningDesignatedSections" : "",
-                             "previouslyApprovedDescription" : "" })[0]
+            courseAbbreviation = course,
+            term = termObj,
+            defaults = {"CourseName" : "",
+                        "sectionDesignation" : "",
+                        "courseCredit" : "1",
+                        "term" : termObj,
+                        "status" : 4,
+                        "createdBy" : g.current_user,
+                        "serviceLearningDesignatedSections" : "",
+                        "previouslyApprovedDescription" : "" })[0]
 
             for userDict in courseInfo['students']:
                 if userDict['errorMsg']:
@@ -435,6 +440,4 @@ def parseUploadedFile(filePath):
             
         elif cellVal: # but didn't match the regex
             errors.append((f'ERROR: "{cellVal}" in row {cellRow} of the Excel document does not appear to be a term, course, or valid B#.',1))
-        
-
     return result, errors

--- a/app/logic/serviceLearningCourses.py
+++ b/app/logic/serviceLearningCourses.py
@@ -129,8 +129,7 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
                                         questionNumber=question.questionNumber)
                     
                     instructors = CourseInstructor.select().where(CourseInstructor.course == previousMatchedCourse.id)
-                    print('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
-                    print(instructors)
+                    
                     for instructor in instructors:
                         CourseInstructor.create(course = courseObj.id,
                                             user = instructor.user)

--- a/app/logic/serviceLearningCourses.py
+++ b/app/logic/serviceLearningCourses.py
@@ -60,12 +60,12 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
             if 'errorMsg' in courseInfo and courseInfo['errorMsg']:
                 print(f"Unable to save course {course}. {courseInfo['errorMsg']}")
                 continue
-            data = Course.select().where(Course.courseAbbreviation == course).order_by(Course.term.desc()).limit(1)
-            get_existing_info = list(data.dicts())
 
-            if not get_existing_info:
-                print("########################################################")
-                print(course)
+            data = Course.get_or_none(Course.courseAbbreviation == course),(Course.term.desc())
+            print("#################################################################")
+            print(data)
+            if data == None :
+
                 courseObj: Course = Course.create(courseName = "",
                                 sectionDesignation = "",
                                 courseAbbreviation = course,
@@ -77,18 +77,18 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
                                 previouslyApprovedDescription = "" )
             
             else :
-                existing_info_dict = get_existing_info[0]
+
                 print("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")
-                print(existing_info_dict)
-                courseObj: Course = Course.create(courseName = existing_info_dict['courseName'],
-                                courseAbbreviation = existing_info_dict['courseAbbreviation'],
-                                sectionDesignation = existing_info_dict['sectionDesignation'],
+                
+                courseObj: Course = Course.create(courseName = data.courseName,
+                                courseAbbreviation = data.courseAbbreviation,
+                                sectionDesignation = data.sectionDesignation,
                                 courseCredit = 1,
                                 term = termObj,
                                 status = 4,
                                 createdBy = g.current_user, 
-                                serviceLearningDesignatedSections = existing_info_dict['serviceLearningDesignatedSections'],
-                                previouslyApprovedDescription = existing_info_dict['previouslyApprovedDescription'])
+                                serviceLearningDesignatedSections = data.serviceLearningDesignatedSections,
+                                previouslyApprovedDescription =data.previouslyApprovedDescription)
 
             for userDict in courseInfo['students']:
                 if userDict['errorMsg']:

--- a/app/logic/serviceLearningCourses.py
+++ b/app/logic/serviceLearningCourses.py
@@ -61,10 +61,13 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
                 print(f"Unable to save course {course}. {courseInfo['errorMsg']}")
                 continue
 
-            data = Course.get_or_none(Course.courseAbbreviation == course),(Course.term.desc())
-            print("#################################################################")
-            print(data)
-            if data == None :
+            data = list((Course.select().where(Course.courseAbbreviation == course ).order_by(Course.term.desc()).limit(1)))
+
+            print("#################################################################LOOKIE")
+            
+            
+
+            if not data :
 
                 courseObj: Course = Course.create(courseName = "",
                                 sectionDesignation = "",
@@ -79,16 +82,18 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
             else :
 
                 print("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")
+
+                existing_data =data[0]
                 
-                courseObj: Course = Course.create(courseName = data.courseName,
-                                courseAbbreviation = data.courseAbbreviation,
-                                sectionDesignation = data.sectionDesignation,
+                courseObj: Course = Course.create(courseName = existing_data.courseName,
+                                courseAbbreviation = existing_data.courseAbbreviation,
+                                sectionDesignation = existing_data.sectionDesignation,
                                 courseCredit = 1,
                                 term = termObj,
                                 status = 4,
                                 createdBy = g.current_user, 
-                                serviceLearningDesignatedSections = data.serviceLearningDesignatedSections,
-                                previouslyApprovedDescription =data.previouslyApprovedDescription)
+                                serviceLearningDesignatedSections = existing_data.serviceLearningDesignatedSections,
+                                previouslyApprovedDescription = existing_data.previouslyApprovedDescription)
 
             for userDict in courseInfo['students']:
                 if userDict['errorMsg']:

--- a/app/logic/serviceLearningCourses.py
+++ b/app/logic/serviceLearningCourses.py
@@ -63,7 +63,9 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
             data = Course.select().where(Course.courseAbbreviation == course).order_by(Course.term.desc()).limit(1)
             get_existing_info = list(data.dicts())
 
+
             if not get_existing_info:
+                print("############################################################################################")
                 courseObj: Course = Course.create(
                     defaults = {"CourseName" : "",
                                 "sectionDesignation" : "",
@@ -76,7 +78,7 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
             
             else :
                 existing_info_dict = get_existing_info[0]
-                print("#########################################################")
+                print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
                 print(existing_info_dict['courseName'])
                 courseObj: Course = Course.create(
                     #  courseAbbreviation = course,

--- a/app/logic/serviceLearningCourses.py
+++ b/app/logic/serviceLearningCourses.py
@@ -60,30 +60,17 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
             if 'errorMsg' in courseInfo and courseInfo['errorMsg']:
                 print(f"Unable to save course {course}. {courseInfo['errorMsg']}")
                 continue
-            # Look in the db for a course that matches abbreviation and term (query that returns one course)
-            # If matches, use this course to add participants
-
-            # If no match
-                # Select most recent course whose abbreviations match, but term is before the term we are trying to import for (termorder is LESS)
-                # If this course exists, use this course 
-                # If this course does not exist, create a new course
-
-            # Add participants to desired course from the database
 
             termCheck = Term.get(Term.id == termObj)
 
             checkTermOrder = termCheck.termOrder
-            #dosnt work
-                        
+
             check_for_Existing_Courses = list((Course.select()
                                         .join(Term, on =(Course.term == Term.id))
                                         .where((Course.courseAbbreviation == course) & (Term.termOrder <= checkTermOrder))
                                         .order_by(Course.term.desc())
                                         .limit(1)))
             
-            
-
-   
             if not check_for_Existing_Courses :
 
                 courseObj: Course = Course.create(courseName = "",
@@ -103,7 +90,6 @@ def saveCourseParticipantsToDatabase(cpPreview: Dict[str, Dict[str, Dict[str, Li
                 
                 
                 if (currentTerm.termOrder) == checkTermOrder:
-                    print("##########################################################################")
                     courseObj : Course = Course.get( courseAbbreviation = course, term = termObj) 
                
                 else:


### PR DESCRIPTION
We changed the functionality of importing courses. When a course is imported, it checks if it already exists in the courses table. If it does exist then it copies the all information other that status(originally it was just directly set to 4, so we did not change it) and term (because term might be different). It does not check if the course exists in the same term anymore. On discussion with Karina, she pointed out that we should not completely rule out on the basis on term as there might be multiple sections of a class with the same course name and term. Maybe we can add another enhancement where it checks for the section but I don't think we are able to import sections through the spreadsheet. Have not tried to import it yet. 

Issue : #1180

***New Updates***
On discussion with Brian, we decided that we are going to ignore the case of sections for now and not add any courses that have the same course abbreviation or term. We checked for three conditions. If the Course Abbreviation and Term is the same, we add the course participants. If the Course Abbreviation is the same and the term is different there are two sub-conditions. If the term is older than that of the most recent Course Abbreviation match, a new course is added without copying any information. If the term is newer than that of the most recent Course Abbreviation match, a new course is added but with information copied from the match. If none of the Course Abbreviation or term match, we enter a new course into the table.