### PR TITLE
Delete event hours

### DIFF
--- a/app/logic/events.py
+++ b/app/logic/events.py
@@ -372,7 +372,7 @@ def getParticipatedEventsForUser(user):
                                .join(Program, JOIN.LEFT_OUTER).switch()
                                .join(EventParticipant)
                                .where(EventParticipant.user == user,
-                                      Event.isAllVolunteerTraining == False)
+                                      Event.isAllVolunteerTraining == False, Event.deletionDate == None)
                                .order_by(Event.startDate, Event.name))
 
     allVolunteer = (Event.select(Event, "")

--- a/app/logic/transcript.py
+++ b/app/logic/transcript.py
@@ -20,10 +20,11 @@ def getProgramTranscript(username):
 
     EventData = (Event.select(Event, fn.SUM(EventParticipant.hoursEarned).alias("hoursEarned"))
                       .join(EventParticipant)
-                      .where(EventParticipant.user == username)
+                      .where((EventParticipant.user == username) & (Event.deletionDate == None))
                       .group_by(Event.program, Event.term)
                       .order_by(Event.term)
                       .having(fn.SUM(EventParticipant.hoursEarned > 0)))
+    print("cve",EventData)
 
     # Fetch all ProgramBan objects for the user
     bannedProgramsForParticipant = ProgramBan.select().where(ProgramBan.user == username)
@@ -61,7 +62,7 @@ def getTotalHours(username):
     
     eventHours = (EventParticipant.select(fn.SUM(EventParticipant.hoursEarned))
                   .join(Event, on=(EventParticipant.event == Event.id))
-                  .where((EventParticipant.user == username) & (Event.program_id.not_in(transcriptsRemovedIdList)))).scalar()
+                  .where((EventParticipant.user == username) & (Event.program_id.not_in(transcriptsRemovedIdList)) & (Event.deletionDate == None))).scalar()
    
 
     

--- a/app/logic/transcript.py
+++ b/app/logic/transcript.py
@@ -24,7 +24,6 @@ def getProgramTranscript(username):
                       .group_by(Event.program, Event.term)
                       .order_by(Event.term)
                       .having(fn.SUM(EventParticipant.hoursEarned > 0)))
-    print("cve",EventData)
 
     # Fetch all ProgramBan objects for the user
     bannedProgramsForParticipant = ProgramBan.select().where(ProgramBan.user == username)


### PR DESCRIPTION
## Issue Description

Fixes ##1414

- If you delete an event, but have added a volunteer to that event already, it will still appear in the volunteer's participation history and the hours will still appear on the participant's service transcript in both total hours and the total service event hours.
- We will likely need to create a new SQL script to make sure any instances of this currently in the DB will be removed.
- Work through to identify the issue:
![Before event is deleted (1)](https://github.com/user-attachments/assets/e8e2eb04-28dc-435a-bd56-47e803bf76af)

## Changes

- When fixing it we found out events are not actually deleted but hidden from the view while still stored in the database with a deletion timestamp and deletion by, which is why we decided not to create a SQL script because the events are not deleted in the database at all.
- Identified it could be a peewee issue so we added Event.deletionDate == None to the where parameter in functions:

1. getParticipatedEventsForUser(user) to fix the volunteer's participation history bug
2. getProgramTranscript(username) to fix the deleted events from showing up
3. getTotalHours(username) to remove the deleted events' hours from being incremented

## Testing

- Set up 

- checkout the branch `git checkout deleteEventHours`
- pull the code when you are in the branch `git pull`
- reset the database `database/reset_database.sh test`
- run the test suite to make sure all the tests are working `tests/run_tests.sh`
- run the application `flask run`

- Create Event 

- create an event by going to current users on the menu bar and ensure you are Brian Ramsay
- go to "Create Event" tab and choose "Adopt-a-Grandparent" 
- fill out the form and make sure to checked the "Allow start date to be in the past" and "This event earns service hours." 
- set the date in the past
- after creating the event go to the "Manage Volunteer" tab and add the student in "Add volunteers" and add neillz or Zach Neill and save the student
- go to the "Current User" tab > Choose neillz > Go to My Profile  > click dropdown Choose an Action > Select View Service Transcript the events are created there
- go to the "Current User" tab > Choose neillz > Go to My Profile  > click accordion the Participation History the events are shown there

-Work through of the creation:
![Before event is deleted (2)](https://github.com/user-attachments/assets/030f641a-3b24-41f9-9fa2-dd5eb605990a)


- Delete Event

- Go back to the Brian Ramsay admin and go to Event List and find the event you created and click on the event.
- Deleted the event and return back to the "Current User" tab > Choose neillz > Go to My Profile  > click dropdown Choose an Action > Select View Service Transcript you will find the event deleted and the total time not being added up
-  go to "Current User" tab > Choose neillz > Go to My Profile  > click accordion the Participation History you will find the event no longer in the participation history

-Work through of the deletion:
![Before event is deleted](https://github.com/user-attachments/assets/3bcb14a9-2a3e-47de-ab00-38dbc1e14dfc)




