### PR TITLE
Event page restructure 1442

### DIFF
--- a/app/templates/events/templateSelector.html
+++ b/app/templates/events/templateSelector.html
@@ -1,7 +1,19 @@
 {% set title = "Template Selector" %}
 {% extends "base.html"%}
 {% block app_content %}
-<h1 class="text-center mb-5">Create an Event</h1>
+<h1 class="text-center mb-3"><u>Create an Event</u></h1>
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-lg-5 mx-3 mb-3">
+            <h2 class="text-center">Shortcuts</h2>
+            <div class="list-group">
+                {% for template in templates %}
+                <a href="/eventTemplates/{{template.id}}/{{celtsSponsoredProgram.id}}/create" class="list-group-item list-group-item-action">{{ template.name }}</a>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+</div>
 <div class="container">
     <div class="row justify-content-center">
         <div class="col-lg-5 mx-3">
@@ -12,14 +24,6 @@
                 {% endfor %}
             </div>
         </div>
-        <div class="col-lg-5 mx-3">
-            <h2 class="text-center">Templates</h2>
-            <div class="list-group">
-                {% for template in templates %}
-                <a href="/eventTemplates/{{template.id}}/{{celtsSponsoredProgram.id}}/create" class="list-group-item list-group-item-action">{{ template.name }}</a>
-                {% endfor %}
-            </div>
-        </div>
-    </div>
-</div>
+    </div>  
+</div>  
 {% endblock %} 

--- a/app/templates/events/templateSelector.html
+++ b/app/templates/events/templateSelector.html
@@ -8,7 +8,7 @@
             <h2 class="text-center">Shortcuts</h2>
             <div class="list-group">
                 {% for template in templates %}
-                <a href="/eventTemplates/{{template.id}}/{{celtsSponsoredProgram.id}}/create" class="list-group-item list-group-item-action">{{ template.name }}</a>
+                    <a href="/eventTemplates/{{template.id}}/{{celtsSponsoredProgram.id}}/create" class="list-group-item list-group-item-action">{{ template.name }}</a>
                 {% endfor %}
             </div>
         </div>
@@ -20,7 +20,7 @@
             <h2 class="text-center">Programs</h2>
             <div class="list-group">
                 {% for program in programs %}
-                <a href="/eventTemplates/1/{{program.id}}/create" class="list-group-item list-group-item-action">{{ program.programName }}</a>
+                    <a href="/eventTemplates/1/{{program.id}}/create" class="list-group-item list-group-item-action">{{ program.programName }}</a>
                 {% endfor %}
             </div>
         </div>

--- a/app/templates/events/templateSelector.html
+++ b/app/templates/events/templateSelector.html
@@ -1,7 +1,7 @@
 {% set title = "Template Selector" %}
 {% extends "base.html"%}
 {% block app_content %}
-<h1 class="text-center mb-3"><u>Create an Event</u></h1>
+<h1 class="text-center mb-4">Create an Event</h1>
 <div class="container">
     <div class="row justify-content-center">
         <div class="col-lg-5 mx-3 mb-3">


### PR DESCRIPTION
## Issue Description

Fixes #1442 
- Rename the Templates into "Shortcuts." Instead of two columns, have Templates be on the top, before the Programs, and Programs right below it. If it does not look appealing, try swapping the two columns.
-We could not make functionality for creating a new draft for Templates. We were instructed to have this task be a separate issue to work on later. 

## Changes

- renamed the column "Template" to "Shortcut"
- moved the "shortcut color to be on top

## Testing

- Go to the Create event Tab as admin 