### PR TITLE
Odd Spacing on the manageServiceLearningFaculty.html page

### DIFF
--- a/app/controllers/serviceLearning/routes.py
+++ b/app/controllers/serviceLearning/routes.py
@@ -83,7 +83,7 @@ def slcEditProposal(courseID):
         abort(403)
         
 
-@serviceLearning_bp.route('/serviceLearning/createCourse', methods=['POST'])
+@serviceLearning_bp.route('/serviceLearning/createCourse', methods=['GET'])
 def slcCreateCourse():
     """will give a new course ID so that it can redirect to an edit page"""
     course = createCourse(g.current_user)

--- a/app/templates/admin/manageServiceLearningFaculty.html
+++ b/app/templates/admin/manageServiceLearningFaculty.html
@@ -44,9 +44,7 @@
       </div>
       <div class="col">
         <div align="right">
-          <form method="post" action="/serviceLearning/createCourse">
-            <button class="btn btn-success btn-sm mr" type='Submit'>Add Course</button>
-          </form>
+          <a class="btn btn-success btn-sm mr" href="/serviceLearning/createCourse">Add Course</a>
         </div>
       </div>
     </div>

--- a/app/templates/serviceLearning/slcManagement.html
+++ b/app/templates/serviceLearning/slcManagement.html
@@ -57,9 +57,7 @@
   {% endif %}
 </div>
 <div align="right">
-  <form method="post" action="/serviceLearning/createCourse" >
-    <button class="btn btn-primary" type = 'Submit'>Create Course Proposal</button>
-  </form>
+  <a class="btn btn-primary" href='/serviceLearning/createCourse'>Create Course Proposal</a>
 </div>
 <div class="modal fade" id="withdrawModal" tabindex="-1" aria-labelledby="withdrawModalLabel" aria-hidden="true">
   <div class="modal-dialog">


### PR DESCRIPTION
## Issue Description

Fixes #1381
There was an odd amount of space on the manageServiceLearningFaculty.html page being caused by some CSS being applied to a form tag which looked bad.

![image](https://github.com/user-attachments/assets/3b9906ad-a718-4b43-a103-586966f6936b)

Additionally, the form tag itself was only being used to send a post request with a single button for an action that didn't create any resources but led you to a page which did.

## Changes

- Replaced the form tags from two pages where it was being used in the same way with anchor (`<a>`) tags.
- Changed the route to accept GET requests instead of POST requests.

## Testing

- Run the app and navigate to the course proposals and course management tabs separately and check to ensure that their create course proposal and add course buttons are working as intended.

![image](https://github.com/user-attachments/assets/67da9076-f1fb-45cf-a4bb-2a0331032972)
