### PR TITLE
Deleted the "allow start date to be in the past" toggle

### DIFF
--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -509,8 +509,8 @@ $(document).ready(function() {
       let startDate = new Date($("#repeatingEventsStartDate").val());
       let endDate = new Date($("#repeatingEventsEndDate").val());
       let startTime = $("#repeatingEventsStartTime").val();
-      let endTime = $("#repeatingEventsEndTime").val();      
-startDatePicker
+      let endTime = $("#repeatingEventsEndTime").val();
+
       if (navigator.userAgent.indexOf("Chrome") == -1) {
         startTime = format12to24HourTime(startTime)
         endTime = format12to24HourTime(endTime)
@@ -652,3 +652,7 @@ startDatePicker
 
   setCharacterLimit($("#inputCharacters"), "#remainingCharacters"); 
 });
+
+
+
+

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -487,6 +487,7 @@ $(document).ready(function() {
       // Enable single event name field
       $('#inputEventName').prop('readonly', false)
       $('#inputEventName').prop('placeholder', 'Enter event name')
+      checkIfDateInPast();
     }
   });
 

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -68,6 +68,7 @@ function setViewForSeries(){
   $(".startDatePicker").prop('required', false);
   $("#multipleOfferingTableDiv").removeClass('d-none');
   $('#eventTime, #eventDate').addClass('d-none');
+  $("#pastDateWarningText").text("")
 }
 
 function displayNotification(message) {
@@ -238,6 +239,7 @@ $('#saveSeries').on('click', function() {
     $('#textNotifierPadding').removeClass('pt-5');
     updateOfferingsTable();
     pendingmultipleEvents = [];
+    $("#pastDateWarningText").text("")
     $("#checkIsSeries").prop('checked', true);
     // Remove the modal and overlay from the DOM
     $('#modalSeries').modal('hide');
@@ -579,6 +581,7 @@ function handleTimeFormatting(timeArray){
     let endDateSelected = new Date(+year, +month - 1, +day, +endHour, +endMin)
     let now = new Date()
     
+
     if (startDateSelected < now && endDateSelected > now) {
       $("#pastDateWarningText").text("This event is currently happening!")
     }
@@ -622,7 +625,7 @@ function handleTimeFormatting(timeArray){
     $(".datePicker").datepicker("option", "disabled", true);
   }
 
-  $(".readonly").on('keydown paste', function (e) {
+  $(".readonly").on('keydown paste', function(e) {
     if (e.keyCode != 9) // ignore tab
       e.preventDefault();
   });

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -550,15 +550,36 @@ $(document).ready(function() {
     var minDate = new Date('10/25/1999') 
     $("#startDatePicker-main").datepicker("option", "minDate", minDate)
 
+  // This converts the time to 24 hour format in case it is in 12 hour format (like in Firefox)
+   function handleTimeFormatting(timeArray){    
+    let time  = timeArray[0]
+    let timeSuffix = timeArray[1]         // looks for AM or PM in time 
+    let [hours , min] = time. split(':')
+
+    if (timeArray.length === 2) {
+        hours  = parseInt(hours, 10)
+          if (timeSuffix === 'PM' && hours !== 12) {
+          hours += 12;
+          } else if (timeSuffix === 'AM' && hours === 12) {
+          hours = 0;
+          }
+
+      const hoursStr = hours.toString().padStart(2, '0');
+        return [hoursStr, min]
+      }
+    return [hours, min]
+  }
+
     function checkIfDateInPast() {
       const [month, day, year] = $("#startDatePicker-main").val().split('/')
-      const [startHour, starMin] = $("#startTime-main").val().split(':')
-      const [endHour, endMin] = $("#endTime-main").val().split(':')
-
-      let startDateSelected = new Date(+year, +month - 1, +day, +startHour, +starMin);  
+      const startTimeArray =  $("#startTime-main").val().split(' ') 
+      const [startHour, startMin] = handleTimeFormatting(startTimeArray)
+      const endTimeArray = $('#endTime-main').val().split(' ')
+      const [endHour, endMin] = handleTimeFormatting (endTimeArray)
+      let startDateSelected =new Date(+year, +month - 1, +day, +startHour, +startMin);  
       let endDateSelected = new Date(+year, +month - 1, +day, +endHour, +endMin)
       let now = new Date()
-
+      
       if (startDateSelected < now && endDateSelected > now) {
         $("#pastDateWarningText").text("This event is currently happening!")
       }

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -547,10 +547,9 @@ $(document).ready(function() {
   the ID of the deleteMultipleOffering so that when the trash icon is clicked, that specific row will be deleted*/
   $(".addMultipleOfferingEvent").click(createOfferingModalRow)
 
-  $("#allowPastStart").click(function() {
-    var minDate = $("#allowPastStart:checked").val() ? new Date('10/25/1999') : new Date()
+    var minDate = new Date('10/25/1999') 
     $("#startDatePicker-main").datepicker("option", "minDate", minDate)
-  })
+  
 
   // everything except Chrome
   if (navigator.userAgent.indexOf("Chrome") == -1) {

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -509,8 +509,8 @@ $(document).ready(function() {
       let startDate = new Date($("#repeatingEventsStartDate").val());
       let endDate = new Date($("#repeatingEventsEndDate").val());
       let startTime = $("#repeatingEventsStartTime").val();
-      let endTime = $("#repeatingEventsEndTime").val();
-
+      let endTime = $("#repeatingEventsEndTime").val();      
+startDatePicker
       if (navigator.userAgent.indexOf("Chrome") == -1) {
         startTime = format12to24HourTime(startTime)
         endTime = format12to24HourTime(endTime)
@@ -549,7 +549,37 @@ $(document).ready(function() {
 
     var minDate = new Date('10/25/1999') 
     $("#startDatePicker-main").datepicker("option", "minDate", minDate)
+
+    function checkIfDateInPast() {
+      const [month, day, year] = $("#startDatePicker-main").val().split('/')
+      const [startHour, starMin] = $("#startTime-main").val().split(':')
+      const [endHour, endMin] = $("#endTime-main").val().split(':')
+
+      let startDateSelected = new Date(+year, +month - 1, +day, +startHour, +starMin);  
+      let endDateSelected = new Date(+year, +month - 1, +day, +endHour, +endMin)
+      let now = new Date()
+
+      if (startDateSelected < now && endDateSelected > now) {
+        $("#pastDateWarningText").text("This event is currently happening!")
+      }
+      else if (startDateSelected < now && endDateSelected < now) {
+        $("#pastDateWarningText").text("This event ended in the past!")
+      }
+      else 
+        $("#pastDateWarningText").text("")
+  }
+
+  $("#startDatePicker-main").on("change", function() {    
+    checkIfDateInPast()
+  })
+
+  $("#startTime-main").on("change", function() {    
+    checkIfDateInPast()
+  })
   
+  $("#endTime-main").on("change", function() {    
+    checkIfDateInPast()
+  })
 
   // everything except Chrome
   if (navigator.userAgent.indexOf("Chrome") == -1) {

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -551,43 +551,42 @@ $(document).ready(function() {
     $("#startDatePicker-main").datepicker("option", "minDate", minDate)
 
   // This converts the time to 24 hour format in case it is in 12 hour format (like in Firefox)
-   function handleTimeFormatting(timeArray){    
-    let time  = timeArray[0]
-    let timeSuffix = timeArray[1]         // looks for AM or PM in time 
-    let [hours , min] = time. split(':')
+function handleTimeFormatting(timeArray){    
+  let time  = timeArray[0]
+  let timeSuffix = timeArray[1]         // looks for AM or PM in time 
+  let [hours , min] = time. split(':')
 
-    if (timeArray.length === 2) {
-        hours  = parseInt(hours, 10)
-          if (timeSuffix === 'PM' && hours !== 12) {
-          hours += 12;
-          } else if (timeSuffix === 'AM' && hours === 12) {
-          hours = 0;
-          }
+  if (timeArray.length === 2) {
+      hours  = parseInt(hours, 10)
+      if (timeSuffix === 'PM' && hours !== 12) {
+      hours += 12;
+      } else if (timeSuffix === 'AM' && hours === 12) {
+      hours = 0;
+      }
+    const hoursStr = hours.toString().padStart(2, '0');
+      return [hoursStr, min]
+    }
+  return [hours, min]
+}
 
-      const hoursStr = hours.toString().padStart(2, '0');
-        return [hoursStr, min]
-      }
-    return [hours, min]
-  }
-
-    function checkIfDateInPast() {
-      const [month, day, year] = $("#startDatePicker-main").val().split('/')
-      const startTimeArray =  $("#startTime-main").val().split(' ') 
-      const [startHour, startMin] = handleTimeFormatting(startTimeArray)
-      const endTimeArray = $('#endTime-main').val().split(' ')
-      const [endHour, endMin] = handleTimeFormatting (endTimeArray)
-      let startDateSelected =new Date(+year, +month - 1, +day, +startHour, +startMin);  
-      let endDateSelected = new Date(+year, +month - 1, +day, +endHour, +endMin)
-      let now = new Date()
-      
-      if (startDateSelected < now && endDateSelected > now) {
-        $("#pastDateWarningText").text("This event is currently happening!")
-      }
-      else if (startDateSelected < now && endDateSelected < now) {
-        $("#pastDateWarningText").text("This event ended in the past!")
-      }
-      else 
-        $("#pastDateWarningText").text("")
+  function checkIfDateInPast() {
+    const [month, day, year] = $("#startDatePicker-main").val().split('/')
+    const startTimeArray =  $("#startTime-main").val().split(' ') 
+    const [startHour, startMin] = handleTimeFormatting(startTimeArray)
+    const endTimeArray = $('#endTime-main').val().split(' ')
+    const [endHour, endMin] = handleTimeFormatting (endTimeArray)
+    let startDateSelected =new Date(+year, +month - 1, +day, +startHour, +startMin);  
+    let endDateSelected = new Date(+year, +month - 1, +day, +endHour, +endMin)
+    let now = new Date()
+    
+    if (startDateSelected < now && endDateSelected > now) {
+      $("#pastDateWarningText").text("This event is currently happening!")
+    }
+    else if (startDateSelected < now && endDateSelected < now) {
+      $("#pastDateWarningText").text("This event ended in the past!")
+    }
+    else 
+      $("#pastDateWarningText").text("")
   }
 
   $("#startDatePicker-main").on("change", function() {    

--- a/app/templates/events/createEvent.html
+++ b/app/templates/events/createEvent.html
@@ -83,19 +83,6 @@
     </div>
   </div>
   <div class="form-group col-md-6">
-<<<<<<< HEAD
-  <div class="form-check form-switch pb-1"><br>
-    <div class="d-flex p-3 ">
-      <fieldset>
-        <label class="custom-control-label" for='checkIsSeries'><strong>This is a series of events.</strong></label>
-        <input class="form-check-input" type="checkbox" id="checkIsSeries" name="isSeries"
-          {{"checked" if eventData.isSeries}} />
-      </fieldset>
-    </div>
-  </div>
-</div>
-          
-=======
     <div style="margin-top: 2.3em;" >
       <div class="form-check form-switch pb-1">
         <fieldset>
@@ -106,7 +93,7 @@
       </div>
     </div>
   </div>
->>>>>>> development
+
 </div>
 
 <br>
@@ -174,13 +161,6 @@
       </div>
 
       {% if isNewEvent %}
-<<<<<<< HEAD
-=======
-
-      {% endif %}
-
-      {% if isNewEvent %}
->>>>>>> development
         {% set hideMultipleOffering = "" %}
       {% else %}
         {% set hideMultipleOffering = "d-none" %}

--- a/app/templates/events/createEvent.html
+++ b/app/templates/events/createEvent.html
@@ -57,6 +57,7 @@
           <h1 id="pageTitle">{{page_title}}</h1>
         </div>
       {% endif %}
+
     {% endblock %}
 
     {% macro locationTimeMacro(eventData, isNewEvent, pageLocation) %}
@@ -80,6 +81,19 @@
       </div>
     </div>
   </div>
+                      <div class="form-group col-md-6">
+          <div class="form-check form-switch pb-1"><br>
+            <fieldset>
+              <label class="custom-control-label" for='checkIsSeries'><strong>This is a series of events.</strong></label>
+              <input class="form-check-input" type="checkbox" id="checkIsSeries" name="isSeries"
+                {{"checked" if eventData.isSeries}} />
+            </fieldset>
+          </div>
+        </div>
+          {% if True %}
+          <p style="color:red; font-weight:bold;"> This date is in the past</p>
+          {% endif %}
+          
 </div>
 <br>
 <!-- Non-Series Start Time -->
@@ -146,20 +160,12 @@
       <div class="row col-md-12">
         <div class="form-group col-md-6">
           <div class="form-check form-switch pb-1">
-            <label class="custom-control-label" for='allowPastStart'><strong>Allow start date to be in the
+            <!-- <label class="custom-control-label" for='allowPastStart'><strong>Allow start date to be in the
                 past.</strong></label>
-            <input class="form-check-input" type="checkbox" id="allowPastStart" />
+            <input class="form-check-input" type="checkbox" id="allowPastStart" /> -->
           </div>
         </div>
-        <div class="form-group col-md-6">
-          <div class="form-check form-switch pb-1">
-            <fieldset>
-              <label class="custom-control-label" for='checkIsSeries'><strong>This is a series of events.</strong></label>
-              <input class="form-check-input" type="checkbox" id="checkIsSeries" name="isSeries"
-                {{"checked" if eventData.isSeries}} />
-            </fieldset>
-          </div>
-        </div>
+      
       </div>
       {% endif %}
 
@@ -474,6 +480,8 @@
                   id='repeatingEventsStartDate' />
               </div>
             </div>
+            
+        </div>
              <!-- Repeating Event End Date Picker -->
              <div class="form-group col-md-3">
               <label class="required form-label me-2 mb-0" for="repeatingEventsEndDate"><strong>Last Event Date</strong></label>
@@ -484,7 +492,8 @@
                   id='repeatingEventsEndDate' />
               </div>
             </div>
-            
+
+
             <!-- Repeating Event Start Time -->
             <div class="form-group col-md-3">
               <label class="form-label me-2 mb-0" for="repeatingEventsStartTime"><strong>Start Time</strong></label>

--- a/app/templates/events/createEvent.html
+++ b/app/templates/events/createEvent.html
@@ -65,6 +65,7 @@
   <input class="form-control" id='inputEventLocation-{{pageLocation}}' placeholder="Enter location" name="location"
     value="{{eventData.location}}" required>
 </div>
+
 <!-- Non-Series Start Datepicker -->
 <div class="row col-md-12" id="eventDate">
   <div class="form-group col-md-6">
@@ -80,8 +81,21 @@
       </div>
     </div>
   </div>
+  <div class="form-group col-md-6">
+    <div style="margin-top: 2.3em;" >
+      <div class="form-check form-switch pb-1">
+        <fieldset>
+          <label class="custom-control-label" for='checkIsSeries'><strong>This is a series of events.</strong></label>
+          <input class="form-check-input" type="checkbox" id="checkIsSeries" name="isSeries"
+            {{"checked" if eventData.isSeries}} />
+        </fieldset>
+      </div>
+    </div>
+  </div>
 </div>
+
 <br>
+
 <!-- Non-Series Start Time -->
 <div class="mb-4" id="eventTime">
   <div class="row col-md-12">
@@ -143,24 +157,7 @@
       </div>
 
       {% if isNewEvent %}
-      <div class="row col-md-12">
-        <div class="form-group col-md-6">
-          <div class="form-check form-switch pb-1">
-            <label class="custom-control-label" for='allowPastStart'><strong>Allow start date to be in the
-                past.</strong></label>
-            <input class="form-check-input" type="checkbox" id="allowPastStart" />
-          </div>
-        </div>
-        <div class="form-group col-md-6">
-          <div class="form-check form-switch pb-1">
-            <fieldset>
-              <label class="custom-control-label" for='checkIsSeries'><strong>This is a series of events.</strong></label>
-              <input class="form-check-input" type="checkbox" id="checkIsSeries" name="isSeries"
-                {{"checked" if eventData.isSeries}} />
-            </fieldset>
-          </div>
-        </div>
-      </div>
+
       {% endif %}
 
       {% if isNewEvent %}
@@ -554,6 +551,7 @@
                 id='multipleOfferingDatePicker-{{pageLocation}}' data-page-location="{{pageLocation}}" />
             </div>
           </div>
+          
 
           <!--series Start Time-->
           <div class="form-group col-md-3">
@@ -616,5 +614,6 @@
       </div> 
   </div>
 </div>
+
 
 {% endblock %}

--- a/app/templates/events/createEvent.html
+++ b/app/templates/events/createEvent.html
@@ -68,8 +68,8 @@
 </div>
 
 <!-- Non-Series Start Datepicker -->
-<div class="row col-md-12" id="eventDate">
-  <div class="form-group col-md-6">
+<div class="row col-md-12">
+  <div class="form-group col-md-6" id="eventDate">
     <label class="required form-label me-2" for="startDatePicker-{{pageLocation}}"><strong>Start Date</strong></label>
     <div class='input-group date startDate' id="startDate-{{pageLocation}}" data-page-location="{{pageLocation}}">
       <input autocomplete="off" type='text' class="form-control datePicker startDatePicker readonly"

--- a/app/templates/events/createEvent.html
+++ b/app/templates/events/createEvent.html
@@ -132,7 +132,7 @@
   </div>
 </div>
 
-<p class="text-danger fw-bold" id="pastDateWarningText"> </p>
+<p class="text-danger fw-bold" id="pastDateWarningText"> </p>  <!-- This is the text for the Event to show if it ended. The text will be filled out using JS function. -->
 
 {% endmacro %}
 
@@ -156,19 +156,6 @@
           {% endfor %}
         </select>
       </div>
-
-      {% if isNewEvent %}
-      <div class="row col-md-12">
-        <div class="form-group col-md-6">
-          <div class="form-check form-switch pb-1">
-            <!-- <label class="custom-control-label" for='allowPastStart'><strong>Allow start date to be in the
-                past.</strong></label>
-            <input class="form-check-input" type="checkbox" id="allowPastStart" /> -->
-          </div>
-        </div>
-      
-      </div>
-      {% endif %}
 
       {% if isNewEvent %}
         {% set hideMultipleOffering = "" %}

--- a/app/templates/events/createEvent.html
+++ b/app/templates/events/createEvent.html
@@ -81,18 +81,17 @@
       </div>
     </div>
   </div>
-                      <div class="form-group col-md-6">
-          <div class="form-check form-switch pb-1"><br>
-            <fieldset>
-              <label class="custom-control-label" for='checkIsSeries'><strong>This is a series of events.</strong></label>
-              <input class="form-check-input" type="checkbox" id="checkIsSeries" name="isSeries"
-                {{"checked" if eventData.isSeries}} />
-            </fieldset>
-          </div>
-        </div>
-          {% if True %}
-          <p style="color:red; font-weight:bold;"> This date is in the past</p>
-          {% endif %}
+  <div class="form-group col-md-6">
+  <div class="form-check form-switch pb-1"><br>
+    <div class="d-flex p-3 ">
+      <fieldset>
+        <label class="custom-control-label" for='checkIsSeries'><strong>This is a series of events.</strong></label>
+        <input class="form-check-input" type="checkbox" id="checkIsSeries" name="isSeries"
+          {{"checked" if eventData.isSeries}} />
+      </fieldset>
+    </div>
+  </div>
+</div>
           
 </div>
 <br>
@@ -132,6 +131,8 @@
     </div>
   </div>
 </div>
+
+<p class="text-danger fw-bold" id="pastDateWarningText"> </p>
 
 {% endmacro %}
 

--- a/app/templates/events/createEvent.html
+++ b/app/templates/events/createEvent.html
@@ -462,17 +462,16 @@
             </div>
 
             <!-- Repeating Event Start Date Picker -->
-            <div class="form-group col-md-3">
-              <label class="required form-label me-2 mb-0" for="repeatingEventsStartDate"><strong>Start Date</strong></label>
-              <div class='input-group date'>
-                <input autocomplete="off" type='date'
-                  class="form-control repeatingEventsField readonly"
-                  name="repeatingEventsStartDate" placeholder="Pick a start date"
-                  id='repeatingEventsStartDate' />
-              </div>
+          <div class="form-group col-md-3">
+            <label class="required form-label me-2 mb-0" for="repeatingEventsStartDate"><strong>Start Date</strong></label>
+            <div class='input-group date'>
+              <input autocomplete="off" type='date'
+                class="form-control repeatingEventsField readonly"
+                name="repeatingEventsStartDate" placeholder="Pick a start date"
+                id='repeatingEventsStartDate' />
             </div>
+          </div>
             
-        </div>
              <!-- Repeating Event End Date Picker -->
              <div class="form-group col-md-3">
               <label class="required form-label me-2 mb-0" for="repeatingEventsEndDate"><strong>Last Event Date</strong></label>


### PR DESCRIPTION
## Issue Description

Fixes #1448 
Delete the toggle "Allow start date to be in the past" and allow the user to pick any date in the past or future, prompting a message if in the past. Also change the multiple offerings toggle to be next to "start date."


![Screenshot 2025-06-13 094504](https://github.com/user-attachments/assets/3cbe528d-ed45-42a9-bd5b-a787f37a7ac2)

## Changes

- Deleted the "allow start date to be in the past" toggle on "Create Event Page"
- Now the user can select dates in the past in the calendar, always, without needing to switch the toggle
- The page will show a message in case the selected start date and time is in the past or/and the end date is in the past
- Changed the "This is a series of events." toggle location in the page 


![Screenshot 2025-06-13 094538](https://github.com/user-attachments/assets/357dbafe-127b-4f66-9b01-560263775712)


## Testing

- Open the CELTS website as an admin or Student Staff and go to "Create Event"
- Under "Programs" Choose any of the list of programs
- Go to start date and pick a date in the past or today
- Pick the start time to be in the past, and try end time in the future or past
- try the program on Firefox since there was a problem there
- Try edge cases in time like 12pm, 12:30pm, etc...