### PR TITLE
Fixed print button position on "View Service Transcript" page #1458

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "msedge",
+            "request": "launch",
+            "name": "Open serviceTranscript.html",
+            "file": "/home/vscode/celts/database/app/templates/main/serviceTranscript.html"
+        }
+    ]
+}

--- a/app/templates/main/serviceTranscript.html
+++ b/app/templates/main/serviceTranscript.html
@@ -55,18 +55,30 @@
       {% endfor %}
       </table>
     {% endif %}
-    <div class="pt-4">
+    <DIV CLASS="col-6""">
+    
+      <div class="pt-4">
       <div class="float-end">
       <p class="fw-bold pb-3 d-inline">Total Service Hours:</p>
       <p class="d-inline bg-light ps-2 pe-5 border-bottom" id="hourTotal">{{ totalHours["totalCourseHours"]|round(2) }}</p>
       </div>
     </div>
-    <p>*Volunteering since {{ startDate }}</p>
-    <div class="float-end">
-      <button type="button" class="btn btn-primary d-print-none m-4" onclick="window.print()"><span class="bi bi-printer d-print-none"></span>Print</button>
+  </DIV>
+    
+  <p>*Volunteering since {{ startDate }}</p>
+
+
+  
+   
+    <div class="float-end" >
       <p class="fw-bold pb-3 d-inline">Total Hours:</p>
+      <br
+      button type="button" class="btn btn-primary d-print-none m-4" onclick="window.print()"><span class="bi bi-printer d-print-none"></span>Print</button>
+      <br
       <p class="d-inline bg-light ps-2 pe-5 border-bottom" id="hourTotal">{{ totalHours["totalHours"]|round(2) }}</p>
     </div>
+    
+
     {% else %}
       <h5>No Volunteer Record</h5>
     {% endif %}

--- a/app/templates/main/serviceTranscript.html
+++ b/app/templates/main/serviceTranscript.html
@@ -71,13 +71,12 @@
   
    
     <div class="float-end" >
-      <button type="button" class="btn btn-primary d-print-none m-4" onclick="window.print()"><span class="bi bi-printer d-print-none"></span>Print</button>
-      <br
       <p class="fw-bold pb-3 d-inline">Total Hours:</p>
-      <br
+      <button type="button" class="btn btn-primary d-print-none m-4" onclick="window.print()"><span class="bi bi-printer d-print-none"></span>Print</button>
+      <br>
       button type="button" class="btn btn-primary d-print-none m-4" onclick="window.print()"><span class="bi bi-printer d-print-none"></span>Print</button>
       <br
-      <p class="d-inline bg-light ps-2 pe-5 border-bottom" id="hourTotal">{{ totalHours["totalHours"]|round(2) }}</p>
+      <p></p>class="d-inline bg-light ps-2 pe-5 border-bottom" id="hourTotal">{{ totalHours["totalHours"]|round(2) }}</p>
     </div>
     
 

--- a/app/templates/main/serviceTranscript.html
+++ b/app/templates/main/serviceTranscript.html
@@ -71,6 +71,8 @@
   
    
     <div class="float-end" >
+      <button type="button" class="btn btn-primary d-print-none m-4" onclick="window.print()"><span class="bi bi-printer d-print-none"></span>Print</button>
+      <br
       <p class="fw-bold pb-3 d-inline">Total Hours:</p>
       <br
       button type="button" class="btn btn-primary d-print-none m-4" onclick="window.print()"><span class="bi bi-printer d-print-none"></span>Print</button>

--- a/app/templates/main/serviceTranscript.html
+++ b/app/templates/main/serviceTranscript.html
@@ -72,11 +72,10 @@
    
     <div class="float-end" >
       <p class="fw-bold pb-3 d-inline">Total Hours:</p>
-      <button type="button" class="btn btn-primary d-print-none m-4" onclick="window.print()"><span class="bi bi-printer d-print-none"></span>Print</button>
-      <br>
+      <br
       button type="button" class="btn btn-primary d-print-none m-4" onclick="window.print()"><span class="bi bi-printer d-print-none"></span>Print</button>
       <br
-      <p></p>class="d-inline bg-light ps-2 pe-5 border-bottom" id="hourTotal">{{ totalHours["totalHours"]|round(2) }}</p>
+      <p class="d-inline bg-light ps-2 pe-5 border-bottom" id="hourTotal">{{ totalHours["totalHours"]|round(2) }}</p>
     </div>
     
 

--- a/app/templates/main/serviceTranscript.html
+++ b/app/templates/main/serviceTranscript.html
@@ -55,30 +55,21 @@
       {% endfor %}
       </table>
     {% endif %}
-    <DIV CLASS="col-6""">
-    
-      <div class="pt-4">
+    <div class="pt-4">
       <div class="float-end">
       <p class="fw-bold pb-3 d-inline">Total Service Hours:</p>
       <p class="d-inline bg-light ps-2 pe-5 border-bottom" id="hourTotal">{{ totalHours["totalCourseHours"]|round(2) }}</p>
       </div>
     </div>
-  </DIV>
-    
-  <p>*Volunteering since {{ startDate }}</p>
-
-
-  
-   
-    <div class="float-end" >
+    <p>*Volunteering since {{ startDate }}</p>
+    <div class="float-end">
+      
       <p class="fw-bold pb-3 d-inline">Total Hours:</p>
-      <br
-      button type="button" class="btn btn-primary d-print-none m-4" onclick="window.print()"><span class="bi bi-printer d-print-none"></span>Print</button>
-      <br
       <p class="d-inline bg-light ps-2 pe-5 border-bottom" id="hourTotal">{{ totalHours["totalHours"]|round(2) }}</p>
+      <br>
+      <button type="button" class="btn btn-primary d-print-none m-4" onclick="window.print()"><span class="bi bi-printer d-print-none"></span>Print</button>
+     
     </div>
-    
-
     {% else %}
       <h5>No Volunteer Record</h5>
     {% endif %}

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -408,7 +408,7 @@
                   </td>
                   <td>
                     {% if (g.current_user == row.note.createdBy) or g.current_user.isCeltsAdmin%}
-                      <button type="button" class="btn btn-sm btn-danger deleteNoteButton float-end" data-noteid="{{row.id}}" data-username="{{volunteer.username}}">Delete</button>
+                      <="button" class="btn btn-sm btn-danger deleteNoteButton float-end" data-noteid="{{row.id}}" data-username="{{volunteer.username}}">Delete</button>
                     {% else %}
                       <button type="button" class="btn btn-sm btn-danger deleteNoteButton float-end disabled" data-noteid="{{row.id}}" data-username="{{volunteer.username}}">Delete</button>
                     {% endif %}


### PR DESCRIPTION
#1458

**Issue Description**
The print button on the View Service Transcript page was incorrectly positioned beside the Total Hrs section, instead of being placed below it. This misalignment affected the layout of the page.

**## Changes**
- Moved the Print button to appear under the Total Hrs session instead of beside it.
- Updated associated layout styles to ensure consistent spacing and responsiveness.

![Screenshot 2025-06-12 at 3 44 06 PM](https://github.com/user-attachments/assets/48c54036-cf95-4eaa-a7e2-a931aa08da67)

 **Testing**
- On the **CELTS Website,** go to my profile
- Select **Choose Action**
- Navigated to the View **Service Transcript page.**
- Verified the Print button now appears directly below the Total Hrs section.


