### PR TITLE
Simplified/Refactored getParticipationStatusForTrainings

### DIFF
--- a/app/logic/participants.py
+++ b/app/logic/participants.py
@@ -11,6 +11,7 @@ from app.logic.users import isEligibleForProgram
 from app.logic.volunteers import getEventLengthInHours
 from app.logic.events import getEventRsvpCountsForTerm
 from app.logic.createLogs import createRsvpLog
+from collections import defaultdict
 
 def trainedParticipants(programID, targetTerm):
     """
@@ -144,23 +145,29 @@ def getParticipationStatusForTrainings(program, userList, term):
                              .join(Term)
                              .where(isRelevantAllVolunteer | isRelevantProgramTraining, (Event.isCanceled != True)).order_by(Event.startDate))
 
-    # Create a dictionary where the keys are trainings and values are a list of those who attended
-    trainingData = {}
+    # Create a dictionary where the keys are trainings and values are a set of those who attended
+    trainingData = defaultdict(set)
     for training in programTrainings:
         try:
             if training.isPastStart:
-                trainingData[training] = trainingData.get(training, []) + [training.eventparticipant.user_id]
+                trainingData[training].add(training.eventparticipant.user_id)
             else:  # The training has yet to happen
-                trainingData[training] = trainingData.get(training, []) + [training.eventrsvp.user_id]
+                trainingData[training].add(training.eventrsvp.user_id)
         except AttributeError:
-            trainingData[training] = trainingData.get(training, [])
-    # Create a dictionary binding usernames to tuples. The tuples consist of the training (event object) and whether or not they attended it (bool)
-    userParticipationStatus = {}
-    for user in userList:
-        for training, attendeeList in trainingData.items():
-            userParticipationStatus[user.username] = userParticipationStatus.get(user.username, []) + [(training, user.username in attendeeList)]
+            pass
+    # Create a dictionary binding usernames to a list of [training, hasAttended] pairs. The tuples consist of the training (event object) and whether or not they attended it (bool)
 
-    return userParticipationStatus
+    # Necessarily complex algorithm to merge the attendances of trainings with the same name
+    # Structure of userParticipationStatus for a single user:
+    # {user.username: {training1.name: [EventObject, hasAttended], training2.name: [EventObject, hasAttended]}, ...}
+    userParticipationStatus = {user.username: {} for user in userList}
+    for training, attendeeList in trainingData.items():
+        for user in userList:
+            if training.name not in userParticipationStatus[user.username] or user.username in attendeeList:
+                userParticipationStatus[user.username][training.name] = [training, user.username in attendeeList]
+    
+    return {user.username: list(userParticipationStatus[user.username].values()) for user in userList}
+
 
 def sortParticipantsByStatus(event):
     """


### PR DESCRIPTION
## Issue Description

This is a very small PR, just refactoring a single function for readability.

I noticed that the `getParticipationStatusForTrainings()` function inside of `/home/vscode/celts/app/logic/participants.py` (which I wrote about a year and a half ago), was far more complicated than it needed to be since I didn't know about better data structures.

## Changes

I refactored the getParticipationStatusForTrainings function which should now, hopefully, be more readable.

## Testing

- Run the tests script and ensure all tests pass. 
- Look at the code and ensure that its readable enough, please suggest any ways I could further simplify this code.