### PR TITLE
View Past Events Toggle Resolved

### DIFF
--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -124,11 +124,11 @@ def update_toggle_state():
     # Continue with setting the cookie as before
     next_url = request.form.get('next_url', '/eventsList')
     resp = make_response(redirect(next_url))
-    resp.set_cookie('toggleState', toggle_state, max_age=60*60*24*7)
+    resp.set_cookie('toggleState', toggle_state)
     return resp
 
 @main_bp.route('/profile/<username>', methods=['GET'])
-def viewUsersProfile(username):
+def viewUsersProfile(username):   
     """
     This function displays the information of a volunteer to the user
     """
@@ -141,7 +141,7 @@ def viewUsersProfile(username):
         else:
             abort(403)  # Error 403 if non admin/student-staff user trys to access via url
 
-    if (g.current_user == volunteer) or g.current_user.isAdmin:
+    if (g.current_user == volunteer) or g.current_user.isAdmin: 
         upcomingEvents = getUpcomingEventsForUser(volunteer)
         participatedEvents = getParticipatedEventsForUser(volunteer)
         programs = Program.select()

--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -121,11 +121,7 @@ def update_toggle_state():
     # Update session with toggle state
     session['toggleState'] = toggle_state
     
-    # Continue with setting the cookie as before
-    next_url = request.form.get('next_url', '/eventsList')
-    resp = make_response(redirect(next_url))
-    resp.set_cookie('toggleState', toggle_state)
-    return resp
+    return "", 200
 
 @main_bp.route('/profile/<username>', methods=['GET'])
 def viewUsersProfile(username):   

--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -94,7 +94,7 @@ def events(selectedTerm, activeTab, programID):
     managersProgramDict = getManagerProgramDict(g.current_user)
 
     # Read the cookie value from the request
-    toggle_state = request.cookies.get('toggleState')
+    toggle_state = request.cookies.get('toggleState', 'unchecked')
 
     return render_template("/events/event_list.html",
                             selectedTerm = term,

--- a/app/static/js/event_list.js
+++ b/app/static/js/event_list.js
@@ -14,7 +14,7 @@ $(document).ready(function(){
       var isChecked = $(this).prop("checked");
       toggleRows(isChecked);
 
-      // localStorage.setItem("toggleState", isChecked ? "checked" : "unchecked")
+      localStorage.setItem("toggleState", isChecked ? "checked" : "unchecked")
     });
 
     function toggleRows(isChecked) {

--- a/app/static/js/event_list.js
+++ b/app/static/js/event_list.js
@@ -6,26 +6,35 @@ $(document).ready(function(){
         rsvpForEvent($("#rsvpBtn").val())
     })
     var viewPastEventsToggle = $("#viewPastEventsToggle");
-    // viewPastEventsToggle.prop("checked", g_isPastTerm);
-    toggleRows(g_isPastTerm);
-    // viewPastEventsToggle.prop("disabled", g_isPastTerm);    
-      
-    viewPastEventsToggle.on("change", function(){
-      var isChecked = $(this).prop("checked");
-      toggleRows(isChecked);
+    var isChecked = viewPastEventsToggle.data("initial-state") === "checked";
+    viewPastEventsToggle.prop("checked", isChecked);
+    toggleRows(isChecked);
 
-      localStorage.setItem("toggleState", isChecked ? "checked" : "unchecked")
-    });
-
-    function toggleRows(isChecked) {
-      var tableRows = $(".showlist");
-      if (isChecked){
-        tableRows.show();
-      } else {
-        tableRows.hide();
-      }
+    if (!g_isPastTerm) {
+      viewPastEventsToggle.on("change", function(){
+        isChecked = $(this).prop("checked");
+        toggleRows(isChecked);
+    
+        // Update server state via AJAX POST
+        $.post("/updateToggleState", {
+          toggleState: isChecked ? "checked" : "unchecked",
+        });
+    
+      });
+    } else {
+      viewPastEventsToggle.prop("checked", g_isPastTerm);
+      toggleRows(g_isPastTerm);
     }
-  });
+
+  function toggleRows(isChecked) {
+    var tableRows = $(".showlist");
+    if (isChecked) {
+      tableRows.show();
+    } else {
+      tableRows.hide();
+    }
+  }
+});
 
 function rsvpForEvent(eventID){
   rsvpInfo = {id: eventID,
@@ -58,7 +67,6 @@ function removeRsvpForEvent(eventID){
     error: function(error, status){
         console.log(error, status)
     }
-
   })
 }
 

--- a/app/static/js/event_list.js
+++ b/app/static/js/event_list.js
@@ -5,14 +5,14 @@ $(document).ready(function(){
     $("#rsvpBtn").click(function(){
         rsvpForEvent($("#rsvpBtn").val())
     })
+
     var viewPastEventsToggle = $("#viewPastEventsToggle");
-    var isChecked = viewPastEventsToggle.data("initial-state") === "checked";
-    viewPastEventsToggle.prop("checked", isChecked);
+    var isChecked = viewPastEventsToggle.prop("checked");
     toggleRows(isChecked);
 
     if (!g_isPastTerm) {
       viewPastEventsToggle.on("change", function(){
-        isChecked = $(this).prop("checked");
+        let isChecked = $(this).prop("checked");
         toggleRows(isChecked);
     
         // Update server state via AJAX POST
@@ -21,9 +21,6 @@ $(document).ready(function(){
         });
     
       });
-    } else {
-      viewPastEventsToggle.prop("checked", g_isPastTerm);
-      toggleRows(g_isPastTerm);
     }
 
   function toggleRows(isChecked) {

--- a/app/static/js/event_list.js
+++ b/app/static/js/event_list.js
@@ -6,15 +6,15 @@ $(document).ready(function(){
         rsvpForEvent($("#rsvpBtn").val())
     })
     var viewPastEventsToggle = $("#viewPastEventsToggle");
-    viewPastEventsToggle.prop("checked", g_isPastTerm);
+    // viewPastEventsToggle.prop("checked", g_isPastTerm);
     toggleRows(g_isPastTerm);
-    viewPastEventsToggle.prop("disabled", g_isPastTerm);    
+    // viewPastEventsToggle.prop("disabled", g_isPastTerm);    
       
     viewPastEventsToggle.on("change", function(){
       var isChecked = $(this).prop("checked");
       toggleRows(isChecked);
 
-      localStorage.setItem("toggleState", isChecked ? "checked" : "unchecked")
+      // localStorage.setItem("toggleState", isChecked ? "checked" : "unchecked")
     });
 
     function toggleRows(isChecked) {

--- a/app/templates/events/event_list.html
+++ b/app/templates/events/event_list.html
@@ -36,8 +36,7 @@
       <div class="form-check form-switch mb-2 col-auto">
         <label class="form-check-label" for="viewPastEventsToggle">View Past Events</label>
         {% if selectedTerm.isFutureTerm or selectedTerm.isCurrentTerm %}
-            <input type="hidden" name="next_url" value="{{ request.url }}">
-            <input class="form-check-input" type="checkbox" id="viewPastEventsToggle" autocomplete="off" data-initial-state="{{ toggle_state }}" autocomplete="off" name="toggleState" {% if toggle_state == 'checked' %}checked{% endif %}>
+            <input class="form-check-input" type="checkbox" id="viewPastEventsToggle" autocomplete="off" name="toggleState" {% if toggle_state == 'checked' %}checked{% endif %}>
         {% else %}  
           <input class="form-check-input" type="checkbox" id="viewPastEventsToggle" autocomplete="off" name="toggleState" checked disabled>
         {% endif %}

--- a/app/templates/events/event_list.html
+++ b/app/templates/events/event_list.html
@@ -35,7 +35,15 @@
       <div class = "d-none d-sm-block col "></div>
       <div class="form-check form-switch mb-2 col-auto">
         <label class="form-check-label" for="viewPastEventsToggle">View Past Events</label>
-        <input class="form-check-input" type="checkbox" id="viewPastEventsToggle" autocomplete="off">
+        {% if selectedTerm.isFutureTerm or selectedTerm.isCurrentTerm %}
+          <!-- <form method="post" action="/updateToggleState"> -->
+            <!-- <input type="hidden" name="next_url" value="{{ request.url }}"> -->
+            <input class="form-check-input" type="checkbox" id="viewPastEventsToggle" autocomplete="off" name="toggleState" value="checked" action="/updateToggleState"
+              {% if toggle_state == 'checked' %}checked{% endif %}>
+          <!-- </form> -->
+        {% else %}  
+          <input class="form-check-input" type="checkbox" id="viewPastEventsToggle" autocomplete="off" checked disabled>
+        {% endif %}
       </div>
     </div>
   {% endif %}

--- a/app/templates/events/event_list.html
+++ b/app/templates/events/event_list.html
@@ -36,11 +36,11 @@
       <div class="form-check form-switch mb-2 col-auto">
         <label class="form-check-label" for="viewPastEventsToggle">View Past Events</label>
         {% if selectedTerm.isFutureTerm or selectedTerm.isCurrentTerm %}
-          <!-- <form method="post" action="/updateToggleState"> -->
-            <!-- <input type="hidden" name="next_url" value="{{ request.url }}"> -->
-            <input class="form-check-input" type="checkbox" id="viewPastEventsToggle" autocomplete="off" name="toggleState" value="checked" action="/updateToggleState"
-              {% if toggle_state == 'checked' %}checked{% endif %}>
-          <!-- </form> -->
+          <form method="post" action="/updateToggleState">
+            <input type="hidden" name="next_url" value="{{ request.url }}">
+            <input class="form-check-input" type="checkbox" id="viewPastEventsToggle" autocomplete="off" name="toggleState" value="checked" onchange="this.form.submit();"
+            {% if toggle_state == 'checked' %}checked{% endif %}>
+          </form>
         {% else %}  
           <input class="form-check-input" type="checkbox" id="viewPastEventsToggle" autocomplete="off" checked disabled>
         {% endif %}

--- a/app/templates/events/event_list.html
+++ b/app/templates/events/event_list.html
@@ -36,10 +36,8 @@
       <div class="form-check form-switch mb-2 col-auto">
         <label class="form-check-label" for="viewPastEventsToggle">View Past Events</label>
         {% if selectedTerm.isFutureTerm or selectedTerm.isCurrentTerm %}
-          <form method="post" action="/updateToggleState">
             <input type="hidden" name="next_url" value="{{ request.url }}">
             <input class="form-check-input" type="checkbox" id="viewPastEventsToggle" autocomplete="off" data-initial-state="{{ toggle_state }}" autocomplete="off" name="toggleState" {% if toggle_state == 'checked' %}checked{% endif %}>
-          </form>
         {% else %}  
           <input class="form-check-input" type="checkbox" id="viewPastEventsToggle" autocomplete="off" name="toggleState" checked disabled>
         {% endif %}

--- a/app/templates/events/event_list.html
+++ b/app/templates/events/event_list.html
@@ -38,11 +38,10 @@
         {% if selectedTerm.isFutureTerm or selectedTerm.isCurrentTerm %}
           <form method="post" action="/updateToggleState">
             <input type="hidden" name="next_url" value="{{ request.url }}">
-            <input class="form-check-input" type="checkbox" id="viewPastEventsToggle" autocomplete="off" name="toggleState" value="checked" onchange="this.form.submit();"
-            {% if toggle_state == 'checked' %}checked{% endif %}>
+            <input class="form-check-input" type="checkbox" id="viewPastEventsToggle" autocomplete="off" data-initial-state="{{ toggle_state }}" autocomplete="off" name="toggleState" {% if toggle_state == 'checked' %}checked{% endif %}>
           </form>
         {% else %}  
-          <input class="form-check-input" type="checkbox" id="viewPastEventsToggle" autocomplete="off" checked disabled>
+          <input class="form-check-input" type="checkbox" id="viewPastEventsToggle" autocomplete="off" name="toggleState" checked disabled>
         {% endif %}
       </div>
     </div>


### PR DESCRIPTION
For past events, the toggle remain checked on and is disabled with the tables always showing. For current or future events, if the toggle is checked on then it remain on even if the term is changed. If it is unchecked, it remain unchecked even if the term is changed. Whenever the toggle is checked on, then the past events table should always show.

Resolves issue #1270 