### PR TITLE
Replaced the Javascript with anchor tag for the service transcript 

### DIFF
--- a/app/static/js/userProfile.js
+++ b/app/static/js/userProfile.js
@@ -25,7 +25,6 @@ $(document).ready(function(){
       })
   $("#actions").on("change", changeAction)
   $("#phoneInput").inputmask('(999)-999-9999');
-  $("#serviceTranscript").click(viewTranscript); 
   $(".notifyInput").click(function updateInterest(){
     var programID = $(this).data("programid");
     var username = $(this).data('username');
@@ -97,11 +96,6 @@ $(document).ready(function(){
     $(this).val('')
   }
   
-  function viewTranscript(e){
-    let username = $(this).data('username')
-    window.location.href = `/profile/${username}/serviceTranscript`
-  }
-
   // This function is to disable all the dates before current date in the ban modal End Date picker
   $(function(){
     var banEndDatepicker = $("#banEndDatepicker");

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -166,7 +166,7 @@
             {% endif %}
           </table>    
         </div>
-        <button class="btn btn-primary" id="serviceTranscript" data-username="{{volunteer.username}}"> View Service Transcript </button>
+        <a href= "{{volunteer.username}}/serviceTranscript" ><button class="btn btn-primary btn-sm" > View Service Transcript </button> </a>
       </div>
     </div>
   </div>

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -166,7 +166,7 @@
             {% endif %}
           </table>    
         </div>
-        <a href= "{{volunteer.username}}/serviceTranscript" ><button class="btn btn-primary btn-sm" > View Service Transcript </button> </a>
+        <a class="btn btn-primary btn-sm" href="{{volunteer.username}}/serviceTranscript" > View Service Transcript</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Issue Description

Fixes #1518 

- The 'View Service Transcript' button in Participation History is using javascript and an onclick handler to change to the service transcript page. We need anchor <a> tag instead and get rid of the Javascript.

## Changes

- Removed the javascript onclick handler and all the JS code that was related to the button. 
- Used anchor tag and a button instead to redirect the page to service transcript.

## Testing

- Flask Run and then go to My Profile.
- Under My Profile, open Participation History 
- Then, click on the 'View Service Transcript' button to see the results. 

![image](https://github.com/user-attachments/assets/5892a4bb-b752-4cc5-943d-bf2eaff25767)
