### PR TITLE
Event title for celts sponsored

### DIFF
--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -160,8 +160,6 @@ def viewUsersProfile(username):
     """
     This function displays the information of a volunteer to the user
     """
-    isChrome = True if "Chrom" in request.user_agent.string else False
-    
     try:
         volunteer = User.get(User.username == username)
     except Exception as e:
@@ -244,7 +242,6 @@ def viewUsersProfile(username):
                                 managersList = managersList,
                                 participatedInLabor = getCeltsLaborHistory(volunteer),
                                 totalSustainedEngagements = totalSustainedEngagements,
-                                isChrome = isChrome
                             )
     abort(403)
 

--- a/app/static/js/userProfile.js
+++ b/app/static/js/userProfile.js
@@ -105,7 +105,7 @@ $(document).ready(function(){
   $(function(){
     var banEndDatepicker = $("#banEndDatepicker");
     banEndDatepicker.datepicker({
-      changeYear: true,   
+      changeYear: true,
       changeMonth: true,
       minDate:+1,
       dateFormat: "yy-mm-dd",
@@ -131,7 +131,7 @@ $(document).ready(function(){
     banButton.data("banOrUnban", banValue);
     banEndDateDiv.show();
     banEndDatepicker.val("")
-   $(".modal-title-ban").text(banValue + " Volunteer");
+    $(".modal-title-ban").text(banValue + " Volunteer");
     $("#modalProgramName").text("Program: " + $(this).data("name "));
     $("#banModal").modal("toggle");
     $("#banNoteTxtArea").val("");
@@ -145,7 +145,7 @@ $(document).ready(function(){
     
   });
 
- $("#banNoteTxtArea, #banEndDatepicker").on('input' , function (e) { //This is the if statement the placeholder in line 45 is for #PLCHLD1
+  $("#banNoteTxtArea, #banEndDatepicker").on('input' , function (e) { //This is the if statement the placeholder in line 45 is for #PLCHLD1
     var enableButton = ($("#banNoteTxtArea").val() && $("#banEndDatepicker").val());
     $("#banButton").prop("disabled", !enableButton);
   });

--- a/app/static/js/userProfile.js
+++ b/app/static/js/userProfile.js
@@ -102,15 +102,14 @@ $(document).ready(function(){
   }
 
   // This function is to disable all the dates before current date in the ban modal End Date picker
-  // console.log($.browser);
   $(function(){
     var banEndDatepicker = $("#banEndDatepicker");
     banEndDatepicker.datepicker({
       changeYear: true,   
       changeMonth: true,
       minDate:+1,
-      dateFormat: "mm-dd-yy",
-    }) 
+      dateFormat: "yy-mm-dd",
+    }).attr('readonly','readonly');
   });
 
     /*
@@ -132,8 +131,8 @@ $(document).ready(function(){
     banButton.data("banOrUnban", banValue);
     banEndDateDiv.show();
     banEndDatepicker.val("")
-    $(".modal-title-ban").text(banValue + " Volunteer from "+ $(this).data("name") + "?");
-    $("#modalProgramName").text("Program: " + $(this).data("name"));
+   $(".modal-title-ban").text(banValue + " Volunteer");
+    $("#modalProgramName").text("Program: " + $(this).data("name "));
     $("#banModal").modal("toggle");
     $("#banNoteTxtArea").val("");
     $("#banButton").prop("disabled", true);
@@ -146,14 +145,10 @@ $(document).ready(function(){
     
   });
 
- $("#banNoteTxtArea, #banEndDatepicker").on('input change' , function (e) { //This is the if statement the placeholder in line 45 is for #PLCHLD1
+ $("#banNoteTxtArea, #banEndDatepicker").on('input' , function (e) { //This is the if statement the placeholder in line 45 is for #PLCHLD1
     var enableButton = ($("#banNoteTxtArea").val() && $("#banEndDatepicker").val());
     $("#banButton").prop("disabled", !enableButton);
   });
-
-$("#banEndDatepicker").on('change', function () {
-  console.log("Datepicker changed:", $(this).val());
-});
 
   $("#banButton").click(function (){
      $("#banButton").prop("disabled", true)

--- a/app/static/js/userProfile.js
+++ b/app/static/js/userProfile.js
@@ -119,11 +119,8 @@ $(document).ready(function(){
     var banEndDatepicker = $("#banEndDatepicker");
     banEndDatepicker.datepicker({
       changeYear: true,
-      changeYear: true,
       changeMonth: true,
       minDate:+1,
-      dateFormat: "yy-mm-dd",
-    }).attr('readonly','readonly');
       dateFormat: "yy-mm-dd",
     }).attr('readonly','readonly');
   });
@@ -147,8 +144,8 @@ $(document).ready(function(){
     banButton.data("banOrUnban", banValue);
     banEndDateDiv.show();
     banEndDatepicker.val("")
-    $(".modal-title-ban").text(banValue + " Volunteer");
-    $("#modalProgramName").text("Program: " + $(this).data("name "));
+    $(".modal-title-ban").text(banValue + " Volunteer from "+ $(this).data("name") + "?");
+    $("#modalProgramName").text("Program: " + $(this).data("name"));
     $("#banModal").modal("toggle");
     $("#banNoteTxtArea").val("");
     $("#banButton").prop("disabled", true);
@@ -161,10 +158,9 @@ $(document).ready(function(){
     
   });
 
-  $("#banNoteTxtArea, #banEndDatepicker").on('input' , function (e) { //This is the if statement the placeholder in line 45 is for #PLCHLD1
+  $("#banNoteTxtArea, #banEndDatepicker").on('input change' , function (e) { //This is the if statement the placeholder in line 45 is for #PLCHLD1
     var enableButton = ($("#banNoteTxtArea").val() && $("#banEndDatepicker").val());
     $("#banButton").prop("disabled", !enableButton);
-  });
   });
 
   $("#banButton").click(function (){

--- a/app/templates/events/createEvent.html
+++ b/app/templates/events/createEvent.html
@@ -320,6 +320,7 @@
         {% if event and not (event.isCanceled or eventPast) %}
         <button type="button" class="btn btn-warning bordered-element m-2" data-bs-toggle="modal"
           data-bs-target="#cancelWarning">Cancel Event</button>
+
         {% elif event and (event.isCanceled) %}
         <button type="button" class="btn btn-success" data-bs-toggle="modal" data-bs-target="#renewWarning">Renew
           Event</button>

--- a/app/templates/events/createEvent.html
+++ b/app/templates/events/createEvent.html
@@ -7,7 +7,13 @@
     {% set page_title = 'Create a ' + eventData["program"].programName %}
 
   {% elif template.tag == 'single-program' %}
-    {%set page_title = 'Create a ' + eventData["program"].programName %}
+    {% if eventData["program"].programName == 'CELTS-Sponsored Event' %}
+      {%set page_title = 'Create a ' + eventData["program"].programName %}
+    {% elif eventData["program"].programName == 'Adopt-a-Grandparent' %}
+      {% set page_title = 'Create an ' + eventData["program"].programName + ' Event' %}
+    {% else %}
+      {%set page_title = 'Create a ' + eventData["program"].programName + ' Event' %}
+    {% endif %}
 
   {% elif eventData["program"].programName == 'CELTS-Sponsored Event' and template.tag == 'all-volunteer' %}
     {% set page_title = 'Create All Volunteer Training' %}

--- a/app/templates/events/createEvent.html
+++ b/app/templates/events/createEvent.html
@@ -3,16 +3,13 @@
 {% set isNewEvent = 'create' in request.path %}
 {% set showRecurringToggle = True %}
 {% if isNewEvent %}
-  {% if eventData["program"].programName == 'CELTS-Sponsored Event' and template.tag == '' %}
-    {% set page_title = 'Create a ' + eventData["program"].programName %}
-
-  {% elif template.tag == 'single-program' %}
+  {% if template.tag == 'single-program' %}
+    {% set programName = eventData.program.programName %}
+    {% set prefix = "an" if programName[0] in 'aeiouAEIOU' else "a" %}
     {% if eventData["program"].programName == 'CELTS-Sponsored Event' %}
-      {%set page_title = 'Create a ' + eventData["program"].programName %}
-    {% elif eventData["program"].programName == 'Adopt-a-Grandparent' %}
-      {% set page_title = 'Create an ' + eventData["program"].programName + ' Event' %}
+      {%set page_title = 'Create ' + prefix + ' ' + eventData["program"].programName %}
     {% else %}
-      {%set page_title = 'Create a ' + eventData["program"].programName + ' Event' %}
+      {%set page_title = 'Create ' + prefix + ' ' + eventData["program"].programName + ' Event' %}
     {% endif %}
 
   {% elif eventData["program"].programName == 'CELTS-Sponsored Event' and template.tag == 'all-volunteer' %}

--- a/app/templates/events/createEvent.html
+++ b/app/templates/events/createEvent.html
@@ -7,7 +7,7 @@
     {% set page_title = 'Create a ' + eventData["program"].programName %}
 
   {% elif template.tag == 'single-program' %}
-    {%set page_title = 'Create Event for ' + eventData["program"].programName %}
+    {%set page_title = 'Create a ' + eventData["program"].programName %}
 
   {% elif eventData["program"].programName == 'CELTS-Sponsored Event' and template.tag == 'all-volunteer' %}
     {% set page_title = 'Create All Volunteer Training' %}

--- a/app/templates/events/eventNav.html
+++ b/app/templates/events/eventNav.html
@@ -8,7 +8,7 @@
     {% if not isNewEvent %}
         {% set programName = event.program.programName %}
         {% set prefix = "An" if programName[0] in 'aeiouAEIOU' else "A" %}
-        <{{smallh}} class="text-muted">{{prefix}} {{ programName }} Event</{{smallh}}>
+        <{{smallh}} class="text-muted">{{prefix}} {{ programName }} </{{smallh}}>
     {% endif %}
 {% endmacro %}
 

--- a/app/templates/events/eventNav.html
+++ b/app/templates/events/eventNav.html
@@ -8,7 +8,7 @@
     {% if not isNewEvent %}
         {% set programName = event.program.programName %}
         {% set prefix = "An" if programName[0] in 'aeiouAEIOU' else "A" %}
-        {% if eventData["program"].programName == 'CELTS-Sponsored Event'%}
+        {% if event["program"].programName == 'CELTS-Sponsored Event'%}
             <{{smallh}} class="text-muted">{{prefix}} {{ programName }} </{{smallh}}> 
         {% else %}
             <{{smallh}} class="text-muted">{{prefix}} {{ programName }} Event </{{smallh}}> 

--- a/app/templates/events/eventNav.html
+++ b/app/templates/events/eventNav.html
@@ -8,7 +8,11 @@
     {% if not isNewEvent %}
         {% set programName = event.program.programName %}
         {% set prefix = "An" if programName[0] in 'aeiouAEIOU' else "A" %}
-        <{{smallh}} class="text-muted">{{prefix}} {{ programName }} </{{smallh}}>
+        {% if eventData["program"].programName == 'CELTS-Sponsored Event'%}
+            <{{smallh}} class="text-muted">{{prefix}} {{ programName }} </{{smallh}}> 
+        {% else %}
+            <{{smallh}} class="text-muted">{{prefix}} {{ programName }} Event </{{smallh}}> 
+        {% endif %}
     {% endif %}
 {% endmacro %}
 

--- a/app/templates/events/manageVolunteers.html
+++ b/app/templates/events/manageVolunteers.html
@@ -117,7 +117,7 @@
                           type ="number"
                           min="0"
                           step="0.01"
-                              value='{{participant.hoursEarned}}'
+                          value='{{participant.hoursEarned}}'
                         />
                       </td>
                       <td style="text-align:center">

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -591,7 +591,7 @@
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title-ban"></h5>
+          <h5 class="modal-title-ban">Ban Volunteer</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body" style="align=center">
@@ -603,9 +603,7 @@
             <p align="left" id="banNote">Why the student was banned</p>
           </div>
           <div id="banEndDate">
-            <h6 align="left" class="d-inline-flex" id="unbanVolunteerEndDate">End Date: &nbsp
-              <input id="banEndDatepicker" readonly='readonly'  type= {% if isChrome == True %} "text" placeholder="mm/dd/yyyy" {% else %} "text" placeholder="mm/dd/yyyy" {% endif %}>
-            </h6>
+            <h6 align="left" class="d-inline-flex" id="unbanVolunteerEndDate">End Date: &nbsp<input id="banEndDatepicker" type="date"></h6>
           </div>
           
           <div class="input-group">

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -597,7 +597,7 @@
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title-ban">Ban Volunteer</h5>
+          <h5 class="modal-title-ban"></h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body" style="align=center">


### PR DESCRIPTION
## Issue Description

Fixes #1520
-The Event Subtitle Displays "A CELTS-Sponsored Event Event"
-Create Event Page Title is messy "Create Event for CELTS-Sponsored Event"

## Changes
-Event only is placed in the title once.
-Create Event Page Title now states "Create a CELTS-Sponsored Event"
![image](https://github.com/user-attachments/assets/532bbf41-2fb6-4c64-b68e-172011f80bf1)
![image](https://github.com/user-attachments/assets/ac5e6f93-39dc-454f-9725-cf646ed6697c)

## Testing
-Go to Create Event and press CELTS-Sponsored Event
-Add a new event then check view/edit event for the subtitle that should display only event once