### PR TITLE
Added Placeholder for Insurance Information

### DIFF
--- a/app/templates/main/insuranceInfo.html
+++ b/app/templates/main/insuranceInfo.html
@@ -34,12 +34,12 @@
 
             <div class='form-group mb-4'>
                 <label class='form-label' for='name'><strong> Name of Policy Holder </strong></label>
-                <input {{'disabled' if readOnly else ''}} class='form-control' type='text' id='policyHolderName' name='policyHolderName' value="{{userInsuranceInfo.policyHolderName if userInsuranceInfo else ''}}"/>
+                <input {{'disabled' if readOnly else ''}} class='form-control' type='text' id='policyHolderName' placeholder= "e.g. Scott Heggen" name='policyHolderName' value="{{userInsuranceInfo.policyHolderName if userInsuranceInfo else ''}}"/>
             </div>
 
             <div class='form-group mb-4'>
                 <label class='form-label' for='relationship'><strong> Holder's Relationship to You </strong></label>
-                <input {{'disabled' if readOnly else ''}} class='form-control' type='text' id='policyHolderRelationship' name='policyHolderRelationship' value="{{userInsuranceInfo.policyHolderRelationship if userInsuranceInfo else ''}}"/>
+                <input {{'disabled' if readOnly else ''}} class='form-control' type='text' id='policyHolderRelationship' placeholder="e.g. Self or Parent "name='policyHolderRelationship' value="{{userInsuranceInfo.policyHolderRelationship if userInsuranceInfo else ''}}"/>
             </div>
         </div>
 
@@ -49,15 +49,15 @@
 
             <div class='form-group mb-4'>
                 <label class='form-label' for='insuranceCompany'><strong> Insurance Company </strong></label>
-                <input {{'disabled' if readOnly else ''}} class='form-control' type='text' id='insuranceCompany' name='insuranceCompany' value="{{userInsuranceInfo.insuranceCompany if userInsuranceInfo else ''}}"/>
+                <input {{'disabled' if readOnly else ''}} class='form-control' type='text' id='insuranceCompany' placeholder = "e.g. United Healthcare" name='insuranceCompany' value="{{userInsuranceInfo.insuranceCompany if userInsuranceInfo else ''}}"/>
             </div>
             <div class='form-group mb-4'>
                 <label class='form-label' for='policyNumber'><strong> Policy Number </strong></label>
-                <input {{'disabled' if readOnly else ''}} class='form-control' type='text' id='insurancePolicyNumber' name='policyNumber' value="{{userInsuranceInfo.policyNumber if userInsuranceInfo else ''}}"/>
+                <input {{'disabled' if readOnly else ''}} class='form-control' type='text' id='insurancePolicyNumber' placeholder="e.g. 123456789" name='policyNumber' value="{{userInsuranceInfo.policyNumber if userInsuranceInfo else ''}}"/>
             </div>
             <div class='form-group mb-4'>
                 <label class='form-label' for='groupNumber'><strong> Group Number (if applicable)</strong></label>
-                <input {{'disabled' if readOnly else ''}} class='form-control' type='text' id='insuranceGroupNumber' name='groupNumber' value="{{userInsuranceInfo.groupNumber if userInsuranceInfo else ''}}"/>
+                <input {{'disabled' if readOnly else ''}} class='form-control' type='text' id='insuranceGroupNumber' placeholder="e.g. GRP45678" name='groupNumber' value="{{userInsuranceInfo.groupNumber if userInsuranceInfo else ''}}"/>
             </div>
         </div>
 
@@ -65,7 +65,7 @@
         <!--Bottom-->
         <div class='form-group'>
             <label class='form-label' for='healthIssues'><strong> Please list any health issues that the Berea College CELTS program staff need to know about </strong></label>
-            <textarea {{'disabled' if readOnly else ''}} rows='8' class='form-control' type='text' id='additionalHealthIssues' name='healthIssues'>{{userInsuranceInfo.healthIssues}}</textarea>
+            <textarea {{'disabled' if readOnly else ''}} rows='8' class='form-control' type='text' id='additionalHealthIssues' placeholder="e.g. asthma, allergies, seizures, diabetes, none" name='healthIssues'>{{userInsuranceInfo.healthIssues}}</textarea>
         </div>
 
     </div>

--- a/app/templates/main/insuranceInfo.html
+++ b/app/templates/main/insuranceInfo.html
@@ -52,8 +52,8 @@
                 <input {{'disabled' if readOnly else ''}} class='form-control' type='text' id='insuranceCompany' placeholder = "e.g. United Healthcare" name='insuranceCompany' value="{{userInsuranceInfo.insuranceCompany if userInsuranceInfo else ''}}"/>
             </div>
             <div class='form-group mb-4'>
-                <label class='form-label' for='policyNumber'><strong> Policy Number </strong></label>
-                <input {{'disabled' if readOnly else ''}} class='form-control' type='text' id='insurancePolicyNumber' placeholder="e.g. 123456789" name='policyNumber' value="{{userInsuranceInfo.policyNumber if userInsuranceInfo else ''}}"/>
+                <label class='form-label' for='policyNumber'><strong> Policy Number / Member ID</strong></label>
+                <input {{'disabled' if readOnly else ''}} class='form-control' type='text' id='insurancePolicyNumber' placeholder="e.g. A3920993R" name='policyNumber' value="{{userInsuranceInfo.policyNumber if userInsuranceInfo else ''}}"/>
             </div>
             <div class='form-group mb-4'>
                 <label class='form-label' for='groupNumber'><strong> Group Number (if applicable)</strong></label>
@@ -65,7 +65,7 @@
         <!--Bottom-->
         <div class='form-group'>
             <label class='form-label' for='healthIssues'><strong> Please list any health issues that the Berea College CELTS program staff need to know about </strong></label>
-            <textarea {{'disabled' if readOnly else ''}} rows='8' class='form-control' type='text' id='additionalHealthIssues' placeholder="e.g. asthma, allergies, seizures, diabetes, none" name='healthIssues'>{{userInsuranceInfo.healthIssues}}</textarea>
+            <textarea {{'disabled' if readOnly else ''}} rows='8' class='form-control' type='text' id='additionalHealthIssues' placeholder="e.g. asthma, specific allergies, seizures, diabetes, none" name='healthIssues'>{{userInsuranceInfo.healthIssues}}</textarea>
         </div>
 
     </div>


### PR DESCRIPTION
## Issue Description

Fixes #1572
- Help students figure out what to input in insurance information by having default values

## Changes

- Added placeholder so that students can see what the input should look like while filling out the Insurance Information
- Add images, where possible, to provide more context to your changes.

## Testing

- Open the CELTS website and then on the Right Side you should see an Accordion that says "Choose an Action", click on it.
- With the variety of options you see in the Accordion, click on the "Edit Insurance Information"
- There, you should be able to see all the changes for the placeholder value that helps the student navigate while filling out the Insurance Information. 

*********BEFORE*******

<img width="1528" height="816" alt="image (1)" src="https://github.com/user-attachments/assets/115bfd6c-36fa-4bfb-8c71-2d29db4ead31" />

**********AFTER******** 

<img width="1543" height="811" alt="image" src="https://github.com/user-attachments/assets/346a9385-0380-4d01-a33b-61b327738dbe" />

