### PR TITLE
Logging Labor Management Events

### DIFF
--- a/app/controllers/admin/routes.py
+++ b/app/controllers/admin/routes.py
@@ -39,6 +39,7 @@ from app.logic.minor import getMinorInterest
 from app.logic.fileHandler import FileHandler
 from app.logic.bonner import getBonnerCohorts, makeBonnerXls, rsvpForBonnerCohort, addBonnerCohortToRsvpLog
 from app.logic.serviceLearningCourses import parseUploadedFile, saveCourseParticipantsToDatabase, unapprovedCourses, approvedCourses, getImportedCourses, getInstructorCourses, editImportedCourses
+from app.logic.createLogs import createRsvpLog
 
 from app.controllers.admin import admin_bp
 from app.logic.volunteerSpreadsheet import createSpreadsheet
@@ -753,10 +754,11 @@ def manageLaborPage(eventID):
 def removeLaborFromEvent():
     user = request.form.get('username')
     eventID = request.form.get('eventId')
+    fullName = request.form.get('fullName')
     if g.current_user.isAdmin:
         userInLaborTable = EventLabor.select(EventLabor, User).join(User).where(EventLabor.user == user, EventLabor.event==eventID).execute()
-        (EventLabor.delete().where(EventLabor.user==user, EventLabor.event==eventID)).execute()
         flash("Student successfully removed", "success")
+        createRsvpLog(eventID,f"Removed {fullName} from labor RSVP")
     return ""
 
 @admin_bp.route('/addLaborToEvent/<eventId>', methods = ['POST'])
@@ -788,6 +790,8 @@ def addLaborToEvent(eventId):
 
     if addedSuccessfullyList:
         studentLabor = ", ".join(vol for vol in addedSuccessfullyList)
+
+        createRsvpLog(eventId, f"Added {studentLabor} to labor RSVP")
         flash(f"{studentLabor} added successfully.", "success")
 
     if errorList:

--- a/app/static/js/manageLabor.js
+++ b/app/static/js/manageLabor.js
@@ -135,10 +135,12 @@ $(document).ready(function() {
     $(".removeLabor").prop("disabled", true)
     let username =  this.id;
     let eventId = $('#eventID').val()
+    let fullName = $(`#${username}FullName`).text();    
+
     $.ajax({
       url: '/removeLaborFromEvent',
       type: "POST",
-      data: {username: username, eventId: eventId},
+      data: {username: username, eventId: eventId, fullName: fullName,},
       success: function(response) {
          location.reload();
       },

--- a/app/templates/events/manageLabor.html
+++ b/app/templates/events/manageLabor.html
@@ -66,7 +66,7 @@
             <tr>
               <td>
                 <input class="form-control" type='hidden' name="username" id="{{participant.user.username}}" value="{{participant.user}}" />
-                <a href="/profile/{{participant.user}}">{{participant.user.firstName}} {{participant.user.lastName}}</a>
+                <a href="/profile/{{participant.user}}" id="{{participant.user.username}}FullName">{{participant.user.firstName}} {{participant.user.lastName}}</a>
                 {% if participant.user in bannedUsersForProgram %}
                   <a href="#" data-toggle="tooltip" data-placement="top" title="User is banned from this program.">
                     <span class="bi bi-x-circle-fill text-danger"></span>


### PR DESCRIPTION
## Issue Description

Fixes #1553 
Actions are not being logged into the log tab in the events page. It is only logging actions for bot labor management and volunteer management, but it is only logging for volunteer management. We need to fix that.

## Changes

- We add the managers actions in the labor management tab to appear in the log tab
- The actions from the labor tab are now stored in the database in eventRsvpLog table

## Testing

- Go to the CELTS website as an admin
- From the left side navigation panel, go to "create event" and create a new event for testing
- Go to events page and pull up the event you created. 
- From the navigation tabs in the event page, go to labor management (or manage labor)
- Try adding a new person, and then remove them
- Go to the log page. You should see the actions you did logged into the table