### PR TITLE
Default Event Location Not Populated When Edit Program Modal is Open

### DIFF
--- a/app/templates/admin/userManagement.html
+++ b/app/templates/admin/userManagement.html
@@ -151,7 +151,7 @@
                         "partner": "{{ program.partner if program.partner else "" }}",
                         "contactEmail": "{{ program.contactEmail if program.contactEmail else "" }}",
                         "contactName": "{{ program.contactName if program.contactName else "" }}",
-                        "location": "{{ program.location if program.location else "" }}",
+                        "location": "{{ program.defaultLocation if program.defaultLocation else "" }}",
                         "programid": "{{ program.id }}",
                         "instagramUrl": "{{ program.instagramUrl if program.instagramUrl else "" }}",
                         "facebookUrl": "{{ program.facebookUrl if program.facebookUrl else "" }}",


### PR DESCRIPTION
Fixes #1424 
- In the Program Management, when editing the details of a specific program and adding a Default Event Location, that input is not recorded if the modal is reopen.

## Changes

- changed program location key from program.location to program.defaultLocation 
-
![image](https://github.com/user-attachments/assets/c7992ecd-6245-48d2-b782-dc039488d321)


## Testing

- Click on the Admin Dropdown button, then Settings and finally click on Program Management.
- Make sure When editing the details of a specific program, a Default Event Location is added. 
- When you save the changes and reopen the modal, the input is recorded. 

***BEFORE***
![image](https://github.com/user-attachments/assets/ad76955d-2339-44d1-9e35-94874d1e4bb4)


***AFTER***
![image](https://github.com/user-attachments/assets/4121de41-2698-4ac4-9caf-70ab8b1c1a77)
