### PR TITLE
Insuranceinfo

### DIFF
--- a/app/controllers/admin/volunteers.py
+++ b/app/controllers/admin/volunteers.py
@@ -103,10 +103,13 @@ def volunteerDetailsPage(eventID):
 
     eventRsvpData = list(EventRsvp.select(EmergencyContact, InsuranceInfo, EventRsvp)
                                   .join(EmergencyContact, JOIN.LEFT_OUTER, on=(EmergencyContact.user==EventRsvp.user))
+                                  .switch(EventRsvp)
                                   .join(InsuranceInfo, JOIN.LEFT_OUTER, on=(InsuranceInfo.user==EventRsvp.user))
                                   .where(EventRsvp.event==event))
-    eventParticipantData = list(EventParticipant.select(EmergencyContact, EventParticipant)
+    eventParticipantData = list(EventParticipant.select(EmergencyContact, EventParticipant,InsuranceInfo)
                                                 .join(EmergencyContact, JOIN.LEFT_OUTER, on=(EmergencyContact.user==EventParticipant.user))
+                                                .switch(EventParticipant)
+                                                .join(InsuranceInfo, JOIN.LEFT_OUTER, on=(InsuranceInfo.user==EventParticipant.user))
                                                 .where(EventParticipant.event==event))
     
     

--- a/app/controllers/admin/volunteers.py
+++ b/app/controllers/admin/volunteers.py
@@ -8,6 +8,7 @@ from app.models.program import Program
 from app.models.user import User
 from app.models.eventParticipant import EventParticipant
 from app.models.emergencyContact import EmergencyContact
+from app.models.insuranceInfo import InsuranceInfo
 from app.logic.searchUsers import searchUsers
 from app.logic.volunteers import updateEventParticipants, getEventLengthInHours, addUserBackgroundCheck, setProgramManager, deleteUserBackgroundCheck
 from app.logic.participants import trainedParticipants, addPersonToEvent, getParticipationStatusForTrainings, sortParticipantsByStatus
@@ -100,12 +101,14 @@ def volunteerDetailsPage(eventID):
     if not (g.current_user.isCeltsAdmin or (g.current_user.isCeltsStudentStaff and g.current_user.isProgramManagerForEvent(event))):
         abort(403)
 
-    eventRsvpData = list(EventRsvp.select(EmergencyContact, EventRsvp)
+    eventRsvpData = list(EventRsvp.select(EmergencyContact, InsuranceInfo, EventRsvp)
                                   .join(EmergencyContact, JOIN.LEFT_OUTER, on=(EmergencyContact.user==EventRsvp.user))
+                                  .join(InsuranceInfo, JOIN.LEFT_OUTER, on=(InsuranceInfo.user==EventRsvp.user))
                                   .where(EventRsvp.event==event))
     eventParticipantData = list(EventParticipant.select(EmergencyContact, EventParticipant)
                                                 .join(EmergencyContact, JOIN.LEFT_OUTER, on=(EmergencyContact.user==EventParticipant.user))
                                                 .where(EventParticipant.event==event))
+    
     
     waitlistUser = list(set([obj for obj in eventRsvpData if obj.rsvpWaitlist]))
     rsvpUser = list(set([obj for obj in eventRsvpData if not obj.rsvpWaitlist ]))

--- a/app/static/css/volunteerDetails.css
+++ b/app/static/css/volunteerDetails.css
@@ -58,8 +58,6 @@
     display: none;
 }
 
-
-
 .custom-odd td {
     background-color: #f8f9fa;
 }

--- a/app/static/css/volunteerDetails.css
+++ b/app/static/css/volunteerDetails.css
@@ -58,6 +58,8 @@
     display: none;
 }
 
+
+
 .custom-odd td {
     background-color: #f8f9fa;
 }

--- a/app/templates/events/volunteerDetails.html
+++ b/app/templates/events/volunteerDetails.html
@@ -115,7 +115,7 @@
           <input class="displayCheckbox noprint" type="checkbox" name="selected_items" id="emailSelect" checked>
           <label for="emailSelect">Email</label><br>
           <input class="displayCheckbox noprint" type="checkbox" name="selected_items" id="insuranceSelect" checked>
-          <label for="InsuranceInformationSelect">Insurance Information</label><br>
+          <label for="InsuranceSelect">Insurance Information</label><br>
           <input class="displayCheckbox noprint bNumberSelect" type="checkbox" name="selected_items" id="barcodeSelect" checked>
           <label class="bNumberSelect" for="barcodeSelect">B-Number Barcode</label><br>
         </div>

--- a/app/templates/events/volunteerDetails.html
+++ b/app/templates/events/volunteerDetails.html
@@ -15,13 +15,23 @@
 {{super()}}
 <script type="module" src="/static/js/volunteerDetails.js"></script>
 <script src="https://cdn.datatables.net/1.11.4/js/jquery.dataTables.min.js"></script>
+
 {% endblock %}
 
 {########################### Display macros ###########################}
 {% macro createCard(participant, volunteerType) %}
   
     <div class="{{volunteerType}}Select col-12 col-md-6 volunteerInfoEntries print-column" data-user="{{participant.user.username}}" nowrap>
-      <h4 class="nameSelect" nowrap><b>{{ participant.user.firstName }} {{ participant.user.lastName }}</b></h4>
+      <h4 class="nameSelect" nowrap><b>{{ participant.user.firstName }} {{ participant.user.lastName }}</b>
+      {% if participant.insuranceinfo %}
+          
+        {% if participant.insuranceinfo.healthIssues %}
+          
+        <i class="bi bi-star-fill fs-6"></i>
+          {% endif %}
+          {% endif %}  
+      
+      </h4>
       <ul>
         <div class="barcodeSelect bnumber-barcode" nowrap>{{participant.user.bnumber[1:]}}</div>
         <div class="phoneSelect" nowrap>{{ participant.user.phoneNumber if participant.user.phoneNumber else "No phone number"}}</div>
@@ -32,7 +42,15 @@
           {{participant.emergencycontact.cellPhone or participant.emergencycontact.homePhone or participant.emergencycontact.workPhone if participant.emergencycontact}} 
           {{"None Specified" if not participant.emergencycontact}}</div>
           
-        <!-- <div class="insuranceInfoSelect" nowrap>Insurance Info: {{participant.insuranceinfo.name if participant.insuranceinfo}}</div> -->
+         <div class="insuranceInfoSelect" nowrap>Insurance Info: 
+          {% if participant.insuranceinfo %}
+          {{participant.insuranceinfo.insuranceCompany}}
+          
+        {% if participant.insuranceinfo.healthIssues %}
+          
+          {% endif %}
+          {% endif %}        
+         </div>
           
         
       </ul>
@@ -49,7 +67,10 @@
       
       <td class="emergencyContactSelect">{{participant.emergencycontact.name if participant.emergencycontact}} 
         {{participant.emergencycontact.cellPhone or participant.emergencycontact.homePhone or participant.emergencycontact.workPhone if participant.emergencycontact}} </td>
-        <td class="insuranceSelect" nowrap>{{ participant.insuranceInfo}}</td>
+      {% if participant.insuranceinfo %}
+        <td class="insuranceSelect" nowrap> {{ participant.insuranceinfo.policyNumber}}</td>
+
+        {% endif %}
       </tr>
 {% endmacro %}
 
@@ -128,7 +149,10 @@
             </div>
           </div>
         </div>
-      </div>
+
+      <div><i class="bi bi-star-fill fs-6"></i> Star indicates this profile needs to be checked</div>
+      
+        </div>
     </div>
 
     <hr>

--- a/app/templates/events/volunteerDetails.html
+++ b/app/templates/events/volunteerDetails.html
@@ -31,6 +31,10 @@
         <div class="emergencyContactSelect" nowrap>Emergency Contact: {{participant.emergencycontact.name if participant.emergencycontact}} 
           {{participant.emergencycontact.cellPhone or participant.emergencycontact.homePhone or participant.emergencycontact.workPhone if participant.emergencycontact}} 
           {{"None Specified" if not participant.emergencycontact}}</div>
+          
+        <!-- <div class="insuranceInfoSelect" nowrap>Insurance Info: {{participant.insuranceinfo.name if participant.insuranceinfo}}</div> -->
+          
+        
       </ul>
     </div>
 {% endmacro %}
@@ -42,9 +46,11 @@
       <td class="emailSelect" nowrap>{{ participant.user.email }}</td>
       <td class="statusSelect" nowrap>{{ volunteerType|title if volunteerType != 'rsvp' else volunteerType|upper}}</td>
       <td class="dietRestrictionSelect">{{ participant.user.dietRestriction if participant.user.dietRestriction else ''}}</td>
+      
       <td class="emergencyContactSelect">{{participant.emergencycontact.name if participant.emergencycontact}} 
         {{participant.emergencycontact.cellPhone or participant.emergencycontact.homePhone or participant.emergencycontact.workPhone if participant.emergencycontact}} </td>
-    </tr>
+        <td class="insuranceSelect" nowrap>{{ participant.insuranceInfo}}</td>
+      </tr>
 {% endmacro %}
 
 {% macro printParticipants(type, attended, rsvp, waitlist) %}
@@ -107,6 +113,8 @@
           <label for="statusSelect">Volunteer Status</label><br>
           <input class="displayCheckbox noprint" type="checkbox" name="selected_items" id="emailSelect" checked>
           <label for="emailSelect">Email</label><br>
+          <input class="displayCheckbox noprint" type="checkbox" name="selected_items" id="insuranceSelect" checked>
+          <label for="InsuranceInformationSelect">Insurance Information</label><br>
           <input class="displayCheckbox noprint bNumberSelect" type="checkbox" name="selected_items" id="barcodeSelect" checked>
           <label class="bNumberSelect" for="barcodeSelect">B-Number Barcode</label><br>
         </div>
@@ -140,6 +148,7 @@
           <th class="statusSelect">Volunteer Status</th>
           <th class="dietRestrictionSelect">Dietary Restriction</th>
           <th class="emergencyContactSelect">Emergency Contact</th>
+          <th class="insuranceSelect">Insurance Information</th>
         </tr>
       </thead>
       <tbody>

--- a/app/templates/events/volunteerDetails.html
+++ b/app/templates/events/volunteerDetails.html
@@ -15,7 +15,6 @@
 {{super()}}
 <script type="module" src="/static/js/volunteerDetails.js"></script>
 <script src="https://cdn.datatables.net/1.11.4/js/jquery.dataTables.min.js"></script>
-
 {% endblock %}
 
 {########################### Display macros ###########################}
@@ -23,14 +22,9 @@
   
     <div class="{{volunteerType}}Select col-12 col-md-6 volunteerInfoEntries print-column" data-user="{{participant.user.username}}" nowrap>
       <h4 class="nameSelect" nowrap><b>{{ participant.user.firstName }} {{ participant.user.lastName }}</b>
-      {% if participant.insuranceinfo %}
-          
-        {% if participant.insuranceinfo.healthIssues %}
-          
-        <i class="bi bi-star-fill fs-6"></i>
-          {% endif %}
-          {% endif %}  
-      
+        {% if participant.insuranceinfo and participant.insuranceinfo.healthIssues %}
+          <i class="bi bi-star-fill fs-6"></i>
+        {% endif %}
       </h4>
       <ul>
         <div class="barcodeSelect bnumber-barcode" nowrap>{{participant.user.bnumber[1:]}}</div>
@@ -41,16 +35,7 @@
         <div class="emergencyContactSelect" nowrap>Emergency Contact: {{participant.emergencycontact.name if participant.emergencycontact}} 
           {{participant.emergencycontact.cellPhone or participant.emergencycontact.homePhone or participant.emergencycontact.workPhone if participant.emergencycontact}} 
           {{"None Specified" if not participant.emergencycontact}}</div>
-          
-          {% if participant.insuranceinfo %}
-          <div class="insuranceSelect" nowrap>Insurance Info: 
-          {{participant.insuranceinfo.insuranceCompany}}
-          
-      
-      </div>
-          {% endif %}        
-          
-        
+        <div class="insuranceSelect" nowrap>Insurance Info: {{participant.insuranceinfo.insuranceCompany if participant.insuranceinfo}}</div>
       </ul>
     </div>
 {% endmacro %}
@@ -65,11 +50,8 @@
       
       <td class="emergencyContactSelect">{{participant.emergencycontact.name if participant.emergencycontact}} 
         {{participant.emergencycontact.cellPhone or participant.emergencycontact.homePhone or participant.emergencycontact.workPhone if participant.emergencycontact}} </td>
-      {% if participant.insuranceinfo %}
-        <td class="insuranceSelect" nowrap> {{ participant.insuranceinfo.policyNumber}}</td>
-
-        {% endif %}
-      </tr>
+      <td class="insuranceSelect" nowrap>{{ participant.insuranceinfo.policyNumber if participant.insuranceinfo}}</td>
+    </tr>
 {% endmacro %}
 
 {% macro printParticipants(type, attended, rsvp, waitlist) %}
@@ -132,10 +114,8 @@
           <label for="statusSelect">Volunteer Status</label><br>
           <input class="displayCheckbox noprint" type="checkbox" name="selected_items" id="emailSelect" checked>
           <label for="emailSelect">Email</label><br>
-
           <input class="displayCheckbox noprint" type="checkbox" name="selected_items" id="insuranceSelect" checked>
-          <label for="insuranceSelect">Insurance Information</label><br>
-
+          <label for="InsuranceInformationSelect">Insurance Information</label><br>
           <input class="displayCheckbox noprint bNumberSelect" type="checkbox" name="selected_items" id="barcodeSelect" checked>
           <label class="bNumberSelect" for="barcodeSelect">B-Number Barcode</label><br>
         </div>
@@ -149,14 +129,10 @@
             </div>
           </div>
         </div>
-
+      </div>
       <div><i class="bi bi-star-fill fs-6"></i> Star indicates this profile needs to be checked</div>
-      
-        </div>
     </div>
-
     <hr>
-
     <div class="d-print-block" id="volunteerInformationCardToPrint">
       <div class="row sort-here">
         {{ printParticipants('card', attendedUser, rsvpUser, waitlistUser) }}


### PR DESCRIPTION
## Issue Description

Fixes #1451
- Add in Insurance Information to Volunteer Details. Either add it in the print view or add another column.

## Changes

- Added Insurance Policy Number for the table view in the Volunteer Details Section of an event.
- Added Insurance Company Name for the card view in the Volunteer Details Section of an event.
- Added star next to full name in card view to indicate health issues.

![image](https://github.com/user-attachments/assets/45d8e662-661e-4738-8863-ed8e5872dde5)
![image](https://github.com/user-attachments/assets/299fe417-6909-4c9f-94ca-07b76a6ef0ca)




## Testing
- Replace line 295 that states `readOnly = g.current_user.username != username` in the directory (/home/vscode/celts/app/controllers/main/routes.py)  with `readOnly = False`
- Replace line 304 that states `if g.current_user.username != username:` in the same directory with `if False:` (please make sure it is indented properly)
- As an admin, go to Events List, select an event, navigate to Manage Volunteers (add volunteers if needed), then go to Volunteer Details. Insurance information should now be visible in both the table and card views.