### PR TITLE
Fixed Spacing on Delete Modal for Repeating Events

### DIFF
--- a/app/templates/events/createEvent.html
+++ b/app/templates/events/createEvent.html
@@ -392,14 +392,14 @@
         <div class="container-fluid">
           <p>This action is irreversible. </p>
           <p>By deleting this event, all information regarding this event will be removed from the website. </p>
-          <div class="d-grid gap-2">
-            <form action="/event/{{eventData.id}}/delete" method='post'>
+          <div class="d-grid">
+            <form class="mb-1" action="/event/{{eventData.id}}/delete" method='post'>
               <button type="submit" class="btn btn-danger">Delete This Event</button>
             </form>
-            <form action="/event/{{eventData.id}}/deleteEventAndAllFollowing" method='post'>
+            <form class="mb-1" action="/event/{{eventData.id}}/deleteEventAndAllFollowing" method='post'>
               <button type="submit" class="btn btn-danger">Delete This and All Following</button>
             </form>
-            <form action="/event/{{eventData.id}}/deleteAllRecurring" method='post'>
+            <form class="mb-1" action="/event/{{eventData.id}}/deleteAllRecurring" method='post'>
               <button type="submit" class="btn btn-danger">Delete Series </button>
             </form>
           </div>


### PR DESCRIPTION
## Issue Description

Fixes #1361
- The spacing on the modal for deletion confirmation was a bit difficult on the eye.

## Changes

- Reduced the spacing between buttons.

Old look:
<img src="https://github.com/user-attachments/assets/86b240f8-bf79-4365-9280-6e0cee7104af" width="250" />

New look:
<img src="https://github.com/user-attachments/assets/8f8dc97a-3f45-49b5-adb9-c44d22ca0612" width="250" />

## Testing

- Test the spacing and view on varying screen sizes and ensure its functionality.