### PR TITLE
Event List Hotfix

### DIFF
--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -130,7 +130,7 @@ def events(selectedTerm, activeTab, programID):
             "toggleStatus": toggleState
         })
     
-    return render_template("/events/event_list.html",
+    return render_template("/events/eventList.html",
                             selectedTerm = term,
                             studentLedEvents = studentLedEvents,
                             trainingEvents = trainingEvents,


### PR DESCRIPTION
## Issue Description

The Events List page is crashing due to a file rename, from `event_list `to `eventList`, to match convention. PR #1334 was responsible for this oversight.

![Screenshot 2024-09-17 090432](https://github.com/user-attachments/assets/e2a17560-9a75-41ec-b1b2-8573c8f92abe)

## Changes

- The `render_template` has been changed from `events/event_list.html` to `events/eventList.html`. 

## Testing

- Switch to development, create a few events, and attempt to view the Events List. It should be crashing.
- Switch to this branch, and ensure the page no longer crashes.