### PR TITLE
#1560 Footer Issue

### DIFF
--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -104,7 +104,7 @@
   </div>
     {% endif %}
 {% endif %}
-</div>
+
 
 <!-- ################# Upcoming Events ################ -->
   <div class="accordion-item">


### PR DESCRIPTION
Issue Description 

Fixes #1560 
- the footer on User Profile page is misplaced, appearing in the center covering the accordion and its contents

Changes
- we found an extra div and deleted it 

Testing
- go to user profile page, and try opening accordions there  - the footer should be at the bottom of the page
- you can also switch the users' status: admin, student. etc. 
