### PR TITLE
Dietary restrictions volunteer details 1450

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,6 +1,5 @@
 from app.models import *
 
-
 class User(baseModel):
     username = CharField(primary_key=True)
     bnumber = CharField(unique=True)
@@ -80,4 +79,3 @@ class User(baseModel):
         # Looks to see who the Program Manager for a specific event is
         return self.isProgramManagerFor(event.program)
 
-    

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -16,7 +16,7 @@ class User(baseModel):
     isStaff = BooleanField(default=False)
     isCeltsAdmin = BooleanField(default=False)
     isCeltsStudentStaff = BooleanField(default=False)
-    dietRestriction = TextField(null=True)
+    dietRestriction = TextField(null=False)
     minorInterest = BooleanField(default=False)
     hasGraduated = BooleanField(default=False)
     declaredMinor = BooleanField(default=False)

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -16,7 +16,7 @@ class User(baseModel):
     isStaff = BooleanField(default=False)
     isCeltsAdmin = BooleanField(default=False)
     isCeltsStudentStaff = BooleanField(default=False)
-    dietRestriction = TextField(null=False)
+    dietRestriction = TextField(null=True)
     minorInterest = BooleanField(default=False)
     hasGraduated = BooleanField(default=False)
     declaredMinor = BooleanField(default=False)

--- a/app/static/js/userProfile.js
+++ b/app/static/js/userProfile.js
@@ -1,4 +1,17 @@
 $(document).ready(function(){
+dietRestriction = "None"
+  $("#checkDietRestriction").on("change",  function() {
+    let norestrict = $(this).is(':checked');
+    console.log(norestrict)
+    if (norestrict) {
+        dietContainer.style.display = "none";
+    }
+    else {
+        dietContainer.style.display = "block";
+    }
+  });
+
+
   $("#expressInterest").on("click", function() {
     let username = $(this).data('username')
     let isAdding = $(this).is(':checked');
@@ -16,6 +29,7 @@ $(document).ready(function(){
           msgToast("Error!", "Failed to save changes!")
         }
     });
+    
   })
   
 
@@ -364,4 +378,8 @@ function updateManagers(el, volunteerUsername ){// retrieve the data of the stud
           console.log(error, status)
       }
   })
+
+  
 }
+
+

--- a/app/static/js/userProfile.js
+++ b/app/static/js/userProfile.js
@@ -1,10 +1,10 @@
 $(document).ready(function(){
-dietRestriction = "None"
-  $("#checkDietRestriction").on("change",  function() {
+  $("#checkDietRestriction, #diet").on("change",  function() {
     let norestrict = $(this).is(':checked');
-    console.log(norestrict)
     if (norestrict) {
         dietContainer.style.display = "none";
+        $("#diet").val("No dietary restrictions");
+
     }
     else {
         dietContainer.style.display = "block";

--- a/app/static/js/userProfile.js
+++ b/app/static/js/userProfile.js
@@ -1,13 +1,12 @@
 $(document).ready(function(){
-  $("#checkDietRestriction, #diet").on("change",  function() {
+  $("#checkDietRestriction").on("change",  function() {
     let norestrict = $(this).is(':checked');
     if (norestrict) {
-        dietContainer.style.display = "none";
+        $("#dietContainer").hide();
         $("#diet").val("No dietary restrictions");
 
-    }
-    else {
-        dietContainer.style.display = "block";
+    } else {
+        $("#dietContainer").show();
     }
   });
 

--- a/app/templates/events/eventView.html
+++ b/app/templates/events/eventView.html
@@ -82,7 +82,7 @@
                 <div class="col-md-6">
                     <h3>Description</h3><p>{{eventData.description|urlize}}</p><br>
                     {% if eventData.isFoodProvided %}
-                        <p>Food will be provided at this event. <a href="/profile/{{g.current_user}}?accordion=dietaryInformation"><br><b>Please fill in any dietary restriction(s) on your "My profile" page.</b></a></p>
+                        <p>Food will be provided at this event. <a href="/profile/{{g.current_user}}?accordion=dietaryInformation"><br><b>Please fill in any dietary restrictions on your "My profile" page.</b></a></p>
                     {% endif %}
                     {% if eventData.isService %}
                         <p>This event earns service hours.</p>

--- a/app/templates/events/eventView.html
+++ b/app/templates/events/eventView.html
@@ -82,7 +82,7 @@
                 <div class="col-md-6">
                     <h3>Description</h3><p>{{eventData.description|urlize}}</p><br>
                     {% if eventData.isFoodProvided %}
-                        <p>Food will be provided at this event. <a href="/profile/{{g.current_user}}?accordion=dietaryInformation"><br><b>Please fill in any dietary restrictions on your "My profile" page.</b></a></p>
+                        <p>Food will be provided at this event. <a href="/profile/{{g.current_user}}?accordion=dietaryInformation"><br><b>Please fill in any dietary restriction(s) on your "My profile" page.</b></a></p>
                     {% endif %}
                     {% if eventData.isService %}
                         <p>This event earns service hours.</p>

--- a/app/templates/events/volunteerDetails.html
+++ b/app/templates/events/volunteerDetails.html
@@ -27,7 +27,7 @@
         <div class="phoneSelect" nowrap>{{ participant.user.phoneNumber if participant.user.phoneNumber else "No phone number"}}</div>
         <div class="emailSelect" nowrap>{{ participant.user.email }}</div>
         <div class="statusSelect" nowrap>Volunteer Status: {{ volunteerType|title }}</div>
-        <div class="dietRestrictionSelect">Dietary Restriction(s): {{ participant.user.dietRestriction if participant.user.dietRestriction else "None Specified" }}</div>
+        <div class="dietRestrictionSelect">Dietary Restrictions: {{ participant.user.dietRestriction if participant.user.dietRestriction else "None Specified" }}</div>
         <div class="emergencyContactSelect" nowrap>Emergency Contact: {{participant.emergencycontact.name if participant.emergencycontact}} 
           {{participant.emergencycontact.cellPhone or participant.emergencycontact.homePhone or participant.emergencycontact.workPhone if participant.emergencycontact}} 
           {{"None Specified" if not participant.emergencycontact}}</div>
@@ -98,7 +98,7 @@
         <div class="col">
           <label><b>Included Information:</b></label><br>
           <input class="displayCheckbox noprint" type="checkbox" name="selected_items" id="dietRestrictionSelect" checked>
-          <label for="dietRestrictionSelect">Dietary Restriction(s)</label><br>
+          <label for="dietRestrictionSelect">Dietary Restrictions</label><br>
           <input class="displayCheckbox noprint" type="checkbox" name="selected_items" id="emergencyContactSelect" checked>
           <label for="emergencyContactSelect">Emergency Contact</label><br>
           <input class="displayCheckbox noprint" type="checkbox" name="selected_items" id="phoneSelect" checked>
@@ -138,7 +138,7 @@
           <th class="phoneSelect">Phone Number</th>
           <th class="emailSelect">Email</th>
           <th class="statusSelect">Volunteer Status</th>
-          <th class="dietRestrictionSelect">Dietary Restriction(s)</th>
+          <th class="dietRestrictionSelect">Dietary Restrictions</th>
           <th class="emergencyContactSelect">Emergency Contact</th>
         </tr>
       </thead>

--- a/app/templates/events/volunteerDetails.html
+++ b/app/templates/events/volunteerDetails.html
@@ -27,7 +27,7 @@
         <div class="phoneSelect" nowrap>{{ participant.user.phoneNumber if participant.user.phoneNumber else "No phone number"}}</div>
         <div class="emailSelect" nowrap>{{ participant.user.email }}</div>
         <div class="statusSelect" nowrap>Volunteer Status: {{ volunteerType|title }}</div>
-        <div class="dietRestrictionSelect">Dietary Restrictions: {{ participant.user.dietRestriction if participant.user.dietRestriction else "None Specified" }}</div>
+        <div class="dietRestrictionSelect">Dietary Restriction(s): {{ participant.user.dietRestriction if participant.user.dietRestriction else "None Specified" }}</div>
         <div class="emergencyContactSelect" nowrap>Emergency Contact: {{participant.emergencycontact.name if participant.emergencycontact}} 
           {{participant.emergencycontact.cellPhone or participant.emergencycontact.homePhone or participant.emergencycontact.workPhone if participant.emergencycontact}} 
           {{"None Specified" if not participant.emergencycontact}}</div>

--- a/app/templates/events/volunteerDetails.html
+++ b/app/templates/events/volunteerDetails.html
@@ -31,10 +31,10 @@
         <div class="phoneSelect" nowrap>{{ participant.user.phoneNumber if participant.user.phoneNumber else "No phone number"}}</div>
         <div class="emailSelect" nowrap>{{ participant.user.email }}</div>
         <div class="statusSelect" nowrap>Volunteer Status: {{ volunteerType|title }}</div>
-        <div class="dietRestrictionSelect">Dietary Restrictions: {{ participant.user.dietRestriction if participant.user.dietRestriction else "None Specified" }}</div>
+        <div class="dietRestrictionSelect">Dietary Restrictions: {{ participant.user.dietRestriction if participant.user.dietRestriction else "Yet to be indicated" }}</div>
         <div class="emergencyContactSelect" nowrap>Emergency Contact: {{participant.emergencycontact.name if participant.emergencycontact}} 
           {{participant.emergencycontact.cellPhone or participant.emergencycontact.homePhone or participant.emergencycontact.workPhone if participant.emergencycontact}} 
-          {{"None Specified" if not participant.emergencycontact}}</div>
+          {{"Yet to be indicated" if not participant.emergencycontact}}</div>
         <div class="insuranceSelect" nowrap>Insurance Info: {{participant.insuranceinfo.insuranceCompany if participant.insuranceinfo}}</div>
       </ul>
     </div>
@@ -46,7 +46,7 @@
       <td class="phoneSelect" nowrap>{{ participant.user.phoneNumber if participant.user.phoneNumber else "" }}</td>
       <td class="emailSelect" nowrap>{{ participant.user.email }}</td>
       <td class="statusSelect" nowrap>{{ volunteerType|title if volunteerType != 'rsvp' else volunteerType|upper}}</td>
-      <td class="dietRestrictionSelect">{{ participant.user.dietRestriction if participant.user.dietRestriction else 'None specified'}}</td>
+      <td class="dietRestrictionSelect">{{ participant.user.dietRestriction if participant.user.dietRestriction else 'Yet to be indicated'}}</td>
       <td class="emergencyContactSelect">{{participant.emergencycontact.name if participant.emergencycontact}} 
         {{participant.emergencycontact.cellPhone or participant.emergencycontact.homePhone or participant.emergencycontact.workPhone if participant.emergencycontact}} </td>
       <td class="insuranceSelect" nowrap>{{ participant.insuranceinfo.policyNumber if participant.insuranceinfo}}</td>

--- a/app/templates/events/volunteerDetails.html
+++ b/app/templates/events/volunteerDetails.html
@@ -27,7 +27,7 @@
         <div class="phoneSelect" nowrap>{{ participant.user.phoneNumber if participant.user.phoneNumber else "No phone number"}}</div>
         <div class="emailSelect" nowrap>{{ participant.user.email }}</div>
         <div class="statusSelect" nowrap>Volunteer Status: {{ volunteerType|title }}</div>
-        <div class="dietRestrictionSelect">Dietary Restriction(s): {{ participant.user.dietRestriction if participant.user.dietRestriction else "None Specified" }}</div>
+        <div class="dietRestrictionSelect">Dietary Restriction(s): {{ participant.user.dietRestriction if not participant.user.dietRestriction else "None Specified" }}</div>
         <div class="emergencyContactSelect" nowrap>Emergency Contact: {{participant.emergencycontact.name if participant.emergencycontact}} 
           {{participant.emergencycontact.cellPhone or participant.emergencycontact.homePhone or participant.emergencycontact.workPhone if participant.emergencycontact}} 
           {{"None Specified" if not participant.emergencycontact}}</div>

--- a/app/templates/events/volunteerDetails.html
+++ b/app/templates/events/volunteerDetails.html
@@ -41,7 +41,7 @@
       <td class="phoneSelect" nowrap>{{ participant.user.phoneNumber if participant.user.phoneNumber else "" }}</td>
       <td class="emailSelect" nowrap>{{ participant.user.email }}</td>
       <td class="statusSelect" nowrap>{{ volunteerType|title if volunteerType != 'rsvp' else volunteerType|upper}}</td>
-      <td class="dietRestrictionSelect">{{ participant.user.dietRestriction if participant.user.dietRestriction else ''}}</td>
+      <td class="dietRestrictionSelect">{{ participant.user.dietRestriction if participant.user.dietRestriction else 'None specified'}}</td>
       <td class="emergencyContactSelect">{{participant.emergencycontact.name if participant.emergencycontact}} 
         {{participant.emergencycontact.cellPhone or participant.emergencycontact.homePhone or participant.emergencycontact.workPhone if participant.emergencycontact}} </td>
     </tr>
@@ -98,7 +98,7 @@
         <div class="col">
           <label><b>Included Information:</b></label><br>
           <input class="displayCheckbox noprint" type="checkbox" name="selected_items" id="dietRestrictionSelect" checked>
-          <label for="dietRestrictionSelect">Dietary Restriction</label><br>
+          <label for="dietRestrictionSelect">Dietary Restriction(s)</label><br>
           <input class="displayCheckbox noprint" type="checkbox" name="selected_items" id="emergencyContactSelect" checked>
           <label for="emergencyContactSelect">Emergency Contact</label><br>
           <input class="displayCheckbox noprint" type="checkbox" name="selected_items" id="phoneSelect" checked>
@@ -138,7 +138,7 @@
           <th class="phoneSelect">Phone Number</th>
           <th class="emailSelect">Email</th>
           <th class="statusSelect">Volunteer Status</th>
-          <th class="dietRestrictionSelect">Dietary Restriction</th>
+          <th class="dietRestrictionSelect">Dietary Restriction(s)</th>
           <th class="emergencyContactSelect">Emergency Contact</th>
         </tr>
       </thead>

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -436,7 +436,7 @@
     <h3 class="accordion-header" id="headingSeven">
     {% set focus = "open" if visibleAccordion == "dietaryInformation" else "collapsed" %}
     <button class="accordion-button {{focus}}" type="button" data-bs-toggle="collapse" data-bs-target="#collapseSeven" aria-expanded="false" aria-controls="collapseSeven">
-      Dietary Restrictions
+      Dietary Restriction(s)
     </button>
     </h3>
     {% set show = "show" if visibleAccordion == "dietaryInformation" else "" %}
@@ -445,7 +445,7 @@
         <div class="container">
           <form>
             <div class="form-group">
-              <label for="usr">Please enter any dietary restrictions you have:</label>
+              <label for="usr">Please enter any dietary restriction(s) you have:</label>
               <textarea class="form-control" id="diet" placeholder="Dietary Restrictions">{%if volunteer.dietRestriction%}{{volunteer.dietRestriction}}{%endif%}</textarea>
             </div>
             <br>

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -449,10 +449,10 @@
                 <label class="custom-control-label" for="checkDietRestriction"><strong> No dietary restrictions</strong></label>
                 <input class="form-check-input" type="checkbox" id="checkDietRestriction" name="DietRestriction" {{"checked" if volunteer.dietRestriction}} />
               </div>
-              {% if volunteer.dietRestriction %}
-              <label for="usr">Please enter any dietary restrictions you have:</label>
-              <textarea class="form-control" id="diet" placeholder="Dietary Restrictions">{%if volunteer.dietRestriction%}{{volunteer.dietRestriction}}{%endif%}</textarea>
-              {% endif %}
+                  <div id="dietContainer" style="display: none;">
+                          <label for="usr">Please enter any dietary restrictions you have:</label>
+                          <textarea class="form-control" id="diet" placeholder="Dietary Restrictions">{%if volunteer.dietRestriction%}{{volunteer.dietRestriction}}{%endif%}</textarea>
+                  </div>  
             </div>
             <br>
             <button type="button" class="saveDiet btn btn-primary" data-user="{{volunteer.username}}">Save</button>

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -436,7 +436,7 @@
     <h3 class="accordion-header" id="headingSeven">
     {% set focus = "open" if visibleAccordion == "dietaryInformation" else "collapsed" %}
     <button class="accordion-button {{focus}}" type="button" data-bs-toggle="collapse" data-bs-target="#collapseSeven" aria-expanded="false" aria-controls="collapseSeven">
-      Dietary Restriction(s)
+      Dietary Restrictions
     </button>
     </h3>
     {% set show = "show" if visibleAccordion == "dietaryInformation" else "" %}
@@ -445,8 +445,14 @@
         <div class="container">
           <form>
             <div class="form-group">
-              <label for="usr">Please enter any dietary restriction(s) you have:</label>
+              <div class=" form-check form-switch mb-2">
+                <label class="custom-control-label" for="checkDietRestriction"><strong> No dietary restrictions</strong></label>
+                <input class="form-check-input" type="checkbox" id="checkDietRestriction" name="DietRestriction" {{"checked" if volunteer.dietRestriction}} />
+              </div>
+              {% if volunteer.dietRestriction %}
+              <label for="usr">Please enter any dietary restrictions you have:</label>
               <textarea class="form-control" id="diet" placeholder="Dietary Restrictions">{%if volunteer.dietRestriction%}{{volunteer.dietRestriction}}{%endif%}</textarea>
+              {% endif %}
             </div>
             <br>
             <button type="button" class="saveDiet btn btn-primary" data-user="{{volunteer.username}}">Save</button>

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -447,7 +447,7 @@
             <div class="form-group">
               <div class=" form-check form-switch mb-2">
                 <label class="custom-control-label" for="checkDietRestriction"><strong> No dietary restrictions</strong></label>
-                <input class="form-check-input" type="checkbox" id="checkDietRestriction" name="DietRestriction" {{"checked" if not (volunteer.dietRestriction) or (volunteer.dietRestriction == "No dietary restrictions")}} />
+                <input class="form-check-input" type="checkbox" id="checkDietRestriction" name="DietRestriction" {{"checked" if (volunteer.dietRestriction == "No dietary restrictions")}} />
               </div>
                   <div id="dietContainer" style="display: block;">
                           <label for="usr">Please enter any dietary restrictions you have:</label>

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -447,9 +447,9 @@
             <div class="form-group">
               <div class=" form-check form-switch mb-2">
                 <label class="custom-control-label" for="checkDietRestriction"><strong> No dietary restrictions</strong></label>
-                <input class="form-check-input" type="checkbox" id="checkDietRestriction" name="DietRestriction" {{"checked" if volunteer.dietRestriction}} />
+                <input class="form-check-input" type="checkbox" id="checkDietRestriction" name="DietRestriction" {{"checked" if not (volunteer.dietRestriction) or (volunteer.dietRestriction == "No dietary restrictions")}} />
               </div>
-                  <div id="dietContainer" style="display: none;">
+                  <div id="dietContainer" style="display: block;">
                           <label for="usr">Please enter any dietary restrictions you have:</label>
                           <textarea class="form-control" id="diet" placeholder="Dietary Restrictions">{%if volunteer.dietRestriction%}{{volunteer.dietRestriction}}{%endif%}</textarea>
                   </div>  

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -449,7 +449,7 @@
                 <label class="custom-control-label" for="checkDietRestriction"><strong> No dietary restrictions</strong></label>
                 <input class="form-check-input" type="checkbox" id="checkDietRestriction" name="DietRestriction" {{"checked" if (volunteer.dietRestriction == "No dietary restrictions")}} />
               </div>
-                  <div id="dietContainer" style="display: block;">
+                  <div id="dietContainer">
                           <label for="usr">Please enter any dietary restrictions you have:</label>
                           <textarea class="form-control" id="diet" placeholder="Dietary Restrictions">{%if volunteer.dietRestriction%}{{volunteer.dietRestriction}}{%endif%}</textarea>
                   </div>  


### PR DESCRIPTION
## Issue Description

Fixes #1450 
- If a user hasn't inputted a dietary restriction, it would show up as a blank field in the volunteer details page. We needed this field to indicate that they haven't specified a dietary restriction yet. 
- "Dietary restriction" needed to be changed to "dietary restriction(s)". 

## Changes

-Changed     dietRestriction = TextField(null=True) in minor.py file to dietRestriction = TextField(null=False) to change the conditional statement for a null input. Now the volunteer details page shows "Not specified" if the dietRestriction is null.
- All "Dietary restriction" has been changed to "dietary restriction(s)". 

## Testing

- Ran the app and went to the user profile to make sure the words are changed. 
- Ran app and went to volunteer details to see what was displayed for volunteers with no specified dietary restrictions.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 