### PR TITLE
Python ver. 3.12 CI Fix

### DIFF
--- a/.github/workflows/actionTests.yml
+++ b/.github/workflows/actionTests.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     # each step can define `env` vars, but it's easiest to define them on the build level
     env:

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,13 +60,13 @@ PyYAML==6.0.1
 regex ==2023.6.3
 requests==2.25.1
 selenium==3.141.0
-six==1.16.0
+six==1.17.0
 SQLAlchemy==1.4.15
 systemtools==1.0.2
 termcolor==1.1.0
 toml==0.10.2
 tomli==2.0.1
-urllib3==1.26.4
+urllib3==1.26.20
 virtualenv==20.4.6
 visitor==0.1.3
 watchdog==2.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,12 +49,12 @@ Pygments==2.9.0
 PyMySQL==1.0.2
 pyodbc==5.2.0
 pyparsing==2.4.7
-pytest==7.1.2
-pytest-base-url==1.4.2
-pytest-html==2.1.1
-pytest-metadata==1.10.0
+pytest==7.4.4
+pytest-base-url==2.1.0
+pytest-html==4.1.1
+pytest-metadata==3.1.1
 pytest-watch==4.2.0
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
 python-editor==1.0.4
 PyYAML==6.0.1
 regex ==2023.6.3
@@ -62,6 +62,7 @@ requests==2.25.1
 selenium==3.141.0
 six==1.16.0
 SQLAlchemy==1.4.15
+systemtools==1.0.2
 termcolor==1.1.0
 toml==0.10.2
 tomli==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ py==1.11.0
 pycparser==2.20
 Pygments==2.9.0
 PyMySQL==1.0.2
-pyodbc==4.0.35
+pyodbc==5.2.0
 pyparsing==2.4.7
 pytest==7.1.2
 pytest-base-url==1.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ Flask-Migrate==3.0.0
 Flask-MySQL==1.5.2
 flask-nav==0.6
 Flask-SQLAlchemy==2.5.1
-greenlet==2.0.2
+greenlet==3.1.1
 humanfriendly==9.1
 idna==2.10
 importlib-metadata==6.5.0


### PR DESCRIPTION
## Issue Description

Fixes #1380 
- The CI workflow fails when running with Python 3.12 due to dependency incompatibilities. This prevents successful builds and testing for Python 3.12 in the GitHub Actions matrix.

## Changes

- Updated many of the dependencies in `requirements.txt` to allow for versions that are compatible with the separate versions of python within the CI tests.

## Testing

- Look through the CI test logs in the PR. If the builds/tests were failing, then we messed up the version numbers. Otherwise, the versions should be working