### PR TITLE
Filename error on Event view page

### DIFF
--- a/app/templates/events/eventView.html
+++ b/app/templates/events/eventView.html
@@ -161,8 +161,12 @@
                         <label class="mb-2" for= "eventAttachments"><strong>Event Attachments</strong></label>
                         <table>
                             {% for key, value in filepaths.items() %}
-                                {% set idx = key.index("/") %}
-                                {% set fileName = key[idx+1:] %}
+                                {% if "/" in key %}
+                                    {% set idx = key.index("/") %}
+                                    {% set fileName = key[idx+1:] %}
+                                {% else %}
+                                    {% set fileName = key %}
+                                {% endif %} 
                                 <tr id="attachment_{{value[1]}}" class="attachmentRow_{{key}}" data-id= "{{key}}">
                                     <td class="pr-5">
                                         {% set shortName = fileName[:8] + "..." + fileName[-10:] if fileName|length > 25 else fileName %}


### PR DESCRIPTION
Fixes #1539 
- Currently the test data causes a server error when viewing Event 1: http://localhost:8080/event/1/view and Event 2: http://localhost:8080/event/2/view

## Changes

-  Added jinja conditional statement which implements a safer way to extract the filename

## Testing

- Open the CELTS website and click on 'Events List'
- At the top, choose Spring 2021 from the drop down menu for Term. 
- Then, click on Trainings and then you will be able to see the Event name ' Empty Bowls Spring Event 1'
- Click on the event and then it show work properly now. 

***BEFORE***

![image](https://github.com/user-attachments/assets/e89b5523-391c-4467-ba49-62946f92897d)


***AFTER***

![image](https://github.com/user-attachments/assets/3f39f76f-ebda-4792-8a1f-83ef2e03c5ee)
