### PR TITLE
Clarified Form Validation for Instructors on the SLC Page

### DIFF
--- a/app/static/js/instructorTable.js
+++ b/app/static/js/instructorTable.js
@@ -31,6 +31,8 @@ export function createNewRow(selectedInstructor) {
   let editLink = newRow.find("td:eq(0) a")
   editLink.attr("id", `editButton-${username}`);
 
+  console.log("Added Row:")
+  console.log(username)
   editLink.attr("data-username", username)
   newRow.prop("hidden", false);
   lastRow.after(newRow);
@@ -43,9 +45,18 @@ export function createNewRow(selectedInstructor) {
   }
 
   $("#instructorTableNames").append(`<input hidden name="instructor[]" value="${username}"/>`)
+  updateEmptyTableMessage()
 }
 
 export function getCourseInstructors() {
   // get usernames out of the table rows 
   return $("#instructorTableNames input").map((i,el) => $(el).val())
+}
+
+export function updateEmptyTableMessage(){
+  if ($("#instructorTable tbody tr").length > 2){
+    $("#instructorTable tbody tr").first().attr("hidden", true)
+  } else{
+    $("#instructorTable tbody tr").first().attr("hidden", false)
+  }
 }

--- a/app/static/js/instructorTable.js
+++ b/app/static/js/instructorTable.js
@@ -31,8 +31,7 @@ export function createNewRow(selectedInstructor) {
   let editLink = newRow.find("td:eq(0) a")
   editLink.attr("id", `editButton-${username}`);
 
-  console.log("Added Row:")
-  console.log(username)
+  newRow.attr("data-username", username)
   editLink.attr("data-username", username)
   newRow.prop("hidden", false);
   lastRow.after(newRow);

--- a/app/static/js/searchUser.js
+++ b/app/static/js/searchUser.js
@@ -35,6 +35,7 @@ export default function searchUser(inputId, callback, clear=false, parentElement
         }
 
        return false;
-     }
+     },
+     autoFocus: true
   });
 };

--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -1,4 +1,4 @@
-import {getCourseInstructors, getRowUsername, createNewRow} from './instructorTable.js'
+import {getCourseInstructors, getRowUsername, createNewRow, updateEmptyTableMessage} from './instructorTable.js'
 import searchUser from './searchUser.js'
 
 var currentTab = 0; // Current tab is set to be the first tab (0)
@@ -130,13 +130,14 @@ $(document).ready(function(e) {
   $("#instructorTable").on("click", ".removeButton", function() {
     let closestRow = $(this).closest("tr");
     let username = closestRow.data('username');
-
+    console.log(closestRow)
     // Check if the username is not empty or undefined
     if (username) {
         $("#instructorTableNames input[value='" + username + "']").remove();
         closestRow.remove();
     }
-});
+    updateEmptyTableMessage();
+  });
 
     $("#courseInstructor").on('input', function() {
         searchUser("courseInstructor", createNewRow, true, null, "instructor");

--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -130,7 +130,7 @@ $(document).ready(function(e) {
   $("#instructorTable").on("click", ".removeButton", function() {
     let closestRow = $(this).closest("tr");
     let username = closestRow.data('username');
-    console.log(closestRow)
+    
     // Check if the username is not empty or undefined
     if (username) {
         $("#instructorTableNames input[value='" + username + "']").remove();
@@ -139,9 +139,22 @@ $(document).ready(function(e) {
     updateEmptyTableMessage();
   });
 
-    $("#courseInstructor").on('input', function() {
-        searchUser("courseInstructor", createNewRow, true, null, "instructor");
-    });
+  $("#courseInstructor").on("focusout", function(){
+    $("#courseInstructor").val("")
+  })
+
+  $("#courseInstructor").on('input', function() {
+      searchUser("courseInstructor", createNewRow, true, null, "instructor");
+  });
+
+  $("#courseInstructor").popover({
+    trigger: "hover",
+    sanitize: false,
+    html: true,
+    content: function() {
+        return $(this).data('tooltip');
+    }
+  });
 
     // for each row in instructorTable that has an instructor, pass that instructors phone data to setupPhoneNumber
     $('#instructorTable tr').each(function(){
@@ -307,9 +320,11 @@ function validateForm() {
   var instructors = getCourseInstructors()
   if (!instructors.length && currentTab == 1) {
     valid = false;
-    $("#courseInstructor").addClass("invalid");
+    $("#instructorTable .emptyTableMessage").addClass("table-danger");
+    $("#instructorTable .emptyTableMessage label").removeClass("text-secondary");
   } else {
-    $("#courseInstructor").removeClass("invalid");
+    $("#instructorTable .emptyTableMessage").removeClass("table-danger");
+    $("#instructorTable .emptyTableMessage label").addClass("text-secondary");
   }
 
   if (valid) {

--- a/app/templates/serviceLearning/slcProposal.html
+++ b/app/templates/serviceLearning/slcProposal.html
@@ -16,16 +16,22 @@
         placeholder="Search instructor"
         value="" />
       <table
-        class="table mb-3"
+        class="table mb-1"
         id="instructorTable"
         name="instructorTable">
         <thead>
           <tr>
-            <th scope="col">Instructor</th>
+            <th scope="col">Instructor(s)</th>
             <th scope="col"></th>
           </tr>
         </thead>
         <tbody>
+            <tr class="emptyTableMessage" {{"hidden" if courseInstructor else ""}}>
+              <td>
+                <label class="text-secondary">No instructors selected</label>
+              </td>
+              <td></td>
+            </tr>
             <tr data-username="" hidden>
                 <td>
                   <p class="mb-0"></p>
@@ -51,7 +57,6 @@
             </tr>
             {% endfor %}
         </tbody>
-
       </table>
       <div id='instructorTableNames'>
         {% for instructor in courseInstructor %}

--- a/app/templates/serviceLearning/slcProposal.html
+++ b/app/templates/serviceLearning/slcProposal.html
@@ -25,7 +25,6 @@
               <td>
                 <label class="text-secondary ms-1"><i>No instructors selected</i></label>
               </td>
-              <td></td>
             </tr>
             <tr data-username="" hidden>
                 <td>

--- a/app/templates/serviceLearning/slcProposal.html
+++ b/app/templates/serviceLearning/slcProposal.html
@@ -14,21 +14,16 @@
         class="form-control"
         type="search"
         placeholder="Search instructor"
+        data-tooltip="Click on an instructor to add them"
         value="" />
       <table
         class="table mb-1"
         id="instructorTable"
         name="instructorTable">
-        <thead>
-          <tr>
-            <th scope="col">Instructor(s)</th>
-            <th scope="col"></th>
-          </tr>
-        </thead>
         <tbody>
             <tr class="emptyTableMessage" {{"hidden" if courseInstructor else ""}}>
               <td>
-                <label class="text-secondary">No instructors selected</label>
+                <label class="text-secondary ms-1"><i>No instructors selected</i></label>
               </td>
               <td></td>
             </tr>


### PR DESCRIPTION
## Issue Description

Fixes #1367 

When we create an SLC form, on the second page where we need to select the instructor, there should be more clarification.

 As of now, if the instructor for a course is not selected, it won't let the user continue to the third page. However, to select the instuctor, the user needs to click on the names appearing when they start typing the name of the instructor. If they don't click on the option with the instructor's name, and type the full name by themselves, it appears an instructor is selected when, in reality, there is not and it is not clear for the user why they can't proceed to the next page. 

## Changes

I did a few things to enhance transparency:
- There's a message that appears when no instructors have been added to the page
![image](https://github.com/user-attachments/assets/b2bac94d-4303-4568-b594-42625aa7cf23)

- Attempting to move onto the next page now highlights the empty table instead of the search field
![image](https://github.com/user-attachments/assets/7488ebec-6545-414b-9f16-541bfc6b11ab)

- The search bar now has a tooltip explaining that a click is required in order to add them to the instructor table
![image](https://github.com/user-attachments/assets/052fb759-9246-4567-af50-eed6f298d0ea)
I also made it so that the first name in the searched list is autofocused by default and can be conveniently added to the table by pressing enter.

- The search box now empties itself when you stop focusing it. This avoids any misunderstanding that you added a course instructor without clicking on their search result.
![image](https://github.com/user-attachments/assets/af31d433-f3a6-46b4-be12-690c1c465bac)
*unfocus
![image](https://github.com/user-attachments/assets/e4664b8e-650d-4244-b018-b3f05a0e0d43)



## Testing

In order to test, navigate to the course proposals tab,
![image](https://github.com/user-attachments/assets/84d99948-cd38-4135-9ef0-3951e0ffa06b)

Create a new course proposal
![image](https://github.com/user-attachments/assets/e3c20ff1-0d38-4aaa-96d3-570e6a12a556)

Navigate to the second page (tab) of the form.
![image](https://github.com/user-attachments/assets/2d28d057-eea0-4d31-90ac-2f3339b90905)

Finally, pretend you've never interacted with the search instructor field and make sure its intuitive what went wrong when you try to navigate to the next page without entering a course instructor and that its intuitive how to add an instructor to the list.
![image](https://github.com/user-attachments/assets/ff4617b9-4611-4eda-bb32-c3e394e281e8)


Two instructors in the test database you can use are `Finn Bledsoe` and `Brian Ramsay`
