### PR TITLE
Focused Student Search on Student Search Page page load

### DIFF
--- a/app/static/js/searchStudent.js
+++ b/app/static/js/searchStudent.js
@@ -2,13 +2,15 @@ import searchUser from './searchUser.js'
 function callback(selected) {
   $("#searchStudent").submit();
 }
-
-$("#searchStudentsInput").on("input", function() {
-  searchUser("searchStudentsInput", callback);
-});
-
-$("#searchIcon").click(function (e) {
-  e.preventDefault();
-  callback($("#searchStudentsInput").val());
-});
+$(document).ready(function() {
+  $("#searchStudentsInput").on("input", function() {
+    searchUser("searchStudentsInput", callback);
+  });
+  
+  $("#searchIcon").click(function (e) {
+    e.preventDefault();
+    callback($("#searchStudentsInput").val());
+  });
+  $("#searchStudentsInput").focus() 
+})
 


### PR DESCRIPTION
## Issue Description

Fixes issue #1369 
- We want to focus the main search bar on the Student Search Page on page load.

## Changes
- Add a document.ready and added a .focus tag to the search bar.

## Testing
- Setup your environment
- Make sure you are an admin
- Go to the student search page (/student_search)
- Upon page load, verify you are automatically focused on the main text box.