### PR TITLE
Added a new filter for the labor history

### DIFF
--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -195,6 +195,7 @@
           </table>
         </div>
         <a class="btn btn-primary btn-sm" href="{{volunteer.username}}/serviceTranscript" > View Service Transcript</a>
+        <a class="btn btn-primary btn-sm" href="{{volunteer.username}}/laborHistory" > View Labor History</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Issue Description

Fixes #1576 
- Add a filter in the Participation history that shows labor history 

## Changes

- Added a HTML line that uses anchor tag and has the button name "View Labor History" in userProfile.html file

## Testing

- Go to CELTS Website and then go to 'My Profile'
- Click on the participation history accordion
- Now, you can see a button that shows "Labor history" next to the View Service Transcript

BEFORE

<img width="1480" height="403" alt="image" src="https://github.com/user-attachments/assets/d697b51c-5a02-4fa8-8ae8-c8e25f6c7d02" />

AFTER

<img width="1189" height="512" alt="Screenshot 2025-07-14 145610 (1)" src="https://github.com/user-attachments/assets/59d105de-d6cf-4c84-b739-12f74c174a50" />
