### PR TITLE
View Past Events toggle on event list page

### DIFF
--- a/app/static/js/event_list.js
+++ b/app/static/js/event_list.js
@@ -33,6 +33,8 @@ $(document).ready(function(){
     
     // Disable toggle if we are in a past term; stuck on "on"
     if (g_isPastTerm) {
+      viewPastEventsToggle.prop("checked", g_isPastTerm);
+      toggleRows(g_isPastTerm);
       viewPastEventsToggle.prop("disabled", true);
     } else {
       viewPastEventsToggle.prop("disabled", false);

--- a/app/static/js/event_list.js
+++ b/app/static/js/event_list.js
@@ -5,29 +5,39 @@ $(document).ready(function(){
     $("#rsvpBtn").click(function(){
         rsvpForEvent($("#rsvpBtn").val())
     })
-   var storedToggleState = localStorage.getItem("toggleState");
-  var isChecked = storedToggleState === "checked";
-  // Initialize toggle based on retrieved state
-  var viewPastEventsToggle = $("#viewPastEventsToggle");
-  viewPastEventsToggle.prop("checked", isChecked);
-  toggleRows(isChecked);
-  // Handle toggle change
-  viewPastEventsToggle.on("change", function() {
-    isChecked = $(this).prop("checked");
+    var storedToggleState = localStorage.getItem("toggleState");
+    var isChecked = storedToggleState === "checked";
+    
+    // Initialize toggle based on retrieved state
+    var viewPastEventsToggle = $("#viewPastEventsToggle");
+    viewPastEventsToggle.prop("checked", isChecked);
     toggleRows(isChecked);
-    // Update localStorage with new toggle state
-    localStorage.setItem("toggleState", isChecked ? "checked" : "unchecked");
-  });
-  // Function to toggle rows visibility
-  function toggleRows(isChecked) {
-    var tableRows = $(".showlist");
-    if (isChecked) {
-      tableRows.show();
-    } else {
-      tableRows.hide();
+    
+    // Handle toggle change
+    viewPastEventsToggle.on("change", function() {
+      isChecked = $(this).prop("checked");
+      toggleRows(isChecked);
+      // Update localStorage with new toggle state
+      localStorage.setItem("toggleState", isChecked ? "checked" : "unchecked");
+    });
+    
+    // Function to toggle rows visibility
+    function toggleRows(isChecked) {
+      var tableRows = $(".showlist");
+      if (isChecked) {
+        tableRows.show();
+      } else {
+        tableRows.hide();
+      }
     }
-  }
-  });
+    
+    // Disable toggle if we are in a past term; stuck on "on"
+    if (g_isPastTerm) {
+      viewPastEventsToggle.prop("disabled", true);
+    } else {
+      viewPastEventsToggle.prop("disabled", false);
+    }
+});
 
 function rsvpForEvent(eventID){
   rsvpInfo = {id: eventID,

--- a/app/static/js/event_list.js
+++ b/app/static/js/event_list.js
@@ -5,26 +5,28 @@ $(document).ready(function(){
     $("#rsvpBtn").click(function(){
         rsvpForEvent($("#rsvpBtn").val())
     })
-    var viewPastEventsToggle = $("#viewPastEventsToggle");
-    viewPastEventsToggle.prop("checked", g_isPastTerm);
-    toggleRows(g_isPastTerm);
-    viewPastEventsToggle.prop("disabled", g_isPastTerm);    
-      
-    viewPastEventsToggle.on("change", function(){
-      var isChecked = $(this).prop("checked");
-      toggleRows(isChecked);
-
-      localStorage.setItem("toggleState", isChecked ? "checked" : "unchecked")
-    });
-
-    function toggleRows(isChecked) {
-      var tableRows = $(".showlist");
-      if (isChecked){
-        tableRows.show();
-      } else {
-        tableRows.hide();
-      }
+   var storedToggleState = localStorage.getItem("toggleState");
+  var isChecked = storedToggleState === "checked";
+  // Initialize toggle based on retrieved state
+  var viewPastEventsToggle = $("#viewPastEventsToggle");
+  viewPastEventsToggle.prop("checked", isChecked);
+  toggleRows(isChecked);
+  // Handle toggle change
+  viewPastEventsToggle.on("change", function() {
+    isChecked = $(this).prop("checked");
+    toggleRows(isChecked);
+    // Update localStorage with new toggle state
+    localStorage.setItem("toggleState", isChecked ? "checked" : "unchecked");
+  });
+  // Function to toggle rows visibility
+  function toggleRows(isChecked) {
+    var tableRows = $(".showlist");
+    if (isChecked) {
+      tableRows.show();
+    } else {
+      tableRows.hide();
     }
+  }
   });
 
 function rsvpForEvent(eventID){

--- a/app/templates/events/event_list.html
+++ b/app/templates/events/event_list.html
@@ -195,6 +195,6 @@
 </div>
 {% include 'emailModal.html' %}
 <script>
-  var g_isPastTerm ={{"false" if selectedTerm.isFutureTerm or selectedTerm.isCurrentTerm else "true" }};
-</script>
+   var g_isPastTerm = {{ "false" if selectedTerm.isFutureTerm or selectedTerm.isCurrentTerm else "true" }};
+ </script>
 {% endblock %}


### PR DESCRIPTION
We modified it to where if the toggle is checked on, then it stays on and if it is checked off, then it stays off even if terms are being changed. We also made sure that the toggle of past terms remain disabled on "on" since those events are past events.