### PR TITLE
Fixed the sticky withdraw action on the course propsal page

### DIFF
--- a/app/static/js/slcManagement.js
+++ b/app/static/js/slcManagement.js
@@ -139,8 +139,10 @@ function withdraw(){
     },
     error: function(request, status, error) {
         console.log(status,error);
+        $('#' + courseID).val('---');
     }
-  })
+  });
+  $('#' + courseID).val('---');
 };
 
 function changeTerm() {

--- a/app/static/js/slcManagement.js
+++ b/app/static/js/slcManagement.js
@@ -138,11 +138,13 @@ function withdraw(){
       location.reload();
     },
     error: function(request, status, error) {
-        console.log(status,error);
-        $('#' + courseID).val('---');
+        console.log(status,error);      
+        
+    },
+    done: function () {
+      $('#' + courseID).val('---');
     }
   });
-  $('#' + courseID).val('---');
 };
 
 function changeTerm() {


### PR DESCRIPTION
## Issue Description

Fixes #1235 
-After you withdraw a proposal in the "Course Proposal", the course below the one you withdraw from defaults the "Choose Action" drop down menu to "Withdraw". Even if you are wanting to withdraw from that next course, this action doesn't work.

## Changes

- Added JavaScript code that resets the drop down immediately after sending the request.

## Testing

-  Open the CELTS website and as an Admin go to Course Proposals 
- With the list of courses that can be seen, click on Withdraw on any of the course
- Then once you withdraw the course, the 'action' for rest of the courses remain unchanged


***BEFORE***

![image](https://github.com/user-attachments/assets/08010388-296c-41a5-9cb7-66b7c722bb24)

Once you click on the withdraw course button, the course below the one you withdrew changes the 'Action' to Withdraw automatically.


***AFTER***

![image](https://github.com/user-attachments/assets/de0ce3a1-7d86-4e64-bb3b-d2d4bd82a812)
