### PR TITLE
Fixed unapprove and approve functionality on review modal

### DIFF
--- a/app/static/js/slcManagement.js
+++ b/app/static/js/slcManagement.js
@@ -160,11 +160,16 @@ function reviewCourses(courseID) {
       success: function(modal_html) {
         $("#review-modal").html(modal_html)
         $("#proposal_view").modal('show')
+
+        // once the modal has rendered in we can add the handlers to give the approve/unapprove
+        // buttons functionality
+        $("#unapproveButton").on("click", () => unapproveProposal($("#unapproveButton")))
+        $("#approveButton").on("click", () => approveProposal($("#approveButton")))
       }
     })
 }
 
-function approveProposal(el){
+function approveProposal(el) {
     let courseID = $(el).data("id")
     $.ajax({
       url: '/serviceLearning/approveCourse',
@@ -176,7 +181,7 @@ function approveProposal(el){
     })
 }
 
-function unapproveProposal(el){
+function unapproveProposal(el) {
     let courseID = $(el).data("id")
     $.ajax({
       url: '/serviceLearning/unapproveCourse',

--- a/app/templates/admin/manageServiceLearningFaculty.html
+++ b/app/templates/admin/manageServiceLearningFaculty.html
@@ -392,4 +392,5 @@
     </form>
   </div>
   <div id="review-modal"></div>
+
 {% endblock %}

--- a/app/templates/serviceLearning/reviewProposal.html
+++ b/app/templates/serviceLearning/reviewProposal.html
@@ -1,3 +1,4 @@
+
   <div class="modal fade" tabindex="-1" id="proposal_view">
     <div class="modal-dialog">
       <div class=" modal-content">
@@ -53,12 +54,13 @@
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary me-auto" data-bs-dismiss="modal">Close</button>
           {% if course.status.status == "Approved" %}
-            <button type="button" class="btn btn-warning" data-id="{{course.id}}" id="unapproveButton" onclick="unapproveProposal(this)">Unapprove</button>
+            <button type="button" class="btn btn-warning" data-id="{{course.id}}" id="unapproveButton">Unapprove</button>
           {% else %}
             <a type="button" href="/serviceLearning/editProposal/{{course.id }}"  class="btn btn-primary">Edit</a>
-            <button type="button" class="btn btn-success" data-id="{{course.id}}" id="approveButton" onclick="approveProposal(this)">Approve</button>
+            <button type="button" class="btn btn-success" data-id="{{course.id}}" id="approveButton">Approve</button>
           {% endif %}
         </div>
       </div>
     </div>
   </div>
+


### PR DESCRIPTION
## Issue
Fixes issue #1244 

For some reason the unapproveProposal and approveProposal functions were no longer accessible in the reviewModal.html template.

## Changes
- I removed the unapproveProposal and approveProposal onClick handlers from the template to the javascript to ensure they can properly reference the functions. 
- Only add the onClick handlers to the modal when the request to populate the modal appears so that there is an actual button to add it to.

## Testing
- Checkout fix_unapprove_1244
- Reset database
- Go to Course Management and review a proposal
- Verify that you can both approve and unapprove proposals.