### PR TITLE
Fixed bug with deleting recurring events

### DIFF
--- a/app/logic/events.py
+++ b/app/logic/events.py
@@ -46,12 +46,15 @@ def deleteEvent(eventId):
     if event:
         if event.recurringId:
             recurringId = event.recurringId
-            recurringEvents = list(Event.select().where(Event.recurringId==recurringId).order_by(Event.id)) # orders for tests
+            recurringEvents = list(Event.select().where(Event.recurringId==recurringId, Event.deletionDate.is_null(True)).order_by(Event.id)) # orders for tests
             eventDeleted = False
-
+            print([i.name for i in recurringEvents])
             # once the deleted event is detected, change all other names to the previous event's name
             for recurringEvent in recurringEvents:
+                print("recurringEvent:", recurringEvent.name)
+                print("eventDeleted:", eventDeleted)
                 if eventDeleted:
+                    print("newEventName", newEventName)
                     Event.update({Event.name:newEventName}).where(Event.id==recurringEvent.id).execute()
                     newEventName = recurringEvent.name
 

--- a/app/logic/events.py
+++ b/app/logic/events.py
@@ -48,13 +48,9 @@ def deleteEvent(eventId):
             recurringId = event.recurringId
             recurringEvents = list(Event.select().where(Event.recurringId==recurringId, Event.deletionDate.is_null(True)).order_by(Event.id)) # orders for tests
             eventDeleted = False
-            print([i.name for i in recurringEvents])
             # once the deleted event is detected, change all other names to the previous event's name
             for recurringEvent in recurringEvents:
-                print("recurringEvent:", recurringEvent.name)
-                print("eventDeleted:", eventDeleted)
                 if eventDeleted:
-                    print("newEventName", newEventName)
                     Event.update({Event.name:newEventName}).where(Event.id==recurringEvent.id).execute()
                     newEventName = recurringEvent.name
 


### PR DESCRIPTION
## Issue Description

Fixes #1350 
- When attempting to delete multiple recurring events from a series stuff breaks.

## Changes
- Made sure the only recurring events we were attempting to rename were those that were active and not deleted, as that was causing the problem.

## Testing
- Checkout development
- Reset database
- Create a recurring series with 10 events
- Delete the 5th
- Delete the 1st
- The order should get weird now
- Keep deleting the 1st and verifying weird functionality.
- Checkout `1350_recurring_events_bug`
- Reset database 
- Repeat steps 3-5 but verify it works now.
- Rejoice!