### PR TITLE
Date picker browser issue #1237

### DIFF
--- a/app/logic/emailHandler.py
+++ b/app/logic/emailHandler.py
@@ -281,3 +281,6 @@ class EmailHandler:
                                      recipient_name="{recipient_name}",
                                      relative_time=event.relativeTime)
         return new_body
+    
+
+

--- a/app/templates/admin/createEvent.html
+++ b/app/templates/admin/createEvent.html
@@ -70,7 +70,7 @@
       <div class="form-group col-md-6">
           <label class="form-label me-2" for="startDatePicker-{{pageLocation}}"><strong>Start Date</strong></label>
           <div class='input-group date startDate' id="startDate-{{pageLocation}}" data-page-location="{{pageLocation}}">
-              <input autocomplete="off" type='date' class="form-control datePicker startDatePicker readonly" 
+              <input autocomplete="off" type='date'  class="form-control datePicker startDatePicker readonly" 
                 value="{{ eventData.startDate.strftime('%m-%d-%Y') if eventData.startDate and eventData.startDate.strftime else eventData.startDate}}" 
                 name="startDate" placeholder="Pick a start date" id='startDatePicker-{{pageLocation}}' data-page-location="{{pageLocation}}" required>
               <div class="input-group-text" id="calendarIconStart-{{pageLocation}}">
@@ -84,7 +84,7 @@
               <span><i class="bi bi-calendar-plus-fill"></i></span>
           <label class="form-label me-2" for="endDate-{{pageLocation}}" ><strong>End Date</strong></label>
           <div class='input-group date endDate' id="endDate-{{pageLocation}}" data-page-location="{{pageLocation}}">
-            <input autocomplete="off" type='text' class="form-control datePicker endDatePicker" id='endDatePicker-{{pageLocation}}' 
+            <input autocomplete="off" type='date' class="form-control datePicker endDatePicker" id='endDatePicker-{{pageLocation}}' 
               value="{{eventData.endDate.strftime('%m-%d-%Y') if eventData.endDate and eventData.endDate.strftime else eventData.endDate}}" 
               name="endDate" placeholder="Pick an end date" data-page-location="{{pageLocation}}">
             <div class="input-group-text" id="calendarIconEnd-{{pageLocation}}">

--- a/app/templates/admin/createEvent.html
+++ b/app/templates/admin/createEvent.html
@@ -29,7 +29,7 @@
 
 {% block scripts %}
   {{super()}}
-  <script type="module" src="/static/js/createEvents.js"></script>
+  <script type="module" src="../../static/js/createEvents.js"></script>
   <script type="module" src="/static/js/displayFilesMacro.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/timepicker/1.3.5/jquery.timepicker.min.js"></script>
 {% endblock %}
@@ -70,7 +70,7 @@
       <div class="form-group col-md-6">
           <label class="form-label me-2" for="startDatePicker-{{pageLocation}}"><strong>Start Date</strong></label>
           <div class='input-group date startDate' id="startDate-{{pageLocation}}" data-page-location="{{pageLocation}}">
-              <input autocomplete="off" type='text' class="form-control datePicker startDatePicker readonly" 
+              <input autocomplete="off" type='date' class="form-control datePicker startDatePicker readonly" 
                 value="{{ eventData.startDate.strftime('%m-%d-%Y') if eventData.startDate and eventData.startDate.strftime else eventData.startDate}}" 
                 name="startDate" placeholder="Pick a start date" id='startDatePicker-{{pageLocation}}' data-page-location="{{pageLocation}}" required>
               <div class="input-group-text" id="calendarIconStart-{{pageLocation}}">


### PR DESCRIPTION
The date picker wasn't working on Firefox browser, we fixed the issue by changing the input field type from 'text' to 'date'. Also, the JavaScript file wasn't correctly linked to the HTML file. Fixing that made the behavior of the date picker similar across both browsers.

# Link to Issue
