### PR TITLE
Modifying the title of All Volunteer Training

### DIFF
--- a/app/templates/admin/createEvent.html
+++ b/app/templates/admin/createEvent.html
@@ -2,13 +2,13 @@
 
 {% set isNewEvent = 'create' in request.path %}
 {% if isNewEvent %}          
-  {% if eventData["program"].programName == 'CELTS-Sponsored Event' %}
+  {% if eventData["program"].programName == 'CELTS-Sponsored Event' and template.tag == '' %}
     {% set page_title = 'Create a ' + eventData["program"].programName %}
 
   {% elif template.tag == 'single-program' %}
     {%set page_title = 'Create Event for ' + eventData["program"].programName %}
 
-  {% elif template.tag == 'all-volunteer' %}
+  {% elif eventData["program"].programName == 'CELTS-Sponsored Event' and template.tag == 'all-volunteer' %}
     {% set page_title = 'Create All Volunteer Training' %}
 
   {% elif template.tag == 'no-program' %}


### PR DESCRIPTION
The title before said "Create a CELTS-Sponsored Event" because it was pulling the title by the programName in the createEvent.html and we saw that the All Volunteer Training are under other Celts sponsored event, which is still celts sponsored. We modified the title to be CELTS sponsored only if the programName is Celts Sponsored Event and if the template tag is an empty string. Else if the template tag has 'all volunteer then it will make teh title "All Volunteer Training".

This is the html page for setting title before:
![image](https://github.com/user-attachments/assets/f072ddb8-d9d3-4466-bf07-a9d1502faa3e)

This is after our change:
![image](https://github.com/user-attachments/assets/b78e3455-43cf-4faa-b7a6-929c487bf2d0)
