### PR TITLE
Renamed the Kiosk Mode page to Scanner Entry, for clarification.

### DIFF
--- a/app/controllers/events/routes.py
+++ b/app/controllers/events/routes.py
@@ -12,7 +12,7 @@ from app.controllers.events import email
 from app.logic.emailHandler import EmailHandler
 from app.logic.participants import addBnumberAsParticipant
 
-@events_bp.route('/event/<eventid>/kiosk', methods=['GET'])
+@events_bp.route('/event/<eventid>/scannerentry', methods=['GET'])
 def loadKiosk(eventid):
     """Renders kiosk for specified event."""
     event = Event.get_by_id(eventid)

--- a/app/templates/events/eventKiosk.html
+++ b/app/templates/events/eventKiosk.html
@@ -1,4 +1,4 @@
-{% set title = "Event Kiosk" %}
+{% set title = "Scanner Entry" %}
 {% extends "base.html" %}
 {% block scripts %}
   {{ super() }}

--- a/app/templates/events/manageVolunteers.html
+++ b/app/templates/events/manageVolunteers.html
@@ -34,7 +34,7 @@
   <div class='form-group d-flex row'>
     <div class="col-6 px-1">
       <a class="btn btn-success" role="button" href="#" data-bs-toggle="modal" data-bs-target="#addVolunteerModal" style="margin:5px;">{{modalTitle}}</a>
-      <a class="btn btn-warning" role="button" href= "/event/{{event.id}}/kiosk" style="margin:5px;">Scanner Entry  </a>
+      <a class="btn btn-warning" role="button" href= "/event/{{event.id}}/scannerentry" style="margin:5px;">Scanner Entry  </a>
     </div>
     {% if rsvpFull %}
     <div class="col-6 text-end">

--- a/app/templates/events/manageVolunteers.html
+++ b/app/templates/events/manageVolunteers.html
@@ -34,7 +34,7 @@
   <div class='form-group d-flex row'>
     <div class="col-6 px-1">
       <a class="btn btn-success" role="button" href="#" data-bs-toggle="modal" data-bs-target="#addVolunteerModal" style="margin:5px;">{{modalTitle}}</a>
-      <a class="btn btn-warning" role="button" href= "/event/{{event.id}}/kiosk" style="margin:5px;">Kiosk Entry</a>
+      <a class="btn btn-warning" role="button" href= "/event/{{event.id}}/kiosk" style="margin:5px;">Scanner Entry  </a>
     </div>
     {% if rsvpFull %}
     <div class="col-6 text-end">


### PR DESCRIPTION
Fixes #1519 
- Rename the Kiosk Mode page to Scanner Entry, for clarification.

## Changes

- We opened the manageVolunteers.html file and then renamed the Kiosk Entry to Scanner Entry.

## Testing

- Open the CELTS Site and then go to Create Event 
- Then there's a list of programs and select any of the programs
- Fill out all the information and then save the event.
- Once, the event is successfully created, you will be able to see 'Manage Volunteers', click on it.
- The Yellow button at the top should say Scanner Entry.

***BEFORE***
![image](https://github.com/user-attachments/assets/20297344-3a44-4347-8f62-3a2883cd3282)

***AFTER***
![image](https://github.com/user-attachments/assets/fc025e30-dcd0-4802-afcf-06354c766168)
