### PR TITLE
Editing toasts flashes #1385

### DIFF
--- a/app/static/js/base.js
+++ b/app/static/js/base.js
@@ -6,7 +6,17 @@ function flashMessageResponse(message) {
   return '';
 }
 
-function msgFlash(flashMessage, status, timeout=2500){
+function msgFlash(flashMessage, status, timeout=2500, afterReload=false) {
+    if (afterReload) {
+      // Save message to sessionStorage for next page load
+      sessionStorage.setItem('flashMessage', JSON.stringify({
+          message: flashMessage,
+          type: status,
+          timeout: timeout
+      }));
+      return;
+    }
+
     if (!["success", "warning", "info", "danger"].includes(status)) status = "danger";
     $("#flash_container").prepend(`
       <div class="alert alert-${status} alert-dismissible alert-success" role="alert">${flashMessage}

--- a/app/static/js/base.js
+++ b/app/static/js/base.js
@@ -6,6 +6,20 @@ function flashMessageResponse(message) {
   return '';
 }
 
+function enableLiveCustomValidityClearing(selectors) {
+  selectors.forEach(selector => {
+    $(selector).each(function () {
+      // Avoid rebinding listeners on already-bound elements
+      if (!$(this).data("has-clearing-listener")) {
+        $(this).on("input", function () {
+          this.setCustomValidity("");
+        });
+        $(this).data("has-clearing-listener", true); // flag it
+      }
+    });
+  });
+}
+
 function msgFlash(flashMessage, status, timeout=2500, afterReload=false) {
     if (afterReload) {
       // Save message to sessionStorage for next page load

--- a/app/static/js/base.js
+++ b/app/static/js/base.js
@@ -42,6 +42,10 @@ function msgToast(head, body){
   $("#toast-header").html(head)
   $("#toast-body").html(body)
   toastList[0].show()
+
+  setTimeout(() => {
+    toastList[0].hide();
+  }, 3000);
 }
 
 function setupPhoneNumber(editButtonId, phoneInput){

--- a/app/static/js/base.js
+++ b/app/static/js/base.js
@@ -6,7 +6,7 @@ function flashMessageResponse(message) {
   return '';
 }
 
-function msgFlash(flashMessage, status, timeout=null){
+function msgFlash(flashMessage, status, timeout=2500){
     if (!["success", "warning", "info", "danger"].includes(status)) status = "danger";
     $("#flash_container").prepend(`
       <div class="alert alert-${status} alert-dismissible alert-success" role="alert">${flashMessage}
@@ -114,7 +114,7 @@ function validatePhoneNumber(editButtonId, phoneInputId, username) {
             "phoneNumber":phoneInput.val()},
       success: function(s){
         $(phoneInputId).attr("data-value",phoneInput.val())
-        msgToast("Phone Number", "Successfully updated the phone number.")
+        msgFlash("Successfully updated the phone number.","success" )
       },
       error: function(request, status, error) {
         msgFlash("Phone number not updated.", "danger")

--- a/app/static/js/base.js
+++ b/app/static/js/base.js
@@ -34,7 +34,7 @@ $(document).ready(function() {
 
 });
 
-function msgToast(head, body){
+function msgToast(head, body, duration=3000){
   if ($("#liveToast").is(":visible") == true){
     $('#liveToast').removeClass("show")
     $('#liveToast').addClass("hide")
@@ -45,7 +45,7 @@ function msgToast(head, body){
 
   setTimeout(() => {
     toastList[0].hide();
-  }, 3000);
+  }, duration);
 }
 
 function setupPhoneNumber(editButtonId, phoneInput){

--- a/app/static/js/base.js
+++ b/app/static/js/base.js
@@ -17,6 +17,19 @@ function msgFlash(flashMessage, status, timeout=2500, afterReload=false) {
       return;
     }
 
+    if (!flashMessage || !status) {
+      const storedMessage = sessionStorage.getItem('flashMessage');
+      if (storedMessage) {
+        const messageData = JSON.parse(storedMessage);
+        flashMessage = messageData.message;
+        status = messageData.type;
+        timeout = messageData.timeout ?? 2500;
+        sessionStorage.removeItem('flashMessage');
+      } else {
+        return; // Nothing to show
+      }
+    }
+
     if (!["success", "warning", "info", "danger"].includes(status)) status = "danger";
     $("#flash_container").prepend(`
       <div class="alert alert-${status} alert-dismissible alert-success" role="alert">${flashMessage}

--- a/app/static/js/bonnerManagement.js
+++ b/app/static/js/bonnerManagement.js
@@ -76,9 +76,7 @@ $(document).ready(function(){
         } else {
             fileName = `Bonner Spreadsheet, ${Number(startingYear) - Number(noOfYears)} - ${startingYear}`;
         }
-        // const fileName = noOfYears === "all" 
-        //     ? "Bonner Spreadsheet, All Cohorts" 
-        //     : `Bonner Spreadsheet, ${Number(startingYear) - Number(noOfYears) + 1} - ${Number(startingYear) + 1}`
+
         $.ajax({
             url: url,
             method: "GET",

--- a/app/static/js/bonnerManagement.js
+++ b/app/static/js/bonnerManagement.js
@@ -183,10 +183,10 @@ function saveRequirements() {
                     row.data('id', id);
                 }
             });
-            msgToast("Bonner", "Updated Bonner Requirements");
+            msgFlash("Updated Bonner Requirements","success");
         },
         error: function(e) {
-            msgToast("Error", "Error Saving Requirements");
+            msgFlash("Error Saving Requirements","danger");
         }
     });
 }
@@ -249,6 +249,7 @@ function addRequirementsRowHandlers() {
         // Only remove if it isn't the last row
         if($("#requirements tbody tr").length > 1) {
             $(e.target.closest('tr')).fadeOut(function() { this.remove() });
+            msgFlash("Succsessful deletion of Bonner Requierment", "success")
         }
     });
 }

--- a/app/static/js/bonnerManagement.js
+++ b/app/static/js/bonnerManagement.js
@@ -76,6 +76,9 @@ $(document).ready(function(){
         } else {
             fileName = `Bonner Spreadsheet, ${Number(startingYear) - Number(noOfYears)} - ${startingYear}`;
         }
+        // const fileName = noOfYears === "all" 
+        //     ? "Bonner Spreadsheet, All Cohorts" 
+        //     : `Bonner Spreadsheet, ${Number(startingYear) - Number(noOfYears) + 1} - ${Number(startingYear) + 1}`
         $.ajax({
             url: url,
             method: "GET",
@@ -183,10 +186,10 @@ function saveRequirements() {
                     row.data('id', id);
                 }
             });
-            msgFlash("Updated Bonner Requirements","success");
+            msgToast("Bonner", "Updated Bonner Requirements");
         },
         error: function(e) {
-            msgFlash("Error Saving Requirements","danger");
+            msgToast("Error", "Error Saving Requirements");
         }
     });
 }
@@ -249,7 +252,6 @@ function addRequirementsRowHandlers() {
         // Only remove if it isn't the last row
         if($("#requirements tbody tr").length > 1) {
             $(e.target.closest('tr')).fadeOut(function() { this.remove() });
-            msgFlash("Succsessful deletion of Bonner Requierment", "success")
         }
     });
 }

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -179,7 +179,7 @@ $('#saveSeries').on('click', function(e) {
   let startDateInput = $("#repeatingEventsStartDate");
   let endDateInput = $("#repeatingEventsEndDate");
   
-  let hasErrors = false; // Single flag to track all validation errors
+  let hasErrors = false; 
   
   // Validate repeating events fields first if it's a repeating event
   if (isRepeatingStatus) {
@@ -203,7 +203,6 @@ $('#saveSeries').on('click', function(e) {
     
   } else {
     // Validate individual event offerings for non-repeating events
-    
     // Check event name fields
     eventNameInputs.each((index, eventNameInput) => {
       if (eventNameInput.value.trim() === '') {
@@ -253,8 +252,6 @@ $('#saveSeries').on('click', function(e) {
       displayNotification("Event end time must be after start time");
     }
 
-      
-
     // Check for duplicate event offerings
     let eventListings = {};
     for(let i = 0; i < eventOfferings.length; i++){
@@ -272,7 +269,6 @@ $('#saveSeries').on('click', function(e) {
       }
     }
   }
-
 
   // Only proceed if there are no validation errors
   if (!hasErrors) {
@@ -351,9 +347,6 @@ function saveOfferingsFromModal() {
   $("#seriesData").val(offeringsJson);
 }
 
-
-
-
 function loadOfferingsToModal(){
   let offerings = JSON.parse($("#seriesData").val())
   if (offerings.length < 1) {return;}
@@ -368,6 +361,7 @@ function loadOfferingsToModal(){
       newOfferingModalRow.css('background-color', i % 2 ?'#f2f2f2':'#fff');
     }})
 }
+
 
 function loadRepeatingOfferingToModal(offering){
   var seriesTable = $("#generatedEventsTable");
@@ -426,6 +420,8 @@ function enableLiveCustomValidityClearing() {
     });
   });
 }
+
+
 function checkValidation(seriesEvent){
   let trainingStatus = $("#checkIsTraining").is(":checked")
   let serviceHourStatus = $("#checkServiceHours").is(":checked")
@@ -538,7 +534,6 @@ function checkValidation(seriesEvent){
     }
   } 
   }
-
 
 /*
  * Run when the webpage is ready for javascript

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -152,7 +152,7 @@ function verifyRepeatingFields(){
   // verifies all fields in the repeating table are not empty.
   let repeatingFields = $(".repeatingEventsField");
   let isEmpty = false;
- enableLiveCustomValidityClearing();
+ enableLiveCustomValidityClearing([".repeatingEventsField"]);
 
   repeatingFields.each(function() {
     let value = $(this).val();
@@ -169,7 +169,7 @@ function verifyRepeatingFields(){
 
 $('#saveSeries').on('click', function(e) {
   e.preventDefault(); // Prevent default form submission at the start
-  enableLiveCustomValidityClearing()
+  enableLiveCustomValidityClearing([".multipleOfferingNameField"])
   let eventOfferings = $('#multipleOfferingSlots .eventOffering');
   let eventNameInputs = $('#multipleOfferingSlots .multipleOfferingNameField');
   let datePickerInputs = $('#multipleOfferingSlots .multipleOfferingDatePicker');
@@ -406,22 +406,6 @@ function formatDate(originalDate) {
   return month + " " + day + ", " + year;
 }
 
-function enableLiveCustomValidityClearing() {
-  const allSelectors = [".all", ".series", ".seriesWeekly", ".main", ".allV", ".repeatingEventsField", ".multipleOfferingNameField"];
-//Created the 
-  allSelectors.forEach(selector => {
-    $(selector).each(function () {
-      // Avoid rebinding listeners on already-bound elements
-      if (!$(this).data("has-clearing-listener")) {
-        $(this).on("input", function () {
-          this.setCustomValidity("");
-        });
-        $(this).data("has-clearing-listener", true); // flag it
-      }
-    });
-  });
-}
-
 function validateFieldGroup(selector, allFieldFilled, message="Please fill out the required field") {
   let isValid = allFieldFilled;
   
@@ -471,7 +455,7 @@ function checkValidation() {
   let seriesWeeklyId = $("#checkIsRepeating").is(":checked");
   let isAllVolunteer = $("#pageTitle").text() == 'Create All Volunteer Training';
   
-  enableLiveCustomValidityClearing();
+  enableLiveCustomValidityClearing([".all", ".series", ".seriesWeekly", ".main", ".allV"]);
 
   // Always validate common fields (.all class)
   allFieldFilled = validateFieldGroup(".all", allFieldFilled);

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -706,7 +706,7 @@ $(document).ready(function() {
     }, 500, function() {
         // After the animation completes, remove the row
         attachedRow.remove();
-        msgToast("Deletion info", "You have successfully deleted a serie of event")
+        msgToast("Deletion info", "You have successfully deleted a series of events")
     });
   });
   

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -408,12 +408,12 @@ function checkValidation(seriesEvent){
   // .all is a class that groups the required filled present in all tempplate (event location and description)
    $(".all").each(function(){
     if (!$(this).is(":visible") || $(this).is(":disabled")) return; //check for hidden fields and skip them
-    if ($(this).val() === ""){ 
+    if ($(this).val().trim () === ""){  //if empty excluding spaces
       this.setCustomValidity("Please fill out the required field"); // do these actions
       this.reportValidity();
       allFieldFilled = false;
     } else {
-       this.setCustomValidity(""); 
+       this.setCustomValidity(""); //clears the custom validity 
        } 
    });
   
@@ -428,12 +428,12 @@ function checkValidation(seriesEvent){
         return; // Skip these, they'll be validated separately
       }
 
-      if ($(this).val() === ""){
+      if ($(this).val().trim() === ""){// if value is empty even if there are spaces 
         this.setCustomValidity("Please fill out the required field"); 
         this.reportValidity();
         allFieldFilled = false;
       } else {
-        this.setCustomValidity(""); 
+        this.setCustomValidity(""); // clears validity
         }
     });
   
@@ -450,17 +450,17 @@ function checkValidation(seriesEvent){
             });
         }   
         if (!(trainingStatus || serviceHourStatus || engagementStatus || bonnersStatus)) {
-              $("#checkEngagement")[0].setCustomValidity("Please select at least one of the event options.");
+              $("#checkEngagement")[0].setCustomValidity("Please select at least one of the event options."); // on the check engagement element show the custom validity tag 
               $("#checkEngagement")[0].reportValidity();
               allFieldFilled = false;
             } else {
               $("#checkEngagement")[0].setCustomValidity("");
           }
       } 
-      else if (isAllVolunteer) {
+      else if (isAllVolunteer) {// this checks if we are on the all volunteer page 
       $(".allV").each(function(){
         if (!$(this).is(":visible") || $(this).is(":disabled")) return;
-            if ($(this).val() === ""){
+            if ($(this).val().trim() === ""){// checks if object is empty inludeing it can not handel spaces 
               this.setCustomValidity("Please fill out the required field"); // do these actions
               this.reportValidity();
               allFieldFilled = false;
@@ -478,7 +478,7 @@ function checkValidation(seriesEvent){
           elementId === "checkEngagement" || elementId === "checkBonners") {
         return; // Skip these, they'll be validated separately
   }
-    if ($(this).val() === ""){
+    if ($(this).val().trim() === ""){// checks if object is empty inludeing it can not handel spaces 
       this.setCustomValidity("Please fill out the required field"); 
       this.reportValidity();
       allFieldFilled = false;
@@ -498,7 +498,8 @@ function checkValidation(seriesEvent){
   
   if (allFieldFilled) {
     // Try multiple submission methods
-    const form = document.getElementById("saveEvent");
+   // const form = document.getElementById("saveEvent");
+    const form = $("#SaveEvent")
     if (form) {
       // Try triggering submit event instead of direct submission
       $(form).trigger('submit');

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -394,38 +394,31 @@ function checkValidation(seriesEvent){
   let seriesWeeklyId = $("#checkIsRepeating").is(":checked")
   let isAllVolunteer = $("#pageTitle").text() == 'Create All Volunteer Training'
 
-  
-  //let seriesSuffix = ""; 
-
+  // .all is a class that groups the required filled present in all tempplate (event location and description)
    $(".all").each(function(){
-
-    if (!$(this).is(":visible") || $(this).is(":disabled")) return;
-    
-    if ($(this).val() === ""){
+    if (!$(this).is(":visible") || $(this).is(":disabled")) return; //check for hidden fields and skip them
+    if ($(this).val() === ""){ 
       this.setCustomValidity("Please fill out the required field"); // do these actions
       this.reportValidity();
       allFieldFilled = false;
     } else {
        this.setCustomValidity(""); 
        } 
-   console.log("|||"+ $(this).val()+"|||" + $(this).prop("id")) //TESTING PURPOSE
    });
   
-   console.log($("#checkEngagement").is(":checked"));
   if (seriesEvent) {   
+    // .series is a class that groups the required filled present when the  series event toggle is toggled (event start date, end date and name)
       $(".series").each(function(){
-
       if (!$(this).is(":visible") || $(this).is(":disabled")) return;
             // Skip event type checkboxes from regular validation
       let elementId = $(this).prop("id");
-      if (elementId === "checkIsTraining" || elementId === "checkServiceHours" || 
+      if (elementId === "checkIsTraining" || elementId === "checkServiceHours" || //checking if any of the toggles are toggled
           elementId === "checkEngagement" || elementId === "checkBonners") {
         return; // Skip these, they'll be validated separately
       }
 
-      console.log("|||"+ $(this).val()+"|||" + $(this).prop("id")) 
       if ($(this).val() === ""){
-        this.setCustomValidity("Please fill out the required field"); // do these actions
+        this.setCustomValidity("Please fill out the required field"); 
         this.reportValidity();
         allFieldFilled = false;
       } else {
@@ -435,9 +428,7 @@ function checkValidation(seriesEvent){
   
         if (seriesWeeklyId) {
             $(".seriesWeekly").each(function(){
-              if (!$(this).is(":visible") || $(this).is(":disabled")) return;
-
-           
+            if (!$(this).is(":visible") || $(this).is(":disabled")) return;
             if ($(this).val() === ""){
               this.setCustomValidity("Please fill out the required field"); // do these actions
               this.reportValidity();
@@ -445,21 +436,18 @@ function checkValidation(seriesEvent){
             } else {
               this.setCustomValidity(""); 
               }
-            
             });
         }   
         if (!(trainingStatus || serviceHourStatus || engagementStatus || bonnersStatus)) {
               document.getElementById("checkEngagement").setCustomValidity("Please select at least one of the event options.");
               document.getElementById("checkEngagement").reportValidity();
               allFieldFilled = false;
-              console.log("No event type selected");
             } else {
               document.getElementById("checkEngagement").setCustomValidity("");
           }
       } 
       else if (isAllVolunteer) {
       $(".allV").each(function(){
-
         if (!$(this).is(":visible") || $(this).is(":disabled")) return;
             if ($(this).val() === ""){
               this.setCustomValidity("Please fill out the required field"); // do these actions
@@ -468,20 +456,19 @@ function checkValidation(seriesEvent){
             } else {
               this.setCustomValidity(""); 
               }
-              });
-
-  
-  } else {
-
+              }); 
+  } 
+  else {
+    // .main is a class that groups the required filled present in similar template
     $(".main").each(function(){
-      if (!$(this).is(":visible") || $(this).is(":disabled")) return;
+  if (!$(this).is(":visible") || $(this).is(":disabled")) return;
     let elementId = $(this).prop("id");
     if (elementId === "checkIsTraining" || elementId === "checkServiceHours" || 
           elementId === "checkEngagement" || elementId === "checkBonners") {
         return; // Skip these, they'll be validated separately
   }
     if ($(this).val() === ""){
-      this.setCustomValidity("Please fill out the required field"); // do these actions
+      this.setCustomValidity("Please fill out the required field"); 
       this.reportValidity();
       allFieldFilled = false;
     } else {
@@ -497,29 +484,17 @@ function checkValidation(seriesEvent){
       document.getElementById("checkEngagement").setCustomValidity("");
     }
   }
-
-  console.log("Final allFieldFilled status:", allFieldFilled);
   
   if (allFieldFilled) {
-    //  console.log("All validation passed - submitting form");//TESTING PURPOSE
-    //   $("#saveEvent").submit();     
-    // }
-        // FIX 5: Removed problematic $(this) reference - was outside loop context
-    console.log("All validation passed - submitting form");
-    
     // Try multiple submission methods
     const form = document.getElementById("saveEvent");
     if (form) {
-      console.log("Form found, attempting submission");
       // Try triggering submit event instead of direct submission
       $(form).trigger('submit');
     } else {
-      console.log("Form not found, trying jQuery method");
       $("#saveEvent").trigger('submit');
     }
-  } else {
-    console.log("Validation failed - form NOT submitted");
-  }
+  } 
   }
 
 
@@ -579,15 +554,13 @@ $(document).ready(function() {
     typeBoxes.not($(event.target)).prop('checked', false);
   });
 
+
+  // When Save buttton is clicked, check if required are filled and then submit
   $("#saveButton").on('click', function (event) {
     event.preventDefault(); //prevents from submitting
-  
   //check if Series of events is checked or no and calls the function checkValidation()
   let seriesEvents = $("#checkIsSeries").is(":checked");
-  console.log(seriesEvents);
-  
   checkValidation(seriesEvents);
-
 });
   
   updateOfferingsTable();

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -530,27 +530,6 @@ $(document).ready(function() {
       minDate = null;
   }
 
-  // // Initialize datepicker with proper options
-  // $.datepicker.setDefaults({
-  //   dateFormat: 'yy/mm/dd', // Ensures compatibility across browsers
-  //   minDate: minDate
-  // });
-
-  // $(".datePicker").datepicker({
-  //   dateFormat: 'mm/dd/yy',
-  //   minDate: minDate
-  // });
-
-  // $(".datePicker").each(function(idx, el) {
-  //   var dateStr = $(el).val();
-  //   if (dateStr) {
-  //     var dateObj = new Date(dateStr);
-  //     if (!isNaN(dateObj.getTime())) {
-  //       $(el).datepicker("setDate", dateObj);
-  //     }
-  //   }
-  // });
-
   handleFileSelection("attachmentObject")
 
   $("#checkRSVP").on("click", function () {

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -421,119 +421,205 @@ function enableLiveCustomValidityClearing() {
   });
 }
 
+function validateFieldGroup(selector, allFieldFilled, message="Please fill out the required field") {
+  let isValid = allFieldFilled;
+  
+  $(selector).each(function() {
+    // Skip hidden or disabled fields
+    if (!$(this).is(":visible") || $(this).is(":disabled")) return;
+    
+    // Skip event type checkboxes from regular validation
+    let elementId = $(this).prop("id");
+    if (elementId === "checkIsTraining" || elementId === "checkServiceHours" || 
+        elementId === "checkEngagement" || elementId === "checkBonners") {
+      return;
+    }
 
-function checkValidation(seriesEvent){
-  let trainingStatus = $("#checkIsTraining").is(":checked")
-  let serviceHourStatus = $("#checkServiceHours").is(":checked")
-  let engagementStatus = $("#checkEngagement").is(":checked")
-  let bonnersStatus = $("#checkBonners").is(":checked")
-  let allFieldFilled = true; //if there is text = true]
-  let seriesWeeklyId = $("#checkIsRepeating").is(":checked")
-  let isAllVolunteer = $("#pageTitle").text() == 'Create All Volunteer Training'
+    // Check if field is empty (excluding spaces)
+    if ($(this).val().trim() === "") {
+      this.setCustomValidity(message);
+      this.reportValidity();
+      isValid = false;
+    } else {
+      this.setCustomValidity("");
+    }
+  });
+  
+  return isValid;
+}
+
+function validateEventTypeCheckboxes(message="Please select at least one of the event options.") {
+  let trainingStatus = $("#checkIsTraining").is(":checked");
+  let serviceHourStatus = $("#checkServiceHours").is(":checked");
+  let engagementStatus = $("#checkEngagement").is(":checked");
+  let bonnersStatus = $("#checkBonners").is(":checked");
+  
+  if (!(trainingStatus || serviceHourStatus || engagementStatus || bonnersStatus)) {
+    $("#checkEngagement")[0].setCustomValidity(message);
+    $("#checkEngagement")[0].reportValidity();
+    return false;
+  } else {
+    $("#checkEngagement")[0].setCustomValidity("");
+    return true;
+  }
+}
+
+function checkValidation() {
+  let allFieldFilled = true;
+  let seriesEvent = $("#checkIsSeries").is(":checked");
+  let seriesWeeklyId = $("#checkIsRepeating").is(":checked");
+  let isAllVolunteer = $("#pageTitle").text() == 'Create All Volunteer Training';
   
   enableLiveCustomValidityClearing();
 
-  // .all is a class that groups the required filled present in all tempplate (event location and description)
-   $(".all").each(function(){
-    if (!$(this).is(":visible") || $(this).is(":disabled")) return; //check for hidden fields and skip them
-    if ($(this).val().trim () === ""){  //if empty excluding spaces
-      this.setCustomValidity("Please fill out the required field"); // do these actions
-      this.reportValidity();
-      allFieldFilled = false;
-    } else {
-       this.setCustomValidity(""); //clears the custom validity 
-       } 
-   });
+  // Always validate common fields (.all class)
+  allFieldFilled = validateFieldGroup(".all", allFieldFilled);
   
-  if (seriesEvent) {   
-    // .series is a class that groups the required filled present when the  series event toggle is toggled (event start date, end date and name)
-      $(".series").each(function(){
-      if (!$(this).is(":visible") || $(this).is(":disabled")) return;
-            // Skip event type checkboxes from regular validation
-      let elementId = $(this).prop("id");
-      if (elementId === "checkIsTraining" || elementId === "checkServiceHours" || //checking if any of the toggles are toggled
-          elementId === "checkEngagement" || elementId === "checkBonners") {
-        return; // Skip these, they'll be validated separately
-      }
-
-      if ($(this).val().trim() === ""){// if value is empty even if there are spaces 
-        this.setCustomValidity("Please fill out the required field"); 
-        this.reportValidity();
-        allFieldFilled = false;
-      } else {
-        this.setCustomValidity(""); // clears validity
-        }
-    });
-  
-        if (seriesWeeklyId) {
-            $(".seriesWeekly").each(function(){
-            if (!$(this).is(":visible") || $(this).is(":disabled")) return;
-            if ($(this).val() === ""){
-              this.setCustomValidity("Please fill out the required field"); // do these actions
-              this.reportValidity();
-              allFieldFilled = false;
-            } else {
-              this.setCustomValidity(""); 
-              }
-            });
-        }   
-        if (!(trainingStatus || serviceHourStatus || engagementStatus || bonnersStatus)) {
-              $("#checkEngagement")[0].setCustomValidity("Please select at least one of the event options."); // on the check engagement element show the custom validity tag 
-              $("#checkEngagement")[0].reportValidity();
-              allFieldFilled = false;
-            } else {
-              $("#checkEngagement")[0].setCustomValidity("");
-          }
-      } 
-      else if (isAllVolunteer) {// this checks if we are on the all volunteer page 
-      $(".allV").each(function(){
-        if (!$(this).is(":visible") || $(this).is(":disabled")) return;
-            if ($(this).val().trim() === ""){// checks if object is empty inludeing it can not handel spaces 
-              this.setCustomValidity("Please fill out the required field"); // do these actions
-              this.reportValidity();
-              allFieldFilled = false;
-            } else {
-              this.setCustomValidity(""); 
-              }
-              }); 
-  } 
-  else {
-    // .main is a class that groups the required filled present in similar template
-    $(".main").each(function(){
-  if (!$(this).is(":visible") || $(this).is(":disabled")) return;
-    let elementId = $(this).prop("id");
-    if (elementId === "checkIsTraining" || elementId === "checkServiceHours" || 
-          elementId === "checkEngagement" || elementId === "checkBonners") {
-        return; // Skip these, they'll be validated separately
-  }
-    if ($(this).val().trim() === ""){// checks if object is empty inludeing it can not handel spaces 
-      this.setCustomValidity("Please fill out the required field"); 
-      this.reportValidity();
-      allFieldFilled = false;
-    } else {
-       this.setCustomValidity(""); 
-       }
-  });
-
-  if (!(trainingStatus || serviceHourStatus || engagementStatus || bonnersStatus)) {
-      $("#checkEngagement")[0].setCustomValidity("Please select at least one of the event options.");
-      $("#checkEngagement")[0].reportValidity();
-      allFieldFilled = false;
-    } else {
-        $("#checkEngagement")[0].setCustomValidity("");
-          }
-      } 
-  
-  if (allFieldFilled) {
-    const form = $("#saveEvent")
-    if (form) {
-      // Try triggering submit event instead of direct submission
-      $(form).trigger('submit');
-    } else {
-      $("#saveEvent").trigger('submit');
+  if (seriesEvent) {
+    // Validate series-specific fields
+    allFieldFilled = validateFieldGroup(".series", allFieldFilled);
+    
+    // Validate series weekly fields if needed
+    if (seriesWeeklyId) {
+      allFieldFilled = validateFieldGroup(".seriesWeekly", allFieldFilled);
     }
-  } 
+    
+    // Validate event type checkboxes
+    allFieldFilled = validateEventTypeCheckboxes() && allFieldFilled;
+    
+  } else if (isAllVolunteer) {
+    // Validate all volunteer specific fields
+    allFieldFilled = validateFieldGroup(".allV", allFieldFilled);
+    
+  } else {
+    // Validate main template fields
+    allFieldFilled = validateFieldGroup(".main", allFieldFilled);
+    
+    // Validate event type checkboxes
+    allFieldFilled = validateEventTypeCheckboxes() && allFieldFilled;
   }
+  
+  // Submit form if all fields are valid
+  if (allFieldFilled) {
+    const form = $("#saveEvent");
+    if (form.length) {
+      form.trigger('submit');
+    }
+  }
+}
+
+// function checkValidation(seriesEvent){
+//   let trainingStatus = $("#checkIsTraining").is(":checked")
+//   let serviceHourStatus = $("#checkServiceHours").is(":checked")
+//   let engagementStatus = $("#checkEngagement").is(":checked")
+//   let bonnersStatus = $("#checkBonners").is(":checked")
+//   let allFieldFilled = true; //if there is text = true]
+//   let seriesWeeklyId = $("#checkIsRepeating").is(":checked")
+//   let isAllVolunteer = $("#pageTitle").text() == 'Create All Volunteer Training'
+  
+//   enableLiveCustomValidityClearing();
+
+//   // .all is a class that groups the required filled present in all tempplate (event location and description)
+//    $(".all").each(function(){
+//     if (!$(this).is(":visible") || $(this).is(":disabled")) return; //check for hidden fields and skip them
+//     if ($(this).val().trim () === ""){  //if empty excluding spaces
+//       this.setCustomValidity("Please fill out the required field"); // do these actions
+//       this.reportValidity();
+//       allFieldFilled = false;
+//     } else {
+//        this.setCustomValidity(""); //clears the custom validity 
+//        } 
+//    });
+  
+//   if (seriesEvent) {   
+//     // .series is a class that groups the required filled present when the  series event toggle is toggled (event start date, end date and name)
+//       $(".series").each(function(){
+//       if (!$(this).is(":visible") || $(this).is(":disabled")) return;
+//             // Skip event type checkboxes from regular validation
+//       let elementId = $(this).prop("id");
+//       if (elementId === "checkIsTraining" || elementId === "checkServiceHours" || //checking if any of the toggles are toggled
+//           elementId === "checkEngagement" || elementId === "checkBonners") {
+//         return; // Skip these, they'll be validated separately
+//       }
+
+//       if ($(this).val().trim() === ""){// if value is empty even if there are spaces 
+//         this.setCustomValidity("Please fill out the required field"); 
+//         this.reportValidity();
+//         allFieldFilled = false;
+//       } else {
+//         this.setCustomValidity(""); // clears validity
+//         }
+//       });
+  
+//         if (seriesWeeklyId) {
+//             $(".seriesWeekly").each(function(){
+//             if (!$(this).is(":visible") || $(this).is(":disabled")) return;
+//             if ($(this).val() === ""){
+//               this.setCustomValidity("Please fill out the required field"); // do these actions
+//               this.reportValidity();
+//               allFieldFilled = false;
+//             } else {
+//               this.setCustomValidity(""); 
+//               }
+//             });
+//         }   
+//         if (!(trainingStatus || serviceHourStatus || engagementStatus || bonnersStatus)) {
+//               $("#checkEngagement")[0].setCustomValidity("Please select at least one of the event options."); // on the check engagement element show the custom validity tag 
+//               $("#checkEngagement")[0].reportValidity();
+//               allFieldFilled = false;
+//             } else {
+//               $("#checkEngagement")[0].setCustomValidity("");
+//           }
+//       } 
+//       else if (isAllVolunteer) {// this checks if we are on the all volunteer page 
+//       $(".allV").each(function(){
+//         if (!$(this).is(":visible") || $(this).is(":disabled")) return;
+//             if ($(this).val().trim() === ""){// checks if object is empty inludeing it can not handel spaces 
+//               this.setCustomValidity("Please fill out the required field"); // do these actions
+//               this.reportValidity();
+//               allFieldFilled = false;
+//             } else {
+//               this.setCustomValidity(""); 
+//               }
+//               }); 
+//   } 
+//   else {
+//     // .main is a class that groups the required filled present in similar template
+//     $(".main").each(function(){
+//   if (!$(this).is(":visible") || $(this).is(":disabled")) return;
+//     let elementId = $(this).prop("id");
+//     if (elementId === "checkIsTraining" || elementId === "checkServiceHours" || 
+//           elementId === "checkEngagement" || elementId === "checkBonners") {
+//         return; // Skip these, they'll be validated separately
+//   }
+//     if ($(this).val().trim() === ""){// checks if object is empty inludeing it can not handel spaces 
+//       this.setCustomValidity("Please fill out the required field"); 
+//       this.reportValidity();
+//       allFieldFilled = false;
+//     } else {
+//        this.setCustomValidity(""); 
+//        }
+//   });
+
+//   if (!(trainingStatus || serviceHourStatus || engagementStatus || bonnersStatus)) {
+//       $("#checkEngagement")[0].setCustomValidity("Please select at least one of the event options.");
+//       $("#checkEngagement")[0].reportValidity();
+//       allFieldFilled = false;
+//     } else {
+//         $("#checkEngagement")[0].setCustomValidity("");
+//           }
+//       } 
+  
+//   if (allFieldFilled) {
+//     const form = $("#saveEvent")
+//     if (form) {
+//       // Try triggering submit event instead of direct submission
+//       $(form).trigger('submit');
+//     } else {
+//       $("#saveEvent").trigger('submit');
+//     }
+//   } 
+//   }
 
 /*
  * Run when the webpage is ready for javascript
@@ -595,9 +681,7 @@ $(document).ready(function() {
   // When Save buttton is clicked, check if required are filled and then submit
   $("#saveButton").on('click', function (event) {
     event.preventDefault(); //prevents from submitting
-  //check if Series of events is checked or no and calls the function checkValidation()
-  let seriesEvents = $("#checkIsSeries").is(":checked");
-  checkValidation(seriesEvents);
+    checkValidation();
 });
   
   updateOfferingsTable();

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -530,26 +530,26 @@ $(document).ready(function() {
       minDate = null;
   }
 
-  // Initialize datepicker with proper options
-  $.datepicker.setDefaults({
-    dateFormat: 'yy/mm/dd', // Ensures compatibility across browsers
-    minDate: minDate
-  });
+  // // Initialize datepicker with proper options
+  // $.datepicker.setDefaults({
+  //   dateFormat: 'yy/mm/dd', // Ensures compatibility across browsers
+  //   minDate: minDate
+  // });
 
-  $(".datePicker").datepicker({
-    dateFormat: 'mm/dd/yy',
-    minDate: minDate
-  });
+  // $(".datePicker").datepicker({
+  //   dateFormat: 'mm/dd/yy',
+  //   minDate: minDate
+  // });
 
-  $(".datePicker").each(function(idx, el) {
-    var dateStr = $(el).val();
-    if (dateStr) {
-      var dateObj = new Date(dateStr);
-      if (!isNaN(dateObj.getTime())) {
-        $(el).datepicker("setDate", dateObj);
-      }
-    }
-  });
+  // $(".datePicker").each(function(idx, el) {
+  //   var dateStr = $(el).val();
+  //   if (dateStr) {
+  //     var dateObj = new Date(dateStr);
+  //     if (!isNaN(dateObj.getTime())) {
+  //       $(el).datepicker("setDate", dateObj);
+  //     }
+  //   }
+  // });
 
   handleFileSelection("attachmentObject")
 

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -167,9 +167,14 @@ $('#saveSeries').on('click', function() {
   eventNameInputs.each((index, eventNameInput) => {
     if (eventNameInput.value.trim() === '') {
       isEmpty = true;
-      $(eventNameInput).addClass('border-red');
+      //$(eventNameInput).addClass('border-red');
+      $(eventNameInput)[0].setCustomValidity("Please enter a event name");
+      $(eventNameInput)[0].reportValidity();
+          allFieldFilled = false;
+
     } else {
-      $(eventNameInput).removeClass('border-red');
+      $(eventNameInput)[0].setCustomValidity("");
+      //.removeClass('border-red');
     }
   });
 
@@ -177,9 +182,12 @@ $('#saveSeries').on('click', function() {
   datePickerInputs.each((index, datePickerInput) => {
     if (datePickerInput.value.trim() === '') {
         isEmpty = true;
-        $(datePickerInput).addClass('border-red');
+        //$(datePickerInput).addClass('border-red');
+        $(datePickerInput)[0].setCustomValidity("Please enter a event name");
+        $(datePickerInput)[0].reportValidity();
     } else {
-        $(datePickerInput).removeClass('border-red');
+        $(datePickerInput)[0].setCustomValidity("");
+        //$(datePickerInput).removeClass('border-red');
     }
   });  
 
@@ -225,10 +233,13 @@ $('#saveSeries').on('click', function() {
   }
 
   if (isEmpty){
-    let emptyFieldMessage = "Event name or date field is empty";
-    displayNotification(emptyFieldMessage);
+   return;
+
+    // let emptyFieldMessage = "Event name or date field is empty";
+    // msgToast(emptyFieldMessage);
   }
-  else if (!hasValidTimes) {
+  else 
+  if (!hasValidTimes) {
     let invalidTimeMessage = "Event end time must be after start time";
     displayNotification(invalidTimeMessage);
   }
@@ -439,11 +450,11 @@ function checkValidation(seriesEvent){
             });
         }   
         if (!(trainingStatus || serviceHourStatus || engagementStatus || bonnersStatus)) {
-              document.getElementById("checkEngagement").setCustomValidity("Please select at least one of the event options.");
-              document.getElementById("checkEngagement").reportValidity();
+              $("#checkEngagement")[0].setCustomValidity("Please select at least one of the event options.");
+              $("#checkEngagement")[0].reportValidity();
               allFieldFilled = false;
             } else {
-              document.getElementById("checkEngagement").setCustomValidity("");
+              $("#checkEngagement")[0].setCustomValidity("");
           }
       } 
       else if (isAllVolunteer) {
@@ -477,13 +488,13 @@ function checkValidation(seriesEvent){
   });
 
   if (!(trainingStatus || serviceHourStatus || engagementStatus || bonnersStatus)) {
-      document.getElementById("checkEngagement").setCustomValidity("Please select at least one of the event options.");
-      document.getElementById("checkEngagement").reportValidity();
+      $("#checkEngagement")[0].setCustomValidity("Please select at least one of the event options.");
+      $("#checkEngagement")[0].reportValidity();
       allFieldFilled = false;
     } else {
-      document.getElementById("checkEngagement").setCustomValidity("");
-    }
-  }
+        $("#checkEngagement")[0].setCustomValidity("");
+          }
+      } 
   
   if (allFieldFilled) {
     // Try multiple submission methods

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -415,22 +415,33 @@ $(document).ready(function() {
     typeBoxes.not($(event.target)).prop('checked', false);
   });
 
-  $("#saveEvent").on('submit', function (event) {
+  $("#saveButton").on('click', function (event) {
+    event.preventDefault();
     let trainingStatus = $("#checkIsTraining").is(":checked")
     let serviceHourStatus = $("#checkServiceHours").is(":checked")
     let engagementStatus = $("#checkEngagement").is(":checked")
     let bonnersStatus = $("#checkBonners").is(":checked")
+console.log(trainingStatus, serviceHourStatus, engagementStatus, bonnersStatus)
+    document.getElementById("checkEngagement").setCustomValidity(""); // Clear custom validity
+    document.getElementById("checkEngagement").reportValidity();
+
 
     //check if user has selected a toggle, cancel form submission if not
     let isAllVolunteer = $("#pageTitle").text() == 'Create All Volunteer Training'
     if(trainingStatus || serviceHourStatus || engagementStatus || bonnersStatus || isAllVolunteer) {
+      
       // Disable button when we are ready to submit
-      $(this).find("input[type=submit]").prop("disabled", true);
+      //$(this).find("input[type=submit]").prop("disabled", true);
+      $("#saveEvent").submit();
     }
     else {
-      msgFlash("You must indicate whether the event is a training, is an engagement, earns service hours, or is a Bonners Scholars event!", "danger");
-      event.preventDefault();
+      
+      // jquery does was not supporting Java 
+      document.getElementById("checkEngagement").setCustomValidity("Please select one of the three events")
+      document.getElementById("checkEngagement").reportValidity();
+     
     } 
+
   });
 
   updateOfferingsTable();

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -359,6 +359,140 @@ function formatDate(originalDate) {
   var year = dateObj.getUTCFullYear();
   return month + " " + day + ", " + year;
 }
+
+function checkValidation(seriesEvent){
+  let trainingStatus = $("#checkIsTraining").is(":checked")
+  let serviceHourStatus = $("#checkServiceHours").is(":checked")
+  let engagementStatus = $("#checkEngagement").is(":checked")
+  let bonnersStatus = $("#checkBonners").is(":checked")
+  let allFieldFilled = true; //if there is text = true]
+  let seriesWeeklyId = $("#checkIsRepeating").is(":checked")
+  let isAllVolunteer = $("#pageTitle").text() == 'Create All Volunteer Training'
+
+  
+  //let seriesSuffix = ""; 
+
+   $(".all").each(function(){
+    if ($(this).val() === ""){
+      this.setCustomValidity("Please fill out the required field"); // do these actions
+      this.reportValidity();
+      allFieldFilled = false;
+    } else {
+       this.setCustomValidity(""); 
+       } 
+   console.log("|||"+ $(this).val()+"|||" + $(this).prop("id")) //TESTING PURPOSE
+   });
+  
+   console.log($("#checkEngagement").is(":checked"));
+  if (seriesEvent) {
+    //   if (!(trainingStatus || serviceHourStatus || engagementStatus || bonnersStatus)){
+    //   // If none are checked, show an error message on the engagement checkbox
+    //   const engagementElement = document.getElementById("checkEngagement");
+    //   document.getElementById("checkEngagement").setCustomValidity("Please select at least one of the event options.");
+    //   engagementElement.focus(); 
+    //   document.getElementById("checkEngagement").reportValidity();
+    //   allFieldFilled = false;
+    //   console.log("No event type selected");
+    // } else {
+    //   // Clear any existing validation message
+    //   document.getElementById("checkEngagement").setCustomValidity("");
+    // }
+      
+    //let seriesSuffix = "-modal";    
+      $(".series").each(function(){
+            // Skip event type checkboxes from regular validation
+      let elementId = $(this).prop("id");
+      if (elementId === "checkIsTraining" || elementId === "checkServiceHours" || 
+          elementId === "checkEngagement" || elementId === "checkBonners") {
+        return; // Skip these, they'll be validated separately
+      }
+
+      console.log("|||"+ $(this).val()+"|||" + $(this).prop("id")) 
+      if ($(this).val() === ""){
+        this.setCustomValidity("Please fill out the required field"); // do these actions
+        this.reportValidity();
+        allFieldFilled = false;
+      } else {
+        this.setCustomValidity(""); 
+        }
+    });
+  
+        if (seriesWeeklyId) {
+            $(".seriesWeekly").each(function(){
+
+           
+            if ($(this).val() === ""){
+              this.setCustomValidity("Please fill out the required field"); // do these actions
+              this.reportValidity();
+              allFieldFilled = false;
+            } else {
+              this.setCustomValidity(""); 
+              }
+            
+            });
+        }   
+        if (!(trainingStatus || serviceHourStatus || engagementStatus || bonnersStatus)) {
+              document.getElementById("checkEngagement").setCustomValidity("Please select at least one of the event options.");
+              document.getElementById("checkEngagement").reportValidity();
+              allFieldFilled = false;
+              console.log("No event type selected");
+            } else {
+              document.getElementById("checkEngagement").setCustomValidity("");
+          }
+      } 
+      else if (isAllVolunteer) {
+      $(".allV").each(function(){
+            if ($(this).val() === ""){
+              this.setCustomValidity("Please fill out the required field"); // do these actions
+              this.reportValidity();
+              allFieldFilled = false;
+            } else {
+              this.setCustomValidity(""); 
+              }
+              });
+
+  
+  } else {
+    //let seriesSuffix = "-mainOnly"
+
+    $(".main").each(function(){
+    let elementId = $(this).prop("id");
+    if (elementId === "checkIsTraining" || elementId === "checkServiceHours" || 
+          elementId === "checkEngagement" || elementId === "checkBonners") {
+        return; // Skip these, they'll be validated separately
+  //   if (!(trainingStatus || serviceHourStatus || engagementStatus || bonnersStatus)) {
+  //   // If none are checked, show an error message on the engagement checkbox
+  //   document.getElementById("checkEngagement").setCustomValidity("Please select at least one of the event options.");
+  //   document.getElementById("checkEngagement").reportValidity();
+  // } else {
+  //   // Clear any existing validation message
+  //   document.getElementById("checkEngagement").setCustomValidity("");
+  }
+    if ($(this).val() === ""){
+      this.setCustomValidity("Please fill out the required field"); // do these actions
+      this.reportValidity();
+      allFieldFilled = false;
+    } else {
+       this.setCustomValidity(""); 
+       }
+  });
+
+  if (!(trainingStatus || serviceHourStatus || engagementStatus || bonnersStatus)) {
+      document.getElementById("checkEngagement").setCustomValidity("Please select at least one of the event options.");
+      document.getElementById("checkEngagement").reportValidity();
+      allFieldFilled = false;
+    } else {
+      document.getElementById("checkEngagement").setCustomValidity("");
+    }
+  }
+
+  if (allFieldFilled) {
+     console.log("All validation passed - submitting form");//TESTING PURPOSE
+      $("#saveEvent").submit();     
+    }
+  }
+
+
 /*
  * Run when the webpage is ready for javascript
  */
@@ -416,34 +550,16 @@ $(document).ready(function() {
   });
 
   $("#saveButton").on('click', function (event) {
-    event.preventDefault();
-    let trainingStatus = $("#checkIsTraining").is(":checked")
-    let serviceHourStatus = $("#checkServiceHours").is(":checked")
-    let engagementStatus = $("#checkEngagement").is(":checked")
-    let bonnersStatus = $("#checkBonners").is(":checked")
-console.log(trainingStatus, serviceHourStatus, engagementStatus, bonnersStatus)
-    document.getElementById("checkEngagement").setCustomValidity(""); // Clear custom validity
-    document.getElementById("checkEngagement").reportValidity();
+    event.preventDefault(); //prevents from submitting
+  
+  //check if Series of events is checked or no and calls the function checkValidation()
+  let seriesEvents = $("#checkIsSeries").is(":checked");
+  console.log(seriesEvents);
+  
+  checkValidation(seriesEvents);
 
-
-    //check if user has selected a toggle, cancel form submission if not
-    let isAllVolunteer = $("#pageTitle").text() == 'Create All Volunteer Training'
-    if(trainingStatus || serviceHourStatus || engagementStatus || bonnersStatus || isAllVolunteer) {
-      
-      // Disable button when we are ready to submit
-      //$(this).find("input[type=submit]").prop("disabled", true);
-      $("#saveEvent").submit();
-    }
-    else {
-      
-      // jquery does was not supporting Java 
-      document.getElementById("checkEngagement").setCustomValidity("Please select one of the three events")
-      document.getElementById("checkEngagement").reportValidity();
-     
-    } 
-
-  });
-
+});
+  
   updateOfferingsTable();
   
   if ($("#checkIsSeries").is(":checked")){
@@ -456,7 +572,7 @@ console.log(trainingStatus, serviceHourStatus, engagementStatus, bonnersStatus)
 
     if(!($('#inputEventName').val().trim() == '')){
       //keeps main page event name for multiple event modal
-      $('#eventName').val($('#inputEventName').val());
+      $('#eventName').val($('#inputEventName').val());// the input value from of page copied
     }
     let isSeries = $("#checkIsSeries").is(":checked")
     modalOpenedByEditButton = ($(this).attr('id') === 'edit_modal');
@@ -539,6 +655,7 @@ console.log(trainingStatus, serviceHourStatus, engagementStatus, bonnersStatus)
         $("#generatedEvents").addClass('d-none');
         return;
       }
+      
 
       calculateRepeatingEventFrequency();
     }
@@ -633,4 +750,5 @@ console.log(trainingStatus, serviceHourStatus, engagementStatus, bonnersStatus)
   });
 
   setCharacterLimit($("#inputCharacters"), "#remainingCharacters"); 
+  
 });

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -405,6 +405,7 @@ function formatDate(originalDate) {
   var year = dateObj.getUTCFullYear();
   return month + " " + day + ", " + year;
 }
+
 function enableLiveCustomValidityClearing() {
   const allSelectors = [".all", ".series", ".seriesWeekly", ".main", ".allV", ".repeatingEventsField", ".multipleOfferingNameField"];
 //Created the 
@@ -507,119 +508,6 @@ function checkValidation() {
     }
   }
 }
-
-// function checkValidation(seriesEvent){
-//   let trainingStatus = $("#checkIsTraining").is(":checked")
-//   let serviceHourStatus = $("#checkServiceHours").is(":checked")
-//   let engagementStatus = $("#checkEngagement").is(":checked")
-//   let bonnersStatus = $("#checkBonners").is(":checked")
-//   let allFieldFilled = true; //if there is text = true]
-//   let seriesWeeklyId = $("#checkIsRepeating").is(":checked")
-//   let isAllVolunteer = $("#pageTitle").text() == 'Create All Volunteer Training'
-  
-//   enableLiveCustomValidityClearing();
-
-//   // .all is a class that groups the required filled present in all tempplate (event location and description)
-//    $(".all").each(function(){
-//     if (!$(this).is(":visible") || $(this).is(":disabled")) return; //check for hidden fields and skip them
-//     if ($(this).val().trim () === ""){  //if empty excluding spaces
-//       this.setCustomValidity("Please fill out the required field"); // do these actions
-//       this.reportValidity();
-//       allFieldFilled = false;
-//     } else {
-//        this.setCustomValidity(""); //clears the custom validity 
-//        } 
-//    });
-  
-//   if (seriesEvent) {   
-//     // .series is a class that groups the required filled present when the  series event toggle is toggled (event start date, end date and name)
-//       $(".series").each(function(){
-//       if (!$(this).is(":visible") || $(this).is(":disabled")) return;
-//             // Skip event type checkboxes from regular validation
-//       let elementId = $(this).prop("id");
-//       if (elementId === "checkIsTraining" || elementId === "checkServiceHours" || //checking if any of the toggles are toggled
-//           elementId === "checkEngagement" || elementId === "checkBonners") {
-//         return; // Skip these, they'll be validated separately
-//       }
-
-//       if ($(this).val().trim() === ""){// if value is empty even if there are spaces 
-//         this.setCustomValidity("Please fill out the required field"); 
-//         this.reportValidity();
-//         allFieldFilled = false;
-//       } else {
-//         this.setCustomValidity(""); // clears validity
-//         }
-//       });
-  
-//         if (seriesWeeklyId) {
-//             $(".seriesWeekly").each(function(){
-//             if (!$(this).is(":visible") || $(this).is(":disabled")) return;
-//             if ($(this).val() === ""){
-//               this.setCustomValidity("Please fill out the required field"); // do these actions
-//               this.reportValidity();
-//               allFieldFilled = false;
-//             } else {
-//               this.setCustomValidity(""); 
-//               }
-//             });
-//         }   
-//         if (!(trainingStatus || serviceHourStatus || engagementStatus || bonnersStatus)) {
-//               $("#checkEngagement")[0].setCustomValidity("Please select at least one of the event options."); // on the check engagement element show the custom validity tag 
-//               $("#checkEngagement")[0].reportValidity();
-//               allFieldFilled = false;
-//             } else {
-//               $("#checkEngagement")[0].setCustomValidity("");
-//           }
-//       } 
-//       else if (isAllVolunteer) {// this checks if we are on the all volunteer page 
-//       $(".allV").each(function(){
-//         if (!$(this).is(":visible") || $(this).is(":disabled")) return;
-//             if ($(this).val().trim() === ""){// checks if object is empty inludeing it can not handel spaces 
-//               this.setCustomValidity("Please fill out the required field"); // do these actions
-//               this.reportValidity();
-//               allFieldFilled = false;
-//             } else {
-//               this.setCustomValidity(""); 
-//               }
-//               }); 
-//   } 
-//   else {
-//     // .main is a class that groups the required filled present in similar template
-//     $(".main").each(function(){
-//   if (!$(this).is(":visible") || $(this).is(":disabled")) return;
-//     let elementId = $(this).prop("id");
-//     if (elementId === "checkIsTraining" || elementId === "checkServiceHours" || 
-//           elementId === "checkEngagement" || elementId === "checkBonners") {
-//         return; // Skip these, they'll be validated separately
-//   }
-//     if ($(this).val().trim() === ""){// checks if object is empty inludeing it can not handel spaces 
-//       this.setCustomValidity("Please fill out the required field"); 
-//       this.reportValidity();
-//       allFieldFilled = false;
-//     } else {
-//        this.setCustomValidity(""); 
-//        }
-//   });
-
-//   if (!(trainingStatus || serviceHourStatus || engagementStatus || bonnersStatus)) {
-//       $("#checkEngagement")[0].setCustomValidity("Please select at least one of the event options.");
-//       $("#checkEngagement")[0].reportValidity();
-//       allFieldFilled = false;
-//     } else {
-//         $("#checkEngagement")[0].setCustomValidity("");
-//           }
-//       } 
-  
-//   if (allFieldFilled) {
-//     const form = $("#saveEvent")
-//     if (form) {
-//       // Try triggering submit event instead of direct submission
-//       $(form).trigger('submit');
-//     } else {
-//       $("#saveEvent").trigger('submit');
-//     }
-//   } 
-//   }
 
 /*
  * Run when the webpage is ready for javascript

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -373,6 +373,9 @@ function checkValidation(seriesEvent){
   //let seriesSuffix = ""; 
 
    $(".all").each(function(){
+
+    if (!$(this).is(":visible") || $(this).is(":disabled")) return;
+    
     if ($(this).val() === ""){
       this.setCustomValidity("Please fill out the required field"); // do these actions
       this.reportValidity();
@@ -384,22 +387,10 @@ function checkValidation(seriesEvent){
    });
   
    console.log($("#checkEngagement").is(":checked"));
-  if (seriesEvent) {
-    //   if (!(trainingStatus || serviceHourStatus || engagementStatus || bonnersStatus)){
-    //   // If none are checked, show an error message on the engagement checkbox
-    //   const engagementElement = document.getElementById("checkEngagement");
-    //   document.getElementById("checkEngagement").setCustomValidity("Please select at least one of the event options.");
-    //   engagementElement.focus(); 
-    //   document.getElementById("checkEngagement").reportValidity();
-    //   allFieldFilled = false;
-    //   console.log("No event type selected");
-    // } else {
-    //   // Clear any existing validation message
-    //   document.getElementById("checkEngagement").setCustomValidity("");
-    // }
-      
-    //let seriesSuffix = "-modal";    
+  if (seriesEvent) {   
       $(".series").each(function(){
+
+      if (!$(this).is(":visible") || $(this).is(":disabled")) return;
             // Skip event type checkboxes from regular validation
       let elementId = $(this).prop("id");
       if (elementId === "checkIsTraining" || elementId === "checkServiceHours" || 
@@ -419,6 +410,7 @@ function checkValidation(seriesEvent){
   
         if (seriesWeeklyId) {
             $(".seriesWeekly").each(function(){
+              if (!$(this).is(":visible") || $(this).is(":disabled")) return;
 
            
             if ($(this).val() === ""){
@@ -442,6 +434,8 @@ function checkValidation(seriesEvent){
       } 
       else if (isAllVolunteer) {
       $(".allV").each(function(){
+
+        if (!$(this).is(":visible") || $(this).is(":disabled")) return;
             if ($(this).val() === ""){
               this.setCustomValidity("Please fill out the required field"); // do these actions
               this.reportValidity();
@@ -453,20 +447,13 @@ function checkValidation(seriesEvent){
 
   
   } else {
-    //let seriesSuffix = "-mainOnly"
 
     $(".main").each(function(){
+      if (!$(this).is(":visible") || $(this).is(":disabled")) return;
     let elementId = $(this).prop("id");
     if (elementId === "checkIsTraining" || elementId === "checkServiceHours" || 
           elementId === "checkEngagement" || elementId === "checkBonners") {
         return; // Skip these, they'll be validated separately
-  //   if (!(trainingStatus || serviceHourStatus || engagementStatus || bonnersStatus)) {
-  //   // If none are checked, show an error message on the engagement checkbox
-  //   document.getElementById("checkEngagement").setCustomValidity("Please select at least one of the event options.");
-  //   document.getElementById("checkEngagement").reportValidity();
-  // } else {
-  //   // Clear any existing validation message
-  //   document.getElementById("checkEngagement").setCustomValidity("");
   }
     if ($(this).val() === ""){
       this.setCustomValidity("Please fill out the required field"); // do these actions
@@ -486,10 +473,28 @@ function checkValidation(seriesEvent){
     }
   }
 
+  console.log("Final allFieldFilled status:", allFieldFilled);
+  
   if (allFieldFilled) {
-     console.log("All validation passed - submitting form");//TESTING PURPOSE
-      $("#saveEvent").submit();     
+    //  console.log("All validation passed - submitting form");//TESTING PURPOSE
+    //   $("#saveEvent").submit();     
+    // }
+        // FIX 5: Removed problematic $(this) reference - was outside loop context
+    console.log("All validation passed - submitting form");
+    
+    // Try multiple submission methods
+    const form = document.getElementById("saveEvent");
+    if (form) {
+      console.log("Form found, attempting submission");
+      // Try triggering submit event instead of direct submission
+      $(form).trigger('submit');
+    } else {
+      console.log("Form not found, trying jQuery method");
+      $("#saveEvent").trigger('submit');
     }
+  } else {
+    console.log("Validation failed - form NOT submitted");
+  }
   }
 
 

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -148,114 +148,143 @@ function createOfferingModalRow({eventName=null, eventDate=null, startTime=null,
   return clonedOffering
 }
 
-$('#saveSeries').on('click', function() {
-  //Requires that modal info updated before it can be saved, gives notifier if there are empty fields
+function verifyRepeatingFields(){
+  // verifies all fields in the repeating table are not empty.
+  let repeatingFields = $(".repeatingEventsField");
+  let isEmpty = false;
+ enableLiveCustomValidityClearing();
+
+  repeatingFields.each(function() {
+    let value = $(this).val();
+    if (value === "" || value == null){
+      this.setCustomValidity("Please fill out the required field"); // do these actions
+      this.reportValidity();
+      isEmpty = true;
+    } else {
+      this.setCustomValidity("");
+    }
+  });
+  return isEmpty
+}
+
+$('#saveSeries').on('click', function(e) {
+  e.preventDefault(); // Prevent default form submission at the start
+  enableLiveCustomValidityClearing()
   let eventOfferings = $('#multipleOfferingSlots .eventOffering');
   let eventNameInputs = $('#multipleOfferingSlots .multipleOfferingNameField');
   let datePickerInputs = $('#multipleOfferingSlots .multipleOfferingDatePicker');
   let startTimeInputs = $('#multipleOfferingSlots .multipleOfferingStartTime');
   let endTimeInputs = $('#multipleOfferingSlots .multipleOfferingEndTime');
   let isRepeatingStatus = $("#checkIsRepeating").is(":checked");
-  let dataTable = isRepeatingStatus ? "#generatedEventsList" : "#multipleOfferingSlots";
-  let isEmpty = false;
-  let hasValidTimes = true;
-  let hasDuplicateListings = false;
-  let hasInvalidDates = false;
-
-
-  // Check if the input field is empty
-  eventNameInputs.each((index, eventNameInput) => {
-    if (eventNameInput.value.trim() === '') {
-      isEmpty = true;
-      //$(eventNameInput).addClass('border-red');
-      $(eventNameInput)[0].setCustomValidity("Please enter a event name");
-      $(eventNameInput)[0].reportValidity();
-          allFieldFilled = false;
-
-    } else {
-      $(eventNameInput)[0].setCustomValidity("");
-      //.removeClass('border-red');
+  let startDateInput = $("#repeatingEventsStartDate");
+  let endDateInput = $("#repeatingEventsEndDate");
+  
+  let hasErrors = false; // Single flag to track all validation errors
+  
+  // Validate repeating events fields first if it's a repeating event
+  if (isRepeatingStatus) {
+    if (verifyRepeatingFields()) {
+      hasErrors = true;
     }
-  });
-
-  // Check if the date input field is empty
-  datePickerInputs.each((index, datePickerInput) => {
-    if (datePickerInput.value.trim() === '') {
-        isEmpty = true;
-        //$(datePickerInput).addClass('border-red');
-        $(datePickerInput)[0].setCustomValidity("Please enter a event name");
-        $(datePickerInput)[0].reportValidity();
-    } else {
-        $(datePickerInput)[0].setCustomValidity("");
-        //$(datePickerInput).removeClass('border-red');
-    }
-  });  
-
-
-  // Check if the start time is after the end time
-  for(let i = 0; i < startTimeInputs.length; i++){
-    let startTime = startTimeInputs[i].value
-    let endTime = endTimeInputs[i].value
     
-    if (navigator.userAgent.indexOf("Chrome") == -1) {
-      startTime = format12to24HourTime(startTime)
-      endTime = format12to24HourTime(endTime)
-    }
-
-    if(startTime < endTime){
-      hasValidTimes = true;
-      $(startTimeInputs[i]).removeClass('border-red');
-      $(endTimeInputs[i]).removeClass('border-red');
+    // Check if start date is before end date for repeating events
+    let startDate = new Date(startDateInput.val());
+    let endDate = new Date(endDateInput.val());
+    
+    if (endDate <= startDate) {
+      hasErrors = true;
+      $(startDateInput).addClass('border-red');
+      $(endDateInput).addClass('border-red');
+      displayNotification("The end date must be after the start date.");
     } else {
-      hasValidTimes = false;
-      $(startTimeInputs[i]).addClass('border-red');
-      $(endTimeInputs[i]).addClass('border-red');
+      $(startDateInput).removeClass('border-red');
+      $(endDateInput).removeClass('border-red');
     }
-  }
-
-  if ($(dataTable).children().length < 1){
-    displayNotification("Please create events.")
-  }
-
-  // Check if there are duplicate event offerings
-  let eventListings = {};
-  for(let i = 0; i < eventOfferings.length; i++){
-    let eventName = eventNameInputs[i].value
-    let date = datePickerInputs[i].value.trim()
-    let startTime = startTimeInputs[i].value
-    let eventListing = JSON.stringify([eventName, date, startTime])
-
-    if (eventListing in eventListings){ // If we've seen this event before mark this event and the previous as duplicates
-      hasDuplicateListings = true
-    } else { // If we haven't seen this event before
-      eventListings[eventListing] = i
-    }
-  }
-
-  if (isEmpty){
-   return;
-
-    // let emptyFieldMessage = "Event name or date field is empty";
-    // msgToast(emptyFieldMessage);
-  }
-  else 
-  if (!hasValidTimes) {
-    let invalidTimeMessage = "Event end time must be after start time";
-    displayNotification(invalidTimeMessage);
-  }
-  else if (hasDuplicateListings) {
-    let eventConflictMessage = "Event listings cannot have the same event name, date, and start time";
-    displayNotification(eventConflictMessage);
+    
   } else {
+    // Validate individual event offerings for non-repeating events
+    
+    // Check event name fields
+    eventNameInputs.each((index, eventNameInput) => {
+      if (eventNameInput.value.trim() === '') {
+        hasErrors = true;
+        $(eventNameInput)[0].setCustomValidity("Please enter an event name");
+        $(eventNameInput)[0].reportValidity();
+      } else {
+        $(eventNameInput)[0].setCustomValidity("");
+      }
+    });
+
+    // Check date picker fields
+    datePickerInputs.each((index, datePickerInput) => {
+      if (datePickerInput.value.trim() === '') {
+        hasErrors = true;
+        $(datePickerInput)[0].setCustomValidity("Please enter an event date");
+        $(datePickerInput)[0].reportValidity();
+      } else {
+        $(datePickerInput)[0].setCustomValidity("");
+      }
+    });
+
+    
+    let hasTimeErrors = false;
+    // Check if start time is before end time for each event
+    for(let i = 0; i < startTimeInputs.length; i++){
+      let startTime = startTimeInputs[i].value;
+      let endTime = endTimeInputs[i].value;
+      
+      
+      if (navigator.userAgent.indexOf("Chrome") == -1) {
+        startTime = format12to24HourTime(startTime);
+        endTime = format12to24HourTime(endTime);
+      }
+
+      if(startTime >= endTime){
+        hasTimeErrors = true;
+        startTimeInputs[i].classList.add('border-red');
+        endTimeInputs[i].classList.add('border-red');
+      } else {
+        startTimeInputs[i].classList.remove('border-red');
+        endTimeInputs[i].classList.remove('border-red');
+      }
+     }
+     if (hasTimeErrors) {
+      hasErrors = true;
+      displayNotification("Event end time must be after start time");
+    }
+
+      
+
+    // Check for duplicate event offerings
+    let eventListings = {};
+    for(let i = 0; i < eventOfferings.length; i++){
+      let eventName = eventNameInputs[i].value;
+      let date = datePickerInputs[i].value.trim();
+      let startTime = startTimeInputs[i].value;
+      let eventListing = JSON.stringify([eventName, date, startTime]);
+
+      if (eventListing in eventListings){
+        hasErrors = true;
+        displayNotification("Event listings cannot have the same event name, date, and start time");
+        break; // Exit loop on first duplicate found
+      } else {
+        eventListings[eventListing] = i;
+      }
+    }
+  }
+
+
+  // Only proceed if there are no validation errors
+  if (!hasErrors) {
     saveOfferingsFromModal();
     $('#textNotifierPadding').removeClass('pt-5');
     updateOfferingsTable();
     pendingmultipleEvents = [];
-    $("#pastDateWarningText").text("")
+    $("#pastDateWarningText").text("");
     $("#checkIsSeries").prop('checked', true);
-    // Remove the modal and overlay from the DOM
-    updateEventNameField()
+    updateEventNameField();
     $('#modalSeries').modal('hide');
+    msgFlash("You have successfully updated a series of events", "success");
   }
 });
 
@@ -322,19 +351,6 @@ function saveOfferingsFromModal() {
   $("#seriesData").val(offeringsJson);
 }
 
-function verifyRepeatingFields(){
-  // verifies all fields in the repeating table are not empty.
-  let repeatingFields = $(".repeatingEventsField");
-  let allFieldsFilled = true;
-  repeatingFields.each(function() {
-    let value = $(this).val();
-    if (value === "" || value == null){
-      allFieldsFilled = false;
-      return false;
-    }
-  })
-  return allFieldsFilled
-}
 
 
 
@@ -395,7 +411,21 @@ function formatDate(originalDate) {
   var year = dateObj.getUTCFullYear();
   return month + " " + day + ", " + year;
 }
-
+function enableLiveCustomValidityClearing() {
+  const allSelectors = [".all", ".series", ".seriesWeekly", ".main", ".allV", ".repeatingEventsField", ".multipleOfferingNameField"];
+//Created the 
+  allSelectors.forEach(selector => {
+    $(selector).each(function () {
+      // Avoid rebinding listeners on already-bound elements
+      if (!$(this).data("has-clearing-listener")) {
+        $(this).on("input", function () {
+          this.setCustomValidity("");
+        });
+        $(this).data("has-clearing-listener", true); // flag it
+      }
+    });
+  });
+}
 function checkValidation(seriesEvent){
   let trainingStatus = $("#checkIsTraining").is(":checked")
   let serviceHourStatus = $("#checkServiceHours").is(":checked")
@@ -404,6 +434,8 @@ function checkValidation(seriesEvent){
   let allFieldFilled = true; //if there is text = true]
   let seriesWeeklyId = $("#checkIsRepeating").is(":checked")
   let isAllVolunteer = $("#pageTitle").text() == 'Create All Volunteer Training'
+  
+  enableLiveCustomValidityClearing();
 
   // .all is a class that groups the required filled present in all tempplate (event location and description)
    $(".all").each(function(){
@@ -497,9 +529,7 @@ function checkValidation(seriesEvent){
       } 
   
   if (allFieldFilled) {
-    // Try multiple submission methods
-   // const form = document.getElementById("saveEvent");
-    const form = $("#SaveEvent")
+    const form = $("#saveEvent")
     if (form) {
       // Try triggering submit event instead of direct submission
       $(form).trigger('submit');
@@ -605,7 +635,7 @@ $(document).ready(function() {
       $('#multipleOfferingTableDiv').addClass('d-none');
       // Enable single event name field
       $('#inputEventName').prop('readonly', false)
-      $('#inputEventName').prop('placeholder', 'Enter event name')
+      $('#inputEventName').prop('placeholder', 'Enter event name')  
     }
   });
 
@@ -642,16 +672,16 @@ $(document).ready(function() {
   });
   
   $("#repeatingEventsDiv").change(handleRepeatingEventsChange)
-
+// this handels start date, end date, last event date, start time, and end time 
   function handleRepeatingEventsChange() {
-    if (verifyRepeatingFields()) {
+    if (!verifyRepeatingFields()) {
       let table = $("#generatedEventsList").children();
       let startDate = new Date($("#repeatingEventsStartDate").val());
       let endDate = new Date($("#repeatingEventsEndDate").val());
       let startTime = $("#repeatingEventsStartTime").val();
       let endTime = $("#repeatingEventsEndTime").val();
-
-      if (navigator.userAgent.indexOf("Chrome") == -1) {
+      
+      if (navigator.userAgent.indexOf("Chrome") == -1) { //CHANGES 12 HOUR TO 24 HOUR
         startTime = format12to24HourTime(startTime)
         endTime = format12to24HourTime(endTime)
       }
@@ -681,6 +711,7 @@ $(document).ready(function() {
     }, 500, function() {
         // After the animation completes, remove the row
         attachedRow.remove();
+        msgToast("Deletion info", "You have successfully deleted a serie of event")
     });
   });
   

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -509,6 +509,8 @@ function checkValidation() {
   }
 }
 
+
+
 /*
  * Run when the webpage is ready for javascript
  */
@@ -565,6 +567,28 @@ $(document).ready(function() {
     typeBoxes.not($(event.target)).prop('checked', false);
   });
 
+  //to show the msgFlash message when the event is canceled
+$("#cancelEvent").on('click', function (event) {
+    event.preventDefault(); // Prevent normal form submission
+    
+    // Get the form action URL
+    let formAction = $(this).closest('form').attr('action');
+    
+    // Submit via AJAX
+    $.ajax({
+        url: formAction,
+        method: 'POST',
+        success: function(response) {
+            msgFlash("You have successfully canceled the event", "success", 5000);
+            $('#cancelWarning').modal('hide');
+            // Optionally refresh the page or update the UI
+            location.reload(); // or update specific elements
+        },
+        error: function() {
+            msgFlash("Failed to cancel the event", "error");
+        }
+    });
+});
 
   // When Save buttton is clicked, check if required are filled and then submit
   $("#saveButton").on('click', function (event) {

--- a/app/static/js/minorAdminPage.js
+++ b/app/static/js/minorAdminPage.js
@@ -2,13 +2,8 @@ import searchUser from './searchUser.js'
 
 
 $(document).ready(function() {
-    // Load flash message from sessionStorage, if any
-    const storedMessage = sessionStorage.getItem('flashMessage');
-    if (storedMessage) {
-        const messageData = JSON.parse(storedMessage);
-        msgFlash(messageData.message, messageData.type);
-        sessionStorage.removeItem('flashMessage'); // Clean up
-    }
+  // Load flash message from sessionStorage, if any
+  msgFlash();
 
   $('button[data-bs-toggle="tab"]').on('shown.bs.tab', function (e) {
     let activeTab = $(e.target).attr('id').replace('-tab', '');

--- a/app/static/js/minorAdminPage.js
+++ b/app/static/js/minorAdminPage.js
@@ -19,6 +19,7 @@ $(document).ready(function() {
           contentType: "application/json",
           success: function(response) {
             location.reload()
+            msgFlash("Candidate minor succsessfully removed", "success")
           },
           error: function(error) {
            console.log("error")

--- a/app/static/js/minorAdminPage.js
+++ b/app/static/js/minorAdminPage.js
@@ -2,33 +2,43 @@ import searchUser from './searchUser.js'
 
 
 $(document).ready(function() {
+      // Check for stored flash message after page load
+    const storedMessage = sessionStorage.getItem('flashMessage');
+    if (storedMessage) {
+        const messageData = JSON.parse(storedMessage);
+        msgFlash(messageData.message, messageData.type, 1300);
+        sessionStorage.removeItem('flashMessage'); // Clean up
+    }
   $('button[data-bs-toggle="tab"]').on('shown.bs.tab', function (e) {
     let activeTab = $(e.target).attr('id').replace('-tab', '');
     let newUrl = window.location.pathname + '?tab=' + activeTab;
     history.pushState(null, '', newUrl);
   });
 
-  $('.remove_minor_candidate').on('click', function() {
-      let username = $(this).attr('id'); 
-      let isAdding = false
-      
-      $.ajax({
-          type: 'POST',
-          url: '/profile/' + username + '/indicateInterest',
-          data: JSON.stringify({ "isAdding": isAdding }),
-          contentType: "application/json",
-          success: function(response) {
-            msgFlash("Candidate minor succsessfully removed", "success", 1300)
-            // Delay reload to let user see the message
-            setTimeout(function() {
-                location.reload()
-            }, 1500) 
-          },
-          error: function(error) {
-           console.log("error")
-          }
-      });
-  });
+$('.remove_minor_candidate').on('click', function() {
+    let username = $(this).attr('id'); 
+    let isAdding = false
+    
+    $.ajax({
+        type: 'POST',
+        url: '/profile/' + username + '/indicateInterest',
+        data: JSON.stringify({ "isAdding": isAdding }),
+        contentType: "application/json",
+        success: function(response) {
+            // Store message in sessionStorage to survive page reload
+            sessionStorage.setItem('flashMessage', JSON.stringify({
+                message: "Candidate minor successfully removed",
+                type: "success"
+            }));
+            
+            // Reload immediately
+            location.reload();
+        },
+        error: function(error) {
+            console.log("error")
+        }
+    });
+});
 
 
   $('#engagedStudentsTable').DataTable();

--- a/app/static/js/minorAdminPage.js
+++ b/app/static/js/minorAdminPage.js
@@ -2,13 +2,14 @@ import searchUser from './searchUser.js'
 
 
 $(document).ready(function() {
-      // Check for stored flash message after page load
+    // Load flash message from sessionStorage, if any
     const storedMessage = sessionStorage.getItem('flashMessage');
     if (storedMessage) {
         const messageData = JSON.parse(storedMessage);
-        msgFlash(messageData.message, messageData.type, 1300);
+        msgFlash(messageData.message, messageData.type);
         sessionStorage.removeItem('flashMessage'); // Clean up
     }
+
   $('button[data-bs-toggle="tab"]').on('shown.bs.tab', function (e) {
     let activeTab = $(e.target).attr('id').replace('-tab', '');
     let newUrl = window.location.pathname + '?tab=' + activeTab;
@@ -25,13 +26,7 @@ $('.remove_minor_candidate').on('click', function() {
         data: JSON.stringify({ "isAdding": isAdding }),
         contentType: "application/json",
         success: function(response) {
-            // Store message in sessionStorage to survive page reload
-            sessionStorage.setItem('flashMessage', JSON.stringify({
-                message: "Candidate minor successfully removed",
-                type: "success"
-            }));
-            
-            // Reload immediately
+            msgFlash("Candidate minor successfully removed", "success", 1500, true);
             location.reload();
         },
         error: function(error) {

--- a/app/static/js/minorAdminPage.js
+++ b/app/static/js/minorAdminPage.js
@@ -124,6 +124,8 @@ function updateInterestedStudents(){
     $("#addInterestedStudentsbtn").prop("disabled", true)
   } else {
     $("#addInterestedStudentsbtn").prop("disabled", false)
+   
+    msgFlash("Succssesfully added student intrested in minor.", "success", 1300, true)
   }
 }
 

--- a/app/static/js/minorAdminPage.js
+++ b/app/static/js/minorAdminPage.js
@@ -124,7 +124,6 @@ function updateInterestedStudents(){
     $("#addInterestedStudentsbtn").prop("disabled", true)
   } else {
     $("#addInterestedStudentsbtn").prop("disabled", false)
-   
     msgFlash("Succssesfully added student intrested in minor.", "success", 1300, true)
   }
 }

--- a/app/static/js/minorAdminPage.js
+++ b/app/static/js/minorAdminPage.js
@@ -18,8 +18,11 @@ $(document).ready(function() {
           data: JSON.stringify({ "isAdding": isAdding }),
           contentType: "application/json",
           success: function(response) {
-            location.reload()
-            msgFlash("Candidate minor succsessfully removed", "success")
+            msgFlash("Candidate minor succsessfully removed", "success", 1300)
+            // Delay reload to let user see the message
+            setTimeout(function() {
+                location.reload()
+            }, 1500) 
           },
           error: function(error) {
            console.log("error")

--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -301,24 +301,9 @@ function saveCourseData(url, successCallback) {
   });
 }
 
-function enableLiveCustomValidityClearing() {
-  const allSelectors = ["#courseInstructor", "#courseNameId"];
-  allSelectors.forEach(selector => {
-    $(selector).each(function () {
-      // Avoid rebinding listeners on already-bound elements
-      if (!$(this).data("has-clearing-listener")) {
-        $(this).on("input", function () {
-          this.setCustomValidity("");
-        });
-        $(this).data("has-clearing-listener", true); // flag it
-      }
-    });
-  });
-}
-
 function validateForm() {
   // This function ensures our form fields are valid
- enableLiveCustomValidityClearing();
+ enableLiveCustomValidityClearing(["#courseInstructor", "#courseNameId"]);
   if (readOnly())
     return true;
 

--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -297,42 +297,48 @@ function saveCourseData(url, successCallback) {
 
 function validateForm() {
   // This function ensures our form fields are valid
-  // Returns true if we are just viewing a form
-  // TODO: Generalize form validation to include textareas and selects
-
+ 
   if (readOnly())
-      return true;
+    return true;
 
   let valid = true;
 
   let allTabs = $(".tab");
   let allInputs = $(allTabs[currentTab]).find("input");
-  for (let i = 0; i < allInputs.length; i++) {
-    if (allInputs[i].required) {
-      if (!allInputs[i].value){
-        $(allInputs[i]).addClass("invalid");
-        valid = false;
-      } else {
-        $(allInputs[i]).addClass("form-control");
-      }
-    }
-  }
-  var instructors = getCourseInstructors()
-  if (!instructors.length && currentTab == 1) {
-    valid = false;
-    $("#instructorTable .emptyTableMessage").addClass("table-danger");
-    $("#instructorTable .emptyTableMessage label").removeClass("text-secondary");
-  } else {
-    $("#instructorTable .emptyTableMessage").removeClass("table-danger");
-    $("#instructorTable .emptyTableMessage label").addClass("text-secondary");
-  }
 
-  if (valid) {
-    $($(".step")[currentTab]).addClass("finish");
+//Validating the instructor dropdown
+if (currentTab === 1) {
+  let courseInstructor = document.getElementById("courseInstructor");
+  
+  // Check if there are any instructor rows in the table
+  let instructorRows = document.querySelectorAll("tr[data-username]");
+  
+  if (instructorRows.length === 1) {
+    courseInstructor.setCustomValidity("Please select an instructor");
+    courseInstructor.reportValidity();
+    courseInstructor.focus();
+    valid = false;
+  } else {
+    courseInstructor.setCustomValidity("");
   }
+}
+
+  if  (currentTab === 1) {
+    let courseName = document.getElementById("courseNameId");
+    if (courseName.value === "") {
+      console.log("empty")
+      courseName.setCustomValidity("Please enter a course");
+      courseName.reportValidity();
+      courseName.focus();
+      valid = false;
+  } else {
+    courseName.setCustomValidity(""); 
+  }
+}
 
   return valid;
 };
+
 
 function disableSyllabusUploadFile() {
   $("#fileUpload").prop("disabled", true);

--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -301,19 +301,29 @@ function saveCourseData(url, successCallback) {
   });
 }
 
+function enableLiveCustomValidityClearing() {
+  const allSelectors = ["#courseInstructor", "#courseNameId"];
+  allSelectors.forEach(selector => {
+    $(selector).each(function () {
+      // Avoid rebinding listeners on already-bound elements
+      if (!$(this).data("has-clearing-listener")) {
+        $(this).on("input", function () {
+          this.setCustomValidity("");
+        });
+        $(this).data("has-clearing-listener", true); // flag it
+      }
+    });
+  });
+}
+
 function validateForm() {
   // This function ensures our form fields are valid
- 
+ enableLiveCustomValidityClearing();
   if (readOnly())
     return true;
 
   let valid = true;
   let allTabs = $(".tab");
-
-    // Clear all previous validations
-  $("input, select, textarea").each(function() {
-    this.setCustomValidity("");
-  });
 
   //Validating the instructor dropdown
   if (currentTab === 1) {

--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -308,39 +308,39 @@ function validateForm() {
     return true;
 
   let valid = true;
-
   let allTabs = $(".tab");
-  let allInputs = $(allTabs[currentTab]).find("input");
 
-//Validating the instructor dropdown
-if (currentTab === 1) {
-  let courseInstructor = document.getElementById("courseInstructor");
-  
-  // Check if there are any instructor rows in the table
-  let instructorRows = document.querySelectorAll("tr[data-username]");
-  
+    // Clear all previous validations
+  $("input, select, textarea").each(function() {
+    this.setCustomValidity("");
+  });
+
+  //Validating the instructor dropdown
+  if (currentTab === 1) {
+      let $courseInstructor = $("#courseInstructor");
+      let instructorRows = $("tr[data-username]");
+      
   if (instructorRows.length === 1) {
-    courseInstructor.setCustomValidity("Please select an instructor");
-    courseInstructor.reportValidity();
-    courseInstructor.focus();
-    valid = false;
-  } else {
-    courseInstructor.setCustomValidity("");
-  }
+      $courseInstructor[0].setCustomValidity("Please select an instructor");
+      // Focus and show validation immediately
+      $courseInstructor.focus();
+      $courseInstructor[0].reportValidity();
+      valid = false;
+      return valid; // Exit early to prevent other validations from interfering
+    }
 }
 
-  if  (currentTab === 1) {
-    let courseName = document.getElementById("courseNameId");
-    if (courseName.value === "") {
-      console.log("empty")
-      courseName.setCustomValidity("Please enter a course");
-      courseName.reportValidity();
-      courseName.focus();
+  // Course name validation
+  if (currentTab === 1) {
+    let $courseName = $("#courseNameId");
+    if ($courseName.val() === "") {
+      $courseName[0].setCustomValidity("Please enter a course");
+      $courseName.focus();
+      $courseName[0].reportValidity();
       valid = false;
-  } else {
-    courseName.setCustomValidity(""); 
+      return valid; // Exit early
+    }
   }
-}
 
   return valid;
 };

--- a/app/static/js/slcNewProposal.js
+++ b/app/static/js/slcNewProposal.js
@@ -90,7 +90,6 @@ $(document).ready(function(e) {
   });
 
   $("#saveContinue").on("click", function() {
-
       if(readOnly()) {
           let allTabs = $(".tab");
           displayCorrectTab(1)
@@ -127,7 +126,7 @@ $(document).ready(function(e) {
       });
 
   // Add course instructor event handlers
-  $("#instructorTable").on("click", ".removeButton", function() {
+  $("#instructorTable").on("click", ".removeButton", function() {  
     let closestRow = $(this).closest("tr");
     let username = closestRow.data('username');
     
@@ -135,6 +134,7 @@ $(document).ready(function(e) {
     if (username) {
         $("#instructorTableNames input[value='" + username + "']").remove();
         closestRow.remove();
+         msgFlash(`Successfully removed instructor ${username}`, "success", 1300);
     }
     updateEmptyTableMessage();
   });

--- a/app/static/js/userManagement.js
+++ b/app/static/js/userManagement.js
@@ -177,6 +177,7 @@ function editProgramManager(username, fullName, programId, action){
           $(`#programManagersTable #${username}`)
           .closest('tr')
           .remove()
+          msgToast("Confirmed", "You have just deleted a program manager")
           updateManagers(programId)
         })
         if (newManagers.length){

--- a/app/static/js/userProfile.js
+++ b/app/static/js/userProfile.js
@@ -1,4 +1,7 @@
 $(document).ready(function(){
+  //Load flash message from sessionStorage, if any
+  msgFlash();
+
   $("#checkIsInterest").on("change", function() {
     let username = $(this).data('username')
     let isAdding = $(this).is(':checked');
@@ -205,6 +208,7 @@ $(document).ready(function(){
     });
 
   $('#addNoteForm').submit(function(event) {
+
     event.preventDefault()
     let username = $("#notesSaveButton").data('username')
     let isBonner = $("#bonnerInput").is(":checked")
@@ -216,13 +220,12 @@ $(document).ready(function(){
              "noteTextbox": $("#addNoteTextArea").val(),
              "bonner": isBonner ? "yes" : "no"},
       success: function(response) {
-        msgToast("Successfully added a note", "", 2000)
-        target = isBonner ? "bonner" : "notes"
-        // Delay reload to let user see the message
-            setTimeout(function() {
-                reloadWithAccordion(target)
-                location.reload()
-            }, 2500) 
+          target = isBonner ? "bonner" : "notes"
+          msgFlash("Successfully added a note", "success", 1300, true);
+          location.reload()
+      },
+      error: function(error) {
+        console.log("error")
       }
     });
   });
@@ -236,7 +239,6 @@ $(document).ready(function(){
       data: {"id": noteid},
       success: function(response) {
         reloadWithAccordion("notes")
-        // msgFlash("Successfully deleted a note", "success")
       }
     });
   });

--- a/app/static/js/userProfile.js
+++ b/app/static/js/userProfile.js
@@ -224,9 +224,13 @@ $(document).ready(function(){
              "noteTextbox": $("#addNoteTextArea").val(),
              "bonner": isBonner ? "yes" : "no"},
       success: function(response) {
+        msgToast("Successfully added a note", "", 2000)
         target = isBonner ? "bonner" : "notes"
-        reloadWithAccordion(target)
-        msgToast("Successfully added a note")
+        // Delay reload to let user see the message
+            setTimeout(function() {
+                reloadWithAccordion(target)
+                location.reload()
+            }, 2500) 
       }
     });
 });

--- a/app/static/js/userProfile.js
+++ b/app/static/js/userProfile.js
@@ -255,7 +255,24 @@ $(document).ready(function(){
      * Background Check Functionality
      */
     // Updates the Background check of a volunteer in the database
+
+
+function enableLiveCustomValidityClearing() {
+  const allSelectors = [".passedBackgroundCheck"];
+  allSelectors.forEach(selector => {
+    $(selector).each(function () {
+      // Avoid rebinding listeners on already-bound elements
+      if (!$(this).data("has-clearing-listener")) {
+        $(this).on("input", function () {
+          this.setCustomValidity("");
+        });
+        $(this).data("has-clearing-listener", true); // flag it
+      }
+    });
+  });
+}
     $(".savebtn").click(function () {
+      enableLiveCustomValidityClearing()
         $(this).prop("disabled", true);
         let bgCheckType = $(this).data("id")
 

--- a/app/static/js/userProfile.js
+++ b/app/static/js/userProfile.js
@@ -232,6 +232,7 @@ $(document).ready(function(){
       success: function(response) {
         target = isBonner ? "bonner" : "notes"
         reloadWithAccordion(target)
+        msgToast("Successfully added a note")
       }
     });
 });
@@ -245,6 +246,7 @@ $(document).ready(function(){
       data: {"id": noteid},
       success: function(response) {
         reloadWithAccordion("notes")
+        // msgFlash("Successfully deleted a note", "success")
       }
     });
   });

--- a/app/static/js/userProfile.js
+++ b/app/static/js/userProfile.js
@@ -249,6 +249,7 @@ $(document).ready(function(){
   // Updates the Background check of a volunteer in the database
 
   $(".savebtn").click(function () {
+    msgFlash()
       enableLiveCustomValidityClearing([".passedBackgroundCheck"])
       $(this).prop("disabled", true);
       let bgCheckType = $(this).data("id")
@@ -291,10 +292,8 @@ $(document).ready(function(){
           data: data,
           success: function(s){
             var date = new Date(data.bgDate + " 12:00").toLocaleDateString()
-            msgFlash(`Successfully added background check`, "success", 1300)
-            setTimeout(function() {
+            msgFlash(`Successfully added background check`, "success", 1300,true)
             reloadWithAccordion("background")
-            }, 1500)
           },
           error: function(error, status){
               console.log(error, status)

--- a/app/static/js/userProfile.js
+++ b/app/static/js/userProfile.js
@@ -248,23 +248,8 @@ $(document).ready(function(){
     */
   // Updates the Background check of a volunteer in the database
 
-
-function enableLiveCustomValidityClearing() {
-  const allSelectors = [".passedBackgroundCheck"];
-  allSelectors.forEach(selector => {
-    $(selector).each(function () {
-      // Avoid rebinding listeners on already-bound elements
-      if (!$(this).data("has-clearing-listener")) {
-        $(this).on("input", function () {
-          this.setCustomValidity("");
-        });
-        $(this).data("has-clearing-listener", true); // flag it
-      }
-    });
-  });
-}
   $(".savebtn").click(function () {
-      enableLiveCustomValidityClearing()
+      enableLiveCustomValidityClearing([".passedBackgroundCheck"])
       $(this).prop("disabled", true);
       let bgCheckType = $(this).data("id")
 

--- a/app/static/js/userProfile.js
+++ b/app/static/js/userProfile.js
@@ -312,7 +312,10 @@ function enableLiveCustomValidityClearing() {
           data: data,
           success: function(s){
             var date = new Date(data.bgDate + " 12:00").toLocaleDateString()
+            msgFlash(`Successfully added background check`, "success", 1300)
+            setTimeout(function() {
             reloadWithAccordion("background")
+            }, 1500)
           },
           error: function(error, status){
               console.log(error, status)

--- a/app/static/js/userProfile.js
+++ b/app/static/js/userProfile.js
@@ -265,16 +265,20 @@ $(document).ready(function(){
 
         if (bgStatus == '') {
           bgStatusInput.focus()
-          bgStatusInput.addClass("invalid");
-          window.setTimeout(() => bgStatusInput.removeClass("invalid"), 1000);
+           $('.form-select').each(function() {
+                bgStatusInput[0].setCustomValidity("Please enter a status");
+                bgStatusInput[0].reportValidity();
+          });
           $(this).prop("disabled", false);
           return false
         }
 
         if (bgDate == ''){
           bgDateInput.focus()
-          bgDateInput.addClass("invalid");
-          window.setTimeout(() => bgDateInput.removeClass("invalid"), 1000);
+          $('.form-control').each(function() {
+                bgDateInput[0].setCustomValidity("Please enter a date");
+                bgDateInput[0].reportValidity();
+          });
           $(this).prop("disabled", false);
           return false
         }
@@ -310,8 +314,8 @@ $(document).ready(function(){
       type: "POST",
       data: data,
       success: function(s){
-        msgToast("Background Check", `Successfully deleted background check. <a href="/profile/undo" id="bgCheckUndo" class="mx-2">Undo</a>`)
-      },
+       msgFlash(`Successfully deleted background check, <a href="/profile/undo" id="bgCheckUndo" class="mx-2">Undo</a>`, "success")
+      },        
       error: function(error, status){
         console.log(error,status)
       }

--- a/app/templates/events/createEvent.html
+++ b/app/templates/events/createEvent.html
@@ -75,14 +75,10 @@
   <div class="form-group col-md-6" id="eventDate">
     <label class="required form-label me-2" for="startDatePicker-{{pageLocation}}"><strong>Start Date</strong></label>
     <div class='input-group date startDate' id="startDate-{{pageLocation}}" data-page-location="{{pageLocation}}">
-      <input autocomplete="off" type='text' class="form-control datePicker startDatePicker readonly main allV"
-        value="{{ eventData.startDate.strftime('%Y/%m/%d') if eventData.startDate and eventData.startDate.strftime else eventData.startDate}}"
+      <input autocomplete="off" type='date' class="form-control datePicker startDatePicker readonly main allV"
+        value="{{ eventData.startDate.strftime('%Y-%m-%d') if eventData.startDate and eventData.startDate.strftime else eventData.startDate}}"
         name="startDate" placeholder="Pick a start date" id='startDatePicker-{{pageLocation}}Only'
         data-page-location="{{pageLocation}}" required>
-      <div class="input-group-text" id="calendarIconStart-{{pageLocation}}"
-        onclick="$('#startDatePicker-{{pageLocation}}').datepicker('show')">
-        <span><i class="bi bi-calendar-plus-fill"></i></span>
-      </div>
     </div>
   </div>
   <div class="form-group col-md-6" id="checkIsSeriesToggleContainer">
@@ -96,7 +92,6 @@
       </div>
     </div>
   </div>
-
 </div>
 
 <br>

--- a/app/templates/events/createEvent.html
+++ b/app/templates/events/createEvent.html
@@ -540,7 +540,7 @@
             <div class='input-group date multipleOfferingDate' id="multipleOfferingDate-{{pageLocation}}"
               data-page-location="{{pageLocation}}">
               <input autocomplete="off" type='date'
-                class="form-control datePicker multipleOfferingDatePicker readonly-series"
+                class="form-control datePicker multipleOfferingDatePicker readonly series"
                 value="{{ eventData.multipleOfferingDate.strftime('%m-%d-%Y') if eventData.multipleOfferingDate and eventData.multipleOfferingDate.strftime else eventData.multipleOfferingDate}}"
                 name="multipleOfferingDate" placeholder="Pick a start date"
                 id='multipleOfferingDatePicker-{{pageLocation}}' data-page-location="{{pageLocation}}" />

--- a/app/templates/events/createEvent.html
+++ b/app/templates/events/createEvent.html
@@ -327,7 +327,7 @@
         <button type="button" class="btn btn-success" data-bs-toggle="modal" data-bs-target="#renewWarning">Renew
           Event</button>
         {% endif %}
-        <input type="submit" class="btn btn-primary saveBtn" value="Save" />
+        <input type="button" class="btn btn-primary saveBtn" id="saveButton" value="Save" />
       </div>
     </div>
   </div>
@@ -611,7 +611,7 @@
         <button type="button" class="btn btn-secondary me-auto" data-bs-dismiss="modal" name="cancelModalPreview"
           id="cancelModalPreview">Cancel</button>
         {% set disableSave = "disabled" if cpPreviewErrors|count else "" %}
-        <button type="submit" name="saveSeries" class="btn btn-primary saveSeries" {{disableSave}}
+        <button type="button" name="saveSeries" class="btn btn-primary saveSeries" {{disableSave}}
           id="saveSeries">Save</button> <!--check if text box empty upon save-->
       </div> 
   </div>

--- a/app/templates/events/createEvent.html
+++ b/app/templates/events/createEvent.html
@@ -249,17 +249,17 @@
         <input class="form-check-input main series seriesWeekly" type="checkbox" id="checkIsTraining" name="isTraining" {{"checked" if eventData.isTraining}} />
       </div>
       <div class="form-check form-switch">
-        <label class="custom-control-label" for="checkIsService"><strong>This event earns service hours.</strong></label>
-        <input class="form-check-input main series seriesWeekly" type="checkbox" id="checkIsService" name="isService" {{"checked" if eventData.isService}} />
+        <label class="custom-control-label" for="checkServiceHours"><strong>This event earns service hours.</strong></label>
+        <input class="form-check-input main series seriesWeekly" type="checkbox" id="checkServiceHours" name="isService" {{"checked" if eventData.isService}} />
       </div>
       <div class="form-check form-switch">
-        <label class="custom-control-label" for="checkIsEngagement"><strong>This event is engagement or education.</strong></label>
-        <input class="form-check-input main series seriesWeekly" type="checkbox" id="checkIsEngagement" name="isEngagement" {{"checked" if eventData.isEngagement}} />
+        <label class="custom-control-label" for="checkEngagement"><strong>This event is engagement or education.</strong></label>
+        <input class="form-check-input main series seriesWeekly" type="checkbox" id="checkEngagement" name="isEngagement" {{"checked" if eventData.isEngagement}} />
       </div>
       {% if eventData['program'].isBonnerScholars %}
       <div class="form-check form-switch">
-        <label class="custom-control-label" for="checkIsBonner"><strong>This event is for labor only</strong></label>
-        <input class="form-check-input main series seriesWeekly" type="checkbox" id="checkIsBonner" name="isBonnerScholars" {{"checked" if eventData['program'].isBonnerScholars and not eventData.isService and not eventData.isTraining}} />
+        <label class="custom-control-label" for="checkBonners"><strong>This event is for labor only</strong></label>
+        <input class="form-check-input main series seriesWeekly" type="checkbox" id="checkBonners" name="isBonnersChecked" {{"checked" if eventData['program'].isBonnerScholars and not eventData.isService and not eventData.isTraining}} />
       </div>
       {% endif %}
     </div>
@@ -290,7 +290,7 @@
 {% endif %}
 <div class="form-group mb-5">
   <label class="mb-2" for='attachmentObject'><strong>Add Files</strong></label>
-  <input type="file" class="form-control" id="attachmentObject" name="attachmentObject" multiple />
+  <input type="file" class="form-control" id="attachmentObject" name="attachmentObject" multiple accept=".png, .jpg, .pdf, .jpeg, .docx, .xlsx" />
 </div>
 
       {% if filepaths %}

--- a/app/templates/events/createEvent.html
+++ b/app/templates/events/createEvent.html
@@ -62,7 +62,7 @@
     {% macro locationTimeMacro(eventData, isNewEvent, pageLocation) %}
 <div class="form-group mb-4">
   <label class="required form-label" for='inputEventLocation-{{pageLocation}}'><strong>Location</strong></label>
-  <input class="form-control" id='inputEventLocation-{{pageLocation}}' placeholder="Enter location" name="location"
+  <input class="form-control needsValidation all" id='inputEventLocation-{{pageLocation}}' placeholder="Enter location" name="location"
     value="{{eventData.location}}" required>
 </div>
 <!-- Non-Series Start Datepicker -->
@@ -70,9 +70,9 @@
   <div class="form-group col-md-6">
     <label class="required form-label me-2" for="startDatePicker-{{pageLocation}}"><strong>Start Date</strong></label>
     <div class='input-group date startDate' id="startDate-{{pageLocation}}" data-page-location="{{pageLocation}}">
-      <input autocomplete="off" type='text' class="form-control datePicker startDatePicker readonly"
+      <input autocomplete="off" type='text' class="form-control datePicker startDatePicker readonly main"
         value="{{ eventData.startDate.strftime('%Y/%m/%d') if eventData.startDate and eventData.startDate.strftime else eventData.startDate}}"
-        name="startDate" placeholder="Pick a start date" id='startDatePicker-{{pageLocation}}'
+        name="startDate" placeholder="Pick a start date" id='startDatePicker-{{pageLocation}}Only'
         data-page-location="{{pageLocation}}" required>
       <div class="input-group-text" id="calendarIconStart-{{pageLocation}}"
         onclick="$('#startDatePicker-{{pageLocation}}').datepicker('show')">
@@ -130,7 +130,7 @@
       {% endif %}
       <div class="form-group mb-4">
         <label class="required form-label" for='inputEventName'><strong>Event Name</strong></label>
-        <input class="form-control" id='inputEventName' value="{{eventData.name}}" placeholder="Enter event name"
+        <input class="form-control needsValidation main allv" id='inputEventName' value="{{eventData.name}}" placeholder="Enter event name"
           name="name" required>
       </div>
       <div class="form-group mb-4">
@@ -226,7 +226,7 @@
     <div class="col-md-6 form-group">
       <div class="form-group mb-4">
         <label class="required form-label" for='inputCharacters'><strong>Description</strong></label>
-        <textarea rows="5" cols="72" class="form-control" id="inputCharacters" type="text"
+        <textarea rows="5" cols="72" class="form-control needsValidation all" id="inputCharacters" type="text"
           placeholder="Enter event description" name="description" required>{{eventData.description}}</textarea>
         <label class="form-label" id="remainingCharacters"></label>
       </div>
@@ -275,16 +275,16 @@
             <div class="form-check form-switch">
               <label class="custom-control-label" for="checkIsTraining"><strong>This event is a
                   training.</strong></label>
-              <input class="form-check-input" type="checkbox" id="checkIsTraining" name="isTraining" {{"checked" if eventData.isTraining}} />
+              <input class="form-check-input main series seriesWeekly" type="checkbox" id="checkIsTraining" name="isTraining" {{"checked" if eventData.isTraining}} />
             </div>
             <div class="form-check form-switch">
               <label class="custom-control-label" for='checkServiceHours'><strong>This event earns service
                   hours.</strong></label>
-              <input class="form-check-input" type="checkbox" id="checkServiceHours" name="isService" {{"checked" if eventData.isService}} />
+              <input class="form-check-input main series seriesWeekly" type="checkbox" id="checkServiceHours" name="isService" {{"checked" if eventData.isService}} />
             </div>
             <div class="form-check form-switch">
               <label class="custom-control-label" for='checkEngagement'><strong>This event is engagement or education.</strong></label>
-              <input class="form-check-input" type="checkbox" id="checkEngagement" name="isEngagement" {{"checked" if eventData.isEngagement}} />
+              <input class="form-check-input main series seriesWeekly" type="checkbox" id="checkEngagement" name="isEngagement" {{"checked" if eventData.isEngagement}} />
             </div>
             {% if eventData['program'].isBonnerScholars %}
             <div class="form-check form-switch">
@@ -469,7 +469,7 @@
               <label class="required form-label me-2 mb-0" for="repeatingEventsStartDate"><strong>Start Date</strong></label>
               <div class='input-group date'>
                 <input autocomplete="off" type='date'
-                  class="form-control repeatingEventsField readonly"
+                  class="form-control repeatingEventsField readonly seriesWeekly"
                   name="repeatingEventsStartDate" placeholder="Pick a start date"
                   id='repeatingEventsStartDate' />
               </div>
@@ -479,7 +479,7 @@
               <label class="required form-label me-2 mb-0" for="repeatingEventsEndDate"><strong>Last Event Date</strong></label>
               <div class='input-group date'>
                 <input autocomplete="off" type='date'
-                  class="form-control repeatingEventsEndDate repeatingEventsField readonly"
+                  class="form-control repeatingEventsEndDate repeatingEventsField readonly seriesWeekly"
                   name="repeatingEventsEndDate" placeholder="Pick a start date"
                   id='repeatingEventsEndDate' />
               </div>
@@ -548,7 +548,7 @@
             <div class='input-group date multipleOfferingDate' id="multipleOfferingDate-{{pageLocation}}"
               data-page-location="{{pageLocation}}">
               <input autocomplete="off" type='date'
-                class="form-control datePicker multipleOfferingDatePicker readonly"
+                class="form-control datePicker multipleOfferingDatePicker readonly-series"
                 value="{{ eventData.multipleOfferingDate.strftime('%m-%d-%Y') if eventData.multipleOfferingDate and eventData.multipleOfferingDate.strftime else eventData.multipleOfferingDate}}"
                 name="multipleOfferingDate" placeholder="Pick a start date"
                 id='multipleOfferingDatePicker-{{pageLocation}}' data-page-location="{{pageLocation}}" />

--- a/app/templates/events/createEvent.html
+++ b/app/templates/events/createEvent.html
@@ -241,62 +241,58 @@
       </div>
 -     {% if page_title != 'Create All Volunteer Training' %}
       <div class="pt-4 mb-4">
-        <div class="row">
-            <div class="form-group col-xl-8">
-            <label class="label required toggleHeader">(Must Select One)</label>
-                <div class="form-check form-switch">
-              <label class="custom-control-label" for="checkIsTraining"><strong>This event is a
-                  training.</strong></label>
-              <input class="form-check-input main series seriesWeekly" type="checkbox" id="checkIsTraining" name="isTraining" {{"checked" if eventData.isTraining}} />
-            </div>
-            <div class="form-check form-switch">
-              <label class="custom-control-label" for='checkServiceHours'><strong>This event earns service
-                  hours.</strong></label>
-              <input class="form-check-input main series seriesWeekly" type="checkbox" id="checkServiceHours" name="isService" {{"checked" if eventData.isService}} />
-            </div>
-            <div class="form-check form-switch">
-              <label class="custom-control-label" for='checkEngagement'><strong>This event is engagement or education.</strong></label>
-              <input class="form-check-input main series seriesWeekly" type="checkbox" id="checkEngagement" name="isEngagement" {{"checked" if eventData.isEngagement}} />
-            </div>
-            {% if eventData['program'].isBonnerScholars %}
-            <div class="form-check form-switch">
-              <label class="custom-control-label" for='checkBonners'><strong>This is a Bonner Scholars
-                  event.</strong></label>
-              <input class="form-check-input" type="checkbox" id="checkBonners" name="isBonnersChecked" {{"checked" if
-                eventData['program'].isBonnerScholars and not eventData.isService and not eventData.isTraining}} />
-            </div>
-            {% endif %}
+  <div class="row">
+    <div class="form-group col-xl-6">
+      <label class="label required toggleHeader">(Must Select One)</label>
+      <div class="form-check form-switch">
+        <label class="custom-control-label" for="checkIsTraining"><strong>This event is a training.</strong></label>
+        <input class="form-check-input main series seriesWeekly" type="checkbox" id="checkIsTraining" name="isTraining" {{"checked" if eventData.isTraining}} />
+      </div>
+      <div class="form-check form-switch">
+        <label class="custom-control-label" for="checkIsService"><strong>This event earns service hours.</strong></label>
+        <input class="form-check-input main series seriesWeekly" type="checkbox" id="checkIsService" name="isService" {{"checked" if eventData.isService}} />
+      </div>
+      <div class="form-check form-switch">
+        <label class="custom-control-label" for="checkIsEngagement"><strong>This event is engagement or education.</strong></label>
+        <input class="form-check-input main series seriesWeekly" type="checkbox" id="checkIsEngagement" name="isEngagement" {{"checked" if eventData.isEngagement}} />
+      </div>
+      {% if eventData['program'].isBonnerScholars %}
+      <div class="form-check form-switch">
+        <label class="custom-control-label" for="checkIsBonner"><strong>This event is for labor only</strong></label>
+        <input class="form-check-input main series seriesWeekly" type="checkbox" id="checkIsBonner" name="isBonnerScholars" {{"checked" if eventData['program'].isBonnerScholars and not eventData.isService and not eventData.isTraining}} />
       </div>
       {% endif %}
-      <div class="col-xl-1 columnDivide d-none d-xl-block" style="margin-left: -66px;"></div>       
-      <div class="form-group col-xl-5">
-            <label class="label toggleHeader">(Optional)</label>
-           <div class="form-check form-switch mb-2">
-              <input class="form-check-input" type="checkbox" id="checkRSVP" name="isRsvpRequired" ... />
-              <label class="form-check-label" for="checkRSVP"><strong>This event requires RSVP.</strong></label>
-            </div>
-            <div class="form-group mb-3">
-              <div class="form-check form-switch">
-                {% set hide = "" if eventData.isRsvpRequired else "display: none" %}
-                <div class="form-group" id="limitGroup" style="{{hide}}">
-                  <label class="form-label mt-2" for='limitRsvp'><strong>Attendance Limit</strong></label>
-                  <input class="form-control mb-2" type="number" id="limitRsvp" name="rsvpLimit"
-                    value="{{eventData.rsvpLimit}}" min="0" placeholder="No Limit" pattern="^[0-9]+$"></input>
-                </div>
-                <label class="custom-control-label" for="checkFood"><strong>This event will provide food.</strong></label>
-                <input class="form-check-input" type="checkbox" id="checkFood" name="isFoodProvided" {{"checked" if eventData.isFoodProvided}} />
-                <label class="custom-control-label" for="checkLaborOnly"><strong>This event is for labor only</strong></label>
-                <input class="form-check-input" type="checkbox" id="checkLaborOnly" name="isLaborOnly" {{"checked" if eventData.isLaborOnly}}/>
-              </div>
-             </div>
-            </div>
-           </div>
-          </div>
-      <div class="form-group mb-5">
-        <label class="mb-2" for='attachmentObject'><strong>Add Files</strong></label>
-        <input type="file" class="form-control" id="attachmentObject" name="attachmentObject" multiple
-          accept=".png, .jpg, .pdf, .jpeg, .docx, .xlsx" />
+    </div>
+    
+    <div class="col-xl-1 columnDivide d-none d-xl-block"></div>
+    
+    <div class="form-group col-xl-5">
+      <label class="label toggleHeader">(Optional)</label>
+      <div class="form-check form-switch mb-2">
+        <input class="form-check-input" type="checkbox" id="checkRSVP" name="isRsvpRequired" {{"checked" if eventData.isRsvpRequired}} />
+        <label class="form-check-label" for="checkRSVP"><strong>This event requires RSVP.</strong></label>
       </div>
+      <div class="form-group mb-3">
+        <div class="form-check form-switch">
+          {% set hide = "" if eventData.isRsvpRequired else "display: none" %}
+          <div class="form-group" id="limitGroup" style="{{hide}}">
+            <label class="form-label mt-2" for='limitRsvp'><strong>Attendance Limit</strong></label>
+            <input class="form-control mb-2" type="number" id="limitRsvp" name="rsvpLimit"
+              value="{{eventData.rsvpLimit}}" min="0" placeholder="No Limit" pattern="^[0-9]+$"></input>
+          </div>
+          <input class="form-check-input" type="checkbox" id="checkFood" name="isFoodProvided" {{"checked" if eventData.isFoodProvided}} />
+          <label class="custom-control-label" for="checkFood"><strong>This event will provide food.</strong></label>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endif %}
+<div class="form-group mb-5">
+  <label class="mb-2" for='attachmentObject'><strong>Add Files</strong></label>
+  <input type="file" class="form-control" id="attachmentObject" name="attachmentObject" multiple />
+</div>
+
       {% if filepaths %}
       <div class="form-group mb-5">
         {% from 'macros/displayFilesMacro.html' import displayFiles %}

--- a/app/templates/events/createEvent.html
+++ b/app/templates/events/createEvent.html
@@ -70,7 +70,7 @@
   <div class="form-group col-md-6">
     <label class="required form-label me-2" for="startDatePicker-{{pageLocation}}"><strong>Start Date</strong></label>
     <div class='input-group date startDate' id="startDate-{{pageLocation}}" data-page-location="{{pageLocation}}">
-      <input autocomplete="off" type='text' class="form-control datePicker startDatePicker readonly main"
+      <input autocomplete="off" type='text' class="form-control datePicker startDatePicker readonly main allV"
         value="{{ eventData.startDate.strftime('%Y/%m/%d') if eventData.startDate and eventData.startDate.strftime else eventData.startDate}}"
         name="startDate" placeholder="Pick a start date" id='startDatePicker-{{pageLocation}}Only'
         data-page-location="{{pageLocation}}" required>
@@ -130,7 +130,7 @@
       {% endif %}
       <div class="form-group mb-4">
         <label class="required form-label" for='inputEventName'><strong>Event Name</strong></label>
-        <input class="form-control needsValidation main allv" id='inputEventName' value="{{eventData.name}}" placeholder="Enter event name"
+        <input class="form-control needsValidation main allV" id='inputEventName' value="{{eventData.name}}" placeholder="Enter event name"
           name="name" required>
       </div>
       <div class="form-group mb-4">
@@ -247,32 +247,9 @@
       {% if page_title != 'Create All Volunteer Training' %}
       <div class="pt-4 mb-4">
         <div class="row">
-          <div class="form-group col-xl-5">
-            <label class="label toggleHeader">(Optional)</label>
-            <div class="form-check form-switch mb-2">
-              <label class="custom-control-label" for='checkRSVP'><strong>This event requires RSVP.</strong></label>
-              <input class="form-check-input" type="checkbox" id="checkRSVP" name="isRsvpRequired" {{"checked" if
-                eventData.isRsvpRequired}} />
-            </div>
-            <div class="form-group mb-3">
-              <div class="form-check form-switch">
-                {% set hide = "" if eventData.isRsvpRequired else "display: none" %}
-                <div class="form-group" id="limitGroup" style="{{hide}}">
-                  <label class="form-label mt-2" for='limitRsvp'><strong>Attendance Limit</strong></label>
-                  <input class="form-control mb-2" type="number" id="limitRsvp" name="rsvpLimit"
-                    value="{{eventData.rsvpLimit}}" min="0" placeholder="No Limit" pattern="^[0-9]+$"></input>
-                </div>
-                <label class="custom-control-label" for="checkFood"><strong>This event will provide
-                    food.</strong></label>
-                <input class="form-check-input" type="checkbox" id="checkFood" name="isFoodProvided" {{"checked" if
-                  eventData.isFoodProvided}} />
-              </div>
-            </div>
-          </div>
-          <div class="col-xl-1 columnDivide"></div>
-          <div class="form-group col-xl-6">
+            <div class="form-group col-xl-8">
             <label class="label required toggleHeader">(Must Select One)</label>
-            <div class="form-check form-switch">
+                <div class="form-check form-switch">
               <label class="custom-control-label" for="checkIsTraining"><strong>This event is a
                   training.</strong></label>
               <input class="form-check-input main series seriesWeekly" type="checkbox" id="checkIsTraining" name="isTraining" {{"checked" if eventData.isTraining}} />
@@ -294,10 +271,32 @@
                 eventData['program'].isBonnerScholars and not eventData.isService and not eventData.isTraining}} />
             </div>
             {% endif %}
-          </div>
-        </div>
       </div>
       {% endif %}
+      <div class="col-xl-1 columnDivide d-none d-xl-block" style="margin-left: -66px;"></div>       
+      <div class="form-group col-xl-5">
+            <label class="label toggleHeader">(Optional)</label>
+           <div class="form-check form-switch mb-2">
+              <input class="form-check-input" type="checkbox" id="checkRSVP" name="isRsvpRequired" ... />
+              <label class="form-check-label" for="checkRSVP"><strong>This event requires RSVP.</strong></label>
+            </div>
+            <div class="form-group mb-3">
+              <div class="form-check form-switch">
+                {% set hide = "" if eventData.isRsvpRequired else "display: none" %}
+                <div class="form-group" id="limitGroup" style="{{hide}}">
+                  <label class="form-label mt-2" for='limitRsvp'><strong>Attendance Limit</strong></label>
+                  <input class="form-control mb-2" type="number" id="limitRsvp" name="rsvpLimit"
+                    value="{{eventData.rsvpLimit}}" min="0" placeholder="No Limit" pattern="^[0-9]+$"></input>
+                </div>
+                <label class="custom-control-label" for="checkFood"><strong>This event will provide
+                    food.</strong></label>
+                <input class="form-check-input" type="checkbox" id="checkFood" name="isFoodProvided" {{"checked" if
+                  eventData.isFoodProvided}} />
+              </div>
+             </div>
+            </div>
+           </div>
+          </div>
       <div class="form-group mb-5">
         <label class="mb-2" for='attachmentObject'><strong>Add Files</strong></label>
         <input type="file" class="form-control" id="attachmentObject" name="attachmentObject" multiple

--- a/app/templates/events/createEvent.html
+++ b/app/templates/events/createEvent.html
@@ -349,7 +349,7 @@
       <div class="modal-footer justify-content-between">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
         <form action="/event/{{eventData.id}}/cancel" method='post'>
-          <button type="submit" class="btn btn-warning">Cancel Event</button>
+          <button type="submit" id ="cancelEvent" class="btn btn-warning">Cancel Event</button>
         </form>
       </div>
     </div>

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -319,8 +319,8 @@
                 <tr>
                   <th scope="col">Description</th>
                    {% if g.current_user.isCeltsAdmin%}
-                     <th scope="col">Status</th>
-                     <th scope="col">Date</th>
+                     <th class="required" scope="col">Status</th>
+                     <th class="required" scope="col">Date</th>
                      <th class="" id="displaySave" scope="col"></th>
                    {% endif %}
                  </tr>

--- a/app/templates/serviceLearning/slcProposal.html
+++ b/app/templates/serviceLearning/slcProposal.html
@@ -8,14 +8,15 @@
 <div class="container-fluid">
   <div class="row">
     <div class="p-2 col-md-6">
-      <label for="courseInstructor">Course Instructor(s)</label>
+       <label class= "required" for="courseInstructor">Course Instructor(s)</label>
       <input
         id="courseInstructor"
-        class="form-control"
+        class=" form-control"
         type="search"
         placeholder="Search instructor"
         data-tooltip="Click on an instructor to add them"
-        value="" />
+        value="" 
+        />
       <table
         class="table mb-1"
         id="instructorTable"
@@ -57,9 +58,10 @@
         <input hidden name="instructor[]" value='{{instructor.user.username}}'/>
         {% endfor %}
       </div>
-      <label for="courseName" class="pt-3">Course Name</label>
+      <label class= "required" for="courseName" class="pt-3">Course Name</label>
       <input
         class="form-control"
+        id="courseNameId" 
         name="courseName"
         type="text"
         value="{{course.courseName}}"


### PR DESCRIPTION
## Issue Description

Issue: #1385
All over CELTS different pages use different kind of flash messages. We have toasts, flash messages from flask, and flash messages from Javascript. They all behave differently and look differently. It would be a good idea to attempt to normalize these the best we can.

## Changes

The logic we used for implementing flashes and toasts and custom validity tags is that we are using toasts when we are on a Modal and we need updates, success, deletion messages popped up next to the modal. If there is a required field a custom Validity tag will show up.  We are using flashes for page reloads and anything that does not use a modal so the user will see the flash in the center of the page. We are using Custom validity tags for all required fields throughout the page.

this is a toast: 
![image](https://github.com/user-attachments/assets/5f3aaf04-35b5-4bce-8f5f-b3370c61d537)

This is a flash: 
![image](https://github.com/user-attachments/assets/3757ae61-5f51-4adf-8ae4-fa6c0910ad69)

This is a custom validity tag:
![image](https://github.com/user-attachments/assets/8dd5d921-db34-41da-b20d-1d3abbec3b25)


- Create Event page we added custom validity tags to all required fields. On the same page we changed the order of the (Must select one) and the optional boxes so the user can easily recognize the required fields 
- On my profile we added success, deletion messages for adding background checks, as well as for the notes section
- On my profile we created flashes for the changing of the phone number 
- Fixed all toast to be flash messages and added custom validity tag to Status and Date in Description
- On the proposal For Service-Learning Course page we created custom validity tags for the required fields.
- On Settings --> program management page --> edit manager, we added msg toast for Manager deletion. 
- On my profile --> Description, we added the required sign onto the status and date of background check 
- We added a timer to the toast 3 sec (you can test this by creating a note under My Profile --> Note --> save)

## Testing

- User Profile: When opening Background Check the status and the date are required fields and they now show custom validity tags. If bg check is deleted then we get flash message.
![image](https://github.com/user-attachments/assets/bc17d4ac-9765-43d8-aacb-2cd17c85e21a)
- Create Event pg: 
- All of the required fields will show a custom validity tag if not filled out. (asteris- shows required field). There are three main forms a user can fill out are All Volunteer Training, Bonnar scholar, and the rest of the other avaible forms. 
![image](https://github.com/user-attachments/assets/b85c5ce3-186a-4d20-b61a-f332eb5cb5c2)
- we added success and deletion messages for all of the specific pages in itself for the three main pages shown above. When a form is submitted or deleted or if there is an error. 
- we edited the series of events modal if the toggle is switched on:  Adding custom validity tags to the required fields. This functionality is also seen when on the modal and "this series repeats weekly is selected. 
- Under Admin settings: 
![image](https://github.com/user-attachments/assets/e636e851-1702-47b6-931c-eed29312c611)
-  if the removed button is pressed then a success flash will show up for deletion
- On the same page and under program management if Edit details or Edit managers is selected a success flash will show. On the Edit Managers Modal, if a manager is removed a toast will pop up.
![image](https://github.com/user-attachments/assets/b6e2fd5d-7cad-482d-b62b-8e09a56f1dca)
- On the CCE Minor Page 
![image](https://github.com/user-attachments/assets/c810d945-5fb5-4f59-9a42-b9bc5435e9a5)  if declare student button is pressed or you remove a student we added a Flash
![image](https://github.com/user-attachments/assets/68ce7eab-7871-4dbe-aac0-fd9452d345ae)




 

