### PR TITLE
Program Training Display Fix

### DIFF
--- a/app/controllers/admin/routes.py
+++ b/app/controllers/admin/routes.py
@@ -370,8 +370,6 @@ def eventDisplay(eventId):
         currentEventRsvpAmount = getEventRsvpCount(event.id)
 
         userParticipatedTrainingEvents = getParticipationStatusForTrainings(eventData['program'], [g.current_user], g.current_term)
-        
-        
 
         return render_template("events/eventView.html",
                                 eventData=eventData,

--- a/app/controllers/admin/volunteers.py
+++ b/app/controllers/admin/volunteers.py
@@ -65,8 +65,7 @@ def manageVolunteersPage(eventID):
   
         eventNonAttendedData, eventWaitlistData, eventVolunteerData, eventParticipants = sortParticipantsByStatus(event)
         
-        allRelevantUsers = [participant.user for participant in (eventParticipants + eventNonAttendedData + eventWaitlistData)]
-        
+        allRelevantUsers = list(set(participant.user for participant in (eventParticipants + eventNonAttendedData + eventWaitlistData + eventVolunteerData)))
         # ----------- Get miscellaneous data -----------
 
         participationStatusForTrainings = getParticipationStatusForTrainings(event.program, allRelevantUsers, event.term)

--- a/app/logic/participants.py
+++ b/app/logic/participants.py
@@ -157,8 +157,16 @@ def getParticipationStatusForTrainings(program, userList, term):
     # Create a dictionary binding usernames to tuples. The tuples consist of the training (event object) and whether or not they attended it (bool)
     userParticipationStatus = {}
     for user in userList:
-        for training, attendeeList in trainingData.items():
-            userParticipationStatus[user.username] = userParticipationStatus.get(user.username, []) + [(training, user.username in attendeeList)]
+        seenEvents = {}     # Tracks the most recent index where each training event was processed for each user
+        for index, (training, attendeeList) in enumerate(trainingData.items()):
+            userAttendedTraining = user.username in attendeeList
+            if training.name in seenEvents:
+                targetIndex = seenEvents[training.name]
+                if userAttendedTraining:
+                    userParticipationStatus[user.username][targetIndex][1] = True
+            else:
+                userParticipationStatus[user.username] = userParticipationStatus.get(user.username, []) + [(training, user.username in attendeeList)]
+                seenEvents[training.name] = index
 
     return userParticipationStatus
 

--- a/app/logic/participants.py
+++ b/app/logic/participants.py
@@ -136,13 +136,14 @@ def getParticipationStatusForTrainings(program, userList, term):
 
     :returns: trainings for program and if the user participated
     """
-    isRelevantAllVolunteer = (Event.isAllVolunteerTraining) & (Event.term.academicYear == term.academicYear)
-    isRelevantProgramTraining = (Event.program == program) & (Event.term == term) & (Event.isTraining)
+    print(program)
+    isRelevantTraining = ((Event.isAllVolunteerTraining | ((Event.isTraining) & (Event.program == program))) & 
+                              (Event.term.academicYear == term.academicYear))
     programTrainings = (Event.select(Event, Term, EventParticipant, EventRsvp)
                              .join(EventParticipant, JOIN.LEFT_OUTER).switch()
                              .join(EventRsvp, JOIN.LEFT_OUTER).switch()
                              .join(Term)
-                             .where(isRelevantAllVolunteer | isRelevantProgramTraining, (Event.isCanceled != True)).order_by(Event.startDate))
+                             .where(isRelevantTraining, (Event.isCanceled != True)).order_by(Event.startDate))
 
     # Create a dictionary where the keys are trainings and values are a list of those who attended
     trainingData = {}

--- a/app/logic/participants.py
+++ b/app/logic/participants.py
@@ -11,6 +11,7 @@ from app.logic.users import isEligibleForProgram
 from app.logic.volunteers import getEventLengthInHours
 from app.logic.events import getEventRsvpCountsForTerm
 from app.logic.createLogs import createRsvpLog
+from collections import defaultdict
 
 def trainedParticipants(programID, targetTerm):
     """
@@ -136,7 +137,6 @@ def getParticipationStatusForTrainings(program, userList, term):
 
     :returns: trainings for program and if the user participated
     """
-    print(program)
     isRelevantTraining = ((Event.isAllVolunteerTraining | ((Event.isTraining) & (Event.program == program))) & 
                               (Event.term.academicYear == term.academicYear))
     programTrainings = (Event.select(Event, Term, EventParticipant, EventRsvp)
@@ -145,32 +145,29 @@ def getParticipationStatusForTrainings(program, userList, term):
                              .join(Term)
                              .where(isRelevantTraining, (Event.isCanceled != True)).order_by(Event.startDate))
 
-    # Create a dictionary where the keys are trainings and values are a list of those who attended
-    trainingData = {}
+    # Create a dictionary where the keys are trainings and values are a set of those who attended
+    trainingData = defaultdict(set)
     for training in programTrainings:
         try:
             if training.isPastStart:
-                trainingData[training] = trainingData.get(training, []) + [training.eventparticipant.user_id]
+                trainingData[training].add(training.eventparticipant.user_id)
             else:  # The training has yet to happen
-                trainingData[training] = trainingData.get(training, []) + [training.eventrsvp.user_id]
+                trainingData[training].add(training.eventrsvp.user_id)
         except AttributeError:
-            trainingData[training] = trainingData.get(training, [])
-    # Create a dictionary binding usernames to tuples. The tuples consist of the training (event object) and whether or not they attended it (bool)
-    userParticipationStatus = {}
-    for user in userList:
-        seenEvents = {}     # Tracks the most recent index where each training event was processed for each user
-        index = 0
-        for training, attendeeList in trainingData.items():
-            userAttendedTraining = user.username in attendeeList
-            if training.name in seenEvents:
-                targetIndex = seenEvents[training.name] 
-                if userAttendedTraining:
-                    userParticipationStatus[user.username][targetIndex][1] = True
-            else:
-                userParticipationStatus[user.username] = userParticipationStatus.get(user.username, []) + [[training, user.username in attendeeList]]
-                seenEvents[training.name] = index
-                index += 1
-    return userParticipationStatus
+            pass
+    # Create a dictionary binding usernames to a list of [training, hasAttended] pairs. The tuples consist of the training (event object) and whether or not they attended it (bool)
+
+    # Necessarily complex algorithm to merge the attendances of trainings which have the same name
+    # Structure of userParticipationStatus for a single user:
+    # {user.username: {training1.name: [EventObject, hasAttended], training2.name: [EventObject, hasAttended]}, ...}
+    userParticipationStatus = {user.username: {} for user in userList}
+    for training, attendeeList in trainingData.items():
+        for user in userList:
+            if training.name not in userParticipationStatus[user.username] or user.username in attendeeList:
+                userParticipationStatus[user.username][training.name] = [training, user.username in attendeeList]
+    
+    return {user.username: list(userParticipationStatus[user.username].values()) for user in userList}
+
 
 def sortParticipantsByStatus(event):
     """

--- a/app/logic/participants.py
+++ b/app/logic/participants.py
@@ -158,16 +158,17 @@ def getParticipationStatusForTrainings(program, userList, term):
     userParticipationStatus = {}
     for user in userList:
         seenEvents = {}     # Tracks the most recent index where each training event was processed for each user
-        for index, (training, attendeeList) in enumerate(trainingData.items()):
+        index = 0
+        for training, attendeeList in trainingData.items():
             userAttendedTraining = user.username in attendeeList
             if training.name in seenEvents:
-                targetIndex = seenEvents[training.name]
+                targetIndex = seenEvents[training.name] 
                 if userAttendedTraining:
                     userParticipationStatus[user.username][targetIndex][1] = True
             else:
-                userParticipationStatus[user.username] = userParticipationStatus.get(user.username, []) + [(training, user.username in attendeeList)]
+                userParticipationStatus[user.username] = userParticipationStatus.get(user.username, []) + [[training, user.username in attendeeList]]
                 seenEvents[training.name] = index
-
+                index += 1
     return userParticipationStatus
 
 def sortParticipantsByStatus(event):

--- a/app/templates/macros/trainingsHoverMacro.html
+++ b/app/templates/macros/trainingsHoverMacro.html
@@ -13,9 +13,9 @@
                 {% set isRsvpd = rsvpdOrAttended %}
                 {% set date = training.startDate.strftime("%m/%d/%Y") %}
                 {% if isRsvpd %}
-                    <p><b>{{trainingName}}</b>: <br>Rsvp'd for training on {{date}}</p>
+                    <p><b>{{trainingName}}</b>: <br>RSVP'd for training on {{date}}</p>
                 {% else %}
-                    <p><b>{{trainingName}}</b>: <br>Not Rsvp'd for training on {{date}}</p>
+                    <p><b>{{trainingName}}</b>: <br>Not RSVP'd for this training, next training on {{date}}</p>
                 {% endif %}
             {% endif%}
         {% endfor %}


### PR DESCRIPTION
## Issue Description

Fixes #1375 
- If there are multiple instances of the same training where the user only has to attend one instance, all duplicate instances of the test will show up when viewing training requirements for any given user.

## Changes

- Updated logic to track and conditionally display trainings for any given student.
- Fixed bug in development where trainings were not displaying for students in the Manage Volunteer view.

Old look:
![image](https://github.com/user-attachments/assets/5bd855c9-14ff-477b-8cad-ea2cc6b6d1cf)

New look:
![image](https://github.com/user-attachments/assets/ad9ece7f-e316-411f-bd1a-291efb60e54d)

## Testing

- Create sample trainings and ensure that the view works correctly.