### PR TITLE
Multi offer modal should have a different validation

### DIFF
--- a/app/static/css/createEvent.css
+++ b/app/static/css/createEvent.css
@@ -37,7 +37,7 @@
     text-align: center;
     position: fixed;
     z-index: 10;
-    animation: flash 6s forwards;
+    animation: flash 10s forwards;
 }
 
 @keyframes flash {

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -102,7 +102,7 @@ function initializeFlatpickr(obj) {
   });
 }
 
-function createOfferingModalRow({eventName=null, eventDate=null, startTime=null, endTime=null, isDuplicate=false}={}){
+function createOfferingModalRow({eventName=null, eventDate=null, startTime=null, endTime=null}={}){
 
   let clonedOffering = $("#multipleOfferingEvent").clone().removeClass('d-none').removeAttr("id");
 
@@ -111,7 +111,7 @@ function createOfferingModalRow({eventName=null, eventDate=null, startTime=null,
   if (eventDate) {clonedOffering.find('.multipleOfferingDatePicker').val(eventDate)}
   if (startTime) {clonedOffering.find('.multipleOfferingStartTime').val(startTime)}
   if (endTime) {clonedOffering.find('.multipleOfferingEndTime').val(endTime)}
-
+  
   $("#multipleOfferingSlots").append(clonedOffering);
   pendingmultipleEvents.push(clonedOffering);
 

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -106,7 +106,7 @@ function initializeFlatpickr(obj) {
   });
 }
 
-function createOfferingModalRow({eventName=null, eventDate=null, startTime=null, endTime=null, isDuplicate=false}={}){
+function createOfferingModalRow({eventName=null, eventDate=null, startTime=null, endTime=null}={}){
 
   let clonedOffering = $("#multipleOfferingEvent").clone().removeClass('d-none').removeAttr("id");
 
@@ -115,7 +115,7 @@ function createOfferingModalRow({eventName=null, eventDate=null, startTime=null,
   if (eventDate) {clonedOffering.find('.multipleOfferingDatePicker').val(eventDate)}
   if (startTime) {clonedOffering.find('.multipleOfferingStartTime').val(startTime)}
   if (endTime) {clonedOffering.find('.multipleOfferingEndTime').val(endTime)}
-
+  
   $("#multipleOfferingSlots").append(clonedOffering);
   pendingmultipleEvents.push(clonedOffering);
 

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -115,7 +115,6 @@ function createOfferingModalRow({eventName=null, eventDate=null, startTime=null,
   if (eventDate) {clonedOffering.find('.multipleOfferingDatePicker').val(eventDate)}
   if (startTime) {clonedOffering.find('.multipleOfferingStartTime').val(startTime)}
   if (endTime) {clonedOffering.find('.multipleOfferingEndTime').val(endTime)}
-  if (isDuplicate) {clonedOffering.addClass('border-red')}
 
   $("#multipleOfferingSlots").append(clonedOffering);
   pendingmultipleEvents.push(clonedOffering);
@@ -168,9 +167,6 @@ $('#saveSeries').on('click', function() {
   eventNameInputs.each((index, eventNameInput) => {
     if (eventNameInput.value.trim() === '') {
       isEmpty = true;
-      $(eventNameInput).addClass('border-red');
-    } else{
-      $(eventNameInput).removeClass('border-red');
     }
   });
 
@@ -178,9 +174,6 @@ $('#saveSeries').on('click', function() {
   datePickerInputs.each((index, datePickerInput) => {
     if (datePickerInput.value.trim() === '') {
         isEmpty = true;
-        $(datePickerInput).addClass('border-red');
-    } else {
-      $(datePickerInput).removeClass('border-red');
     }
   });  
 
@@ -195,12 +188,7 @@ $('#saveSeries').on('click', function() {
       endTime = format12to24HourTime(endTime)
     }
 
-    if(startTime < endTime){
-      $(startTimeInputs[i]).removeClass('border-red');
-      $(endTimeInputs[i]).removeClass('border-red');
-    } else {
-      $(startTimeInputs[i]).addClass('border-red');
-      $(endTimeInputs[i]).addClass('border-red');
+    if(startTime > endTime){
       hasValidTimes = false;
     }
   }
@@ -219,10 +207,7 @@ $('#saveSeries').on('click', function() {
 
     if (eventListing in eventListings){ // If we've seen this event before mark this event and the previous as duplicates
       hasDuplicateListings = true
-      $(eventOfferings[i]).addClass('border-red');
-      $(eventOfferings[eventListings[eventListing]]).addClass('border-red')
     } else { // If we haven't seen this event before
-      $(eventOfferings[i]).removeClass('border-red');
       eventListings[eventListing] = i
     }
   }
@@ -367,7 +352,7 @@ function updateOfferingsTable() {
     var formattedEventDate = formatDate(offering.eventDate);
     var startTime = format24to12HourTime(offering.startTime);
     var endTime = format24to12HourTime(offering.endTime);
-    offeringsTable.append(`<tr class="${offering.isDuplicate ? "border-red" : ""}">` +
+    offeringsTable.append(`<tr>` +
                                     "<td>" + offering.eventName + "</td>" +
                                     "<td>" + formattedEventDate + "</td>" +
                                     "<td>" + startTime + "</td>" +

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -251,20 +251,37 @@ $('#saveSeries').on('click', function() {
 function updateEventNameField() {
   let offerings = JSON.parse($("#seriesData").val())
   let isSeries = $("#checkIsRepeating").is(":checked")
+<<<<<<< HEAD
 
   // Check if the event is weekly
+=======
+>>>>>>> e9feb306 (Problem solved. Text from the repeated events will populate into the Event Name field as readonly in the main page)
   if (!isSeries) {
     // if not weeekly, add them to a set to remove duplicates, then put them in a string to populate the field
     let names = new Set()
     offerings.forEach(offering => {
       names.add(offering.eventName)
+<<<<<<< HEAD
     });
     let offeringsText = Array.from(names).join(", ")
+=======
+      console.log(offering.eventName);
+    });
+    // Check if the event is weekly
+    let offeringsText = ""
+    names.forEach(offering => {
+    offeringsText += offering + ", "
+    })
+>>>>>>> e9feb306 (Problem solved. Text from the repeated events will populate into the Event Name field as readonly in the main page)
     $('#inputEventName').prop('placeholder', offeringsText)
   }
   else {
     // if weekly, take the name of the first item (which is the same for all) and take the word 'week'
+<<<<<<< HEAD
     let offeringText = $("#repeatingEventsNamePicker").val()
+=======
+    let offeringText = offerings[0].eventName.split(" ").slice(0, -2).join(" ").trimEnd()
+>>>>>>> e9feb306 (Problem solved. Text from the repeated events will populate into the Event Name field as readonly in the main page)
     $('#inputEventName').prop('placeholder', offeringText)
   } 
 }

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -251,37 +251,20 @@ $('#saveSeries').on('click', function() {
 function updateEventNameField() {
   let offerings = JSON.parse($("#seriesData").val())
   let isSeries = $("#checkIsRepeating").is(":checked")
-<<<<<<< HEAD
 
   // Check if the event is weekly
-=======
->>>>>>> e9feb306 (Problem solved. Text from the repeated events will populate into the Event Name field as readonly in the main page)
   if (!isSeries) {
     // if not weeekly, add them to a set to remove duplicates, then put them in a string to populate the field
     let names = new Set()
     offerings.forEach(offering => {
       names.add(offering.eventName)
-<<<<<<< HEAD
     });
     let offeringsText = Array.from(names).join(", ")
-=======
-      console.log(offering.eventName);
-    });
-    // Check if the event is weekly
-    let offeringsText = ""
-    names.forEach(offering => {
-    offeringsText += offering + ", "
-    })
->>>>>>> e9feb306 (Problem solved. Text from the repeated events will populate into the Event Name field as readonly in the main page)
     $('#inputEventName').prop('placeholder', offeringsText)
   }
   else {
     // if weekly, take the name of the first item (which is the same for all) and take the word 'week'
-<<<<<<< HEAD
     let offeringText = $("#repeatingEventsNamePicker").val()
-=======
-    let offeringText = offerings[0].eventName.split(" ").slice(0, -2).join(" ").trimEnd()
->>>>>>> e9feb306 (Problem solved. Text from the repeated events will populate into the Event Name field as readonly in the main page)
     $('#inputEventName').prop('placeholder', offeringText)
   } 
 }

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -110,7 +110,6 @@ function createOfferingModalRow({eventName=null, eventDate=null, startTime=null,
   if (eventDate) {clonedOffering.find('.multipleOfferingDatePicker').val(eventDate)}
   if (startTime) {clonedOffering.find('.multipleOfferingStartTime').val(startTime)}
   if (endTime) {clonedOffering.find('.multipleOfferingEndTime').val(endTime)}
-  if (isDuplicate) {clonedOffering.addClass('border-red')}
 
   $("#multipleOfferingSlots").append(clonedOffering);
   pendingmultipleEvents.push(clonedOffering);
@@ -163,9 +162,6 @@ $('#saveSeries').on('click', function() {
   eventNameInputs.each((index, eventNameInput) => {
     if (eventNameInput.value.trim() === '') {
       isEmpty = true;
-      $(eventNameInput).addClass('border-red');
-    } else{
-      $(eventNameInput).removeClass('border-red');
     }
   });
 
@@ -173,9 +169,6 @@ $('#saveSeries').on('click', function() {
   datePickerInputs.each((index, datePickerInput) => {
     if (datePickerInput.value.trim() === '') {
         isEmpty = true;
-        $(datePickerInput).addClass('border-red');
-    } else {
-      $(datePickerInput).removeClass('border-red');
     }
   });  
 
@@ -190,12 +183,7 @@ $('#saveSeries').on('click', function() {
       endTime = format12to24HourTime(endTime)
     }
 
-    if(startTime < endTime){
-      $(startTimeInputs[i]).removeClass('border-red');
-      $(endTimeInputs[i]).removeClass('border-red');
-    } else {
-      $(startTimeInputs[i]).addClass('border-red');
-      $(endTimeInputs[i]).addClass('border-red');
+    if(startTime > endTime){
       hasValidTimes = false;
     }
   }
@@ -214,10 +202,7 @@ $('#saveSeries').on('click', function() {
 
     if (eventListing in eventListings){ // If we've seen this event before mark this event and the previous as duplicates
       hasDuplicateListings = true
-      $(eventOfferings[i]).addClass('border-red');
-      $(eventOfferings[eventListings[eventListing]]).addClass('border-red')
     } else { // If we haven't seen this event before
-      $(eventOfferings[i]).removeClass('border-red');
       eventListings[eventListing] = i
     }
   }
@@ -339,7 +324,7 @@ function updateOfferingsTable() {
     var formattedEventDate = formatDate(offering.eventDate);
     var startTime = format24to12HourTime(offering.startTime);
     var endTime = format24to12HourTime(offering.endTime);
-    offeringsTable.append(`<tr class="${offering.isDuplicate ? "border-red" : ""}">` +
+    offeringsTable.append(`<tr>` +
                                     "<td>" + offering.eventName + "</td>" +
                                     "<td>" + formattedEventDate + "</td>" +
                                     "<td>" + startTime + "</td>" +

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -167,6 +167,9 @@ $('#saveSeries').on('click', function() {
   eventNameInputs.each((index, eventNameInput) => {
     if (eventNameInput.value.trim() === '') {
       isEmpty = true;
+      $(eventNameInput).addClass('border-red');
+    } else {
+      $(eventNameInput).removeClass('border-red');
     }
   });
 
@@ -174,6 +177,9 @@ $('#saveSeries').on('click', function() {
   datePickerInputs.each((index, datePickerInput) => {
     if (datePickerInput.value.trim() === '') {
         isEmpty = true;
+        $(datePickerInput).addClass('border-red');
+    } else {
+        $(datePickerInput).removeClass('border-red');
     }
   });  
 
@@ -190,6 +196,11 @@ $('#saveSeries').on('click', function() {
 
     if(startTime > endTime){
       hasValidTimes = false;
+      $(startTimeInputs[i]).removeClass('border-red');
+      $(endTimeInputs[i]).removeClass('border-red');
+    } else {
+      $(startTimeInputs[i]).addClass('border-red');
+      $(endTimeInputs[i]).addClass('border-red');
     }
   }
 
@@ -352,7 +363,7 @@ function updateOfferingsTable() {
     var formattedEventDate = formatDate(offering.eventDate);
     var startTime = format24to12HourTime(offering.startTime);
     var endTime = format24to12HourTime(offering.endTime);
-    offeringsTable.append(`<tr>` +
+    offeringsTable.append(`<tr class="${offering.isDuplicate ? "border-red" : ""}">` +
                                     "<td>" + offering.eventName + "</td>" +
                                     "<td>" + formattedEventDate + "</td>" +
                                     "<td>" + startTime + "</td>" +

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -163,6 +163,9 @@ $('#saveSeries').on('click', function() {
   eventNameInputs.each((index, eventNameInput) => {
     if (eventNameInput.value.trim() === '') {
       isEmpty = true;
+      $(eventNameInput).addClass('border-red');
+    } else {
+      $(eventNameInput).removeClass('border-red');
     }
   });
 
@@ -170,6 +173,9 @@ $('#saveSeries').on('click', function() {
   datePickerInputs.each((index, datePickerInput) => {
     if (datePickerInput.value.trim() === '') {
         isEmpty = true;
+        $(datePickerInput).addClass('border-red');
+    } else {
+        $(datePickerInput).removeClass('border-red');
     }
   });  
 
@@ -186,6 +192,11 @@ $('#saveSeries').on('click', function() {
 
     if(startTime > endTime){
       hasValidTimes = false;
+      $(startTimeInputs[i]).removeClass('border-red');
+      $(endTimeInputs[i]).removeClass('border-red');
+    } else {
+      $(startTimeInputs[i]).addClass('border-red');
+      $(endTimeInputs[i]).addClass('border-red');
     }
   }
 
@@ -326,7 +337,7 @@ function updateOfferingsTable() {
     var formattedEventDate = formatDate(offering.eventDate);
     var startTime = format24to12HourTime(offering.startTime);
     var endTime = format24to12HourTime(offering.endTime);
-    offeringsTable.append(`<tr>` +
+    offeringsTable.append(`<tr class="${offering.isDuplicate ? "border-red" : ""}">` +
                                     "<td>" + offering.eventName + "</td>" +
                                     "<td>" + formattedEventDate + "</td>" +
                                     "<td>" + startTime + "</td>" +

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -194,11 +194,12 @@ $('#saveSeries').on('click', function() {
       endTime = format12to24HourTime(endTime)
     }
 
-    if(startTime > endTime){
-      hasValidTimes = false;
+    if(startTime < endTime){
+      hasValidTimes = true;
       $(startTimeInputs[i]).removeClass('border-red');
       $(endTimeInputs[i]).removeClass('border-red');
     } else {
+      hasValidTimes = false;
       $(startTimeInputs[i]).addClass('border-red');
       $(endTimeInputs[i]).addClass('border-red');
     }


### PR DESCRIPTION
## Issue Description

Fixes #1447 
Multiple Offering Modal (In create event page) looks bad when all the fields are left blank. All the fields are red, and it is different from the validation we usually use.

## Changes
- Removed all border-red classes from the JavaScript file. 
- When the the data is not valid, JS will not insert border-red classes into the html, which removes this kind of styling
- The Flash still happens when the data is not valid, which should be enough for the user to see


![Screenshot 2025-06-13 131419](https://github.com/user-attachments/assets/57e7620a-fdea-4f3d-a4e8-1fb6f1324ccf)

## Testing

- Go to the CELTS website as an admin
- Go to create event page
- Toggle "This is a series of events." 
- On the top left side, if "This series repeats weekly" is toggled, untoggle it
- Click "Add Occurrence" two or three times
- then click "save" with  invalid data (like empty fields)
- Watch for the flash to happen. Red Boxes or borders should NOT happen