### PR TITLE
CCE minor redesign

### DIFF
--- a/app/logic/minor.py
+++ b/app/logic/minor.py
@@ -324,7 +324,7 @@ def getCommunityEngagementByTerm(username):
                                                                                        "id":event.program.id,
                                                                                        "type":"program",
                                                                                        "matched": event.matchedReq,
-                                                                                       "term":event.term.id
+                                                                                       "term":event.term.id,
                                                                                       })
 
     # sorting the communityEngagementByTermDict by the term id

--- a/app/logic/minor.py
+++ b/app/logic/minor.py
@@ -306,7 +306,8 @@ def getCommunityEngagementByTerm(username):
                  "id":course.id,
                  "type":"course",
                  "matched": course.matchedReq,
-                 "term":course.term.id})
+                 "term":course.term.id, 
+                 "courseAbbreviation": course.courseAbbreviation})
 
     programMatchCase = Case(None, [(IndividualRequirement.program.is_null(True) , 0)], 1)
 
@@ -324,7 +325,7 @@ def getCommunityEngagementByTerm(username):
                                                                                        "id":event.program.id,
                                                                                        "type":"program",
                                                                                        "matched": event.matchedReq,
-                                                                                       "term":event.term.id,
+                                                                                       "term":event.term.id                                                                                  
                                                                                       })
 
     # sorting the communityEngagementByTermDict by the term id

--- a/app/static/css/minor.css
+++ b/app/static/css/minor.css
@@ -18,5 +18,14 @@
 }
 
 .accordion-body {
-    padding-top: 0;
+    padding: 0px;
 }
+
+.container-fluid {
+    padding: 0px;
+}
+
+.btn {
+    padding: 11px;
+}
+

--- a/app/static/css/minor.css
+++ b/app/static/css/minor.css
@@ -2,3 +2,21 @@
     cursor: pointer;
     background-color: #f0f0f0;
 }
+
+.accordion-item {
+    padding-bottom: 3px;
+    padding-top: 3px;
+}
+
+.accordion-button {
+    font-size: 20px;
+    
+}
+
+.engagement-row {
+    text-align: left;
+}
+
+.accordion-body {
+    padding-top: 0;
+}

--- a/app/static/css/minor.css
+++ b/app/static/css/minor.css
@@ -12,7 +12,6 @@
     font-size: 20px;
     
 }
-
 .engagement-row {
     text-align: left;
 }
@@ -22,10 +21,20 @@
 }
 
 .container-fluid {
+    padding-right: 12px;
+} 
+
+.activity_section {
     padding: 0px;
+}
+
+.activity_info {
+    padding: 0px;
+    text-align: left;
 }
 
 .btn {
     padding: 11px;
 }
 
+ 

--- a/app/static/js/minorProfilePage.js
+++ b/app/static/js/minorProfilePage.js
@@ -68,6 +68,8 @@ function changeAction(action){
       toggleEngagementCredit($(this).is(':checked'), engagementData, this)
   });
 
+  
+
   // ************** END SUSTAINED COMMUNITY ENGAGEMENTS ************** //
 
   // ************** SUMMER EXPERIENCE ************** //
@@ -212,6 +214,8 @@ function showEngagementInformation(engagementInfoDict) {
       html.push("</div>")
       // modify the displayed html by joining together the list we have been pushing to
       $(`#set${term}`).html(html.join(""))
+      const myElement = document.getElementById(`set${term}`);
+      myElement.style.backgroundColor = "#F0F0F0"; // light gray background
     },
     error: function(request, status, error) {
       msgFlash("Error displaying information!", "danger")

--- a/app/static/js/minorProfilePage.js
+++ b/app/static/js/minorProfilePage.js
@@ -162,6 +162,7 @@ function changeAction(action){
 })
 
 function showEngagementInformation(engagementInfoDict) {
+  console.log(engagementInfoDict)
   let type = engagementInfoDict['type'],
       id = engagementInfoDict['id'],
       term= engagementInfoDict['term'];

--- a/app/templates/minor/profile.html
+++ b/app/templates/minor/profile.html
@@ -19,7 +19,7 @@
 {% block app_content %}
   <div class="row">
     <input id="username" value="{{ user.username }}" hidden />
-    <div name="Header" class="row text-center">
+    <div name="Header" class="row text-center mb-4"  >
       <h1>{{ user.firstName }} {{ user.lastName }}'s CCE Minor Profile</h1>
     </div>
     <div class="row">

--- a/app/templates/minor/sustainedCommunityEngagements.html
+++ b/app/templates/minor/sustainedCommunityEngagements.html
@@ -13,9 +13,9 @@
         </h3>
         <div id="collapse{{ loop.index }}" class="accordion-collapse collapse" aria-labelledby="heading{{ loop.index }}" data-bs-parent="#communityEngagement">
           <div class="accordion-body">
-            <div class="container-fluid col-25">
-              <div class="row d-flex justify-content-center mb-3">
-                <div class="col-md-6 mb-3">
+            <div class="container-fluid col-12">
+              <div class="accordion_info row d-flex justify-content-center">
+                <div class="activity_section col-md-6 mb-3">
                   <table class="table mb-3">
                     <tbody>
                       {% for engagement in engagements %}
@@ -29,7 +29,7 @@
                     </tbody>
                   </table>
                 </div>
-                <div class="col-md-6 p-3" id="set{{ term[1] }}">
+                <div class="activity_info col-md-6 p-3" id="set{{ term[1] }}">
                   Click on an engagement entry to see your event history or course information.
                 </div>
               </div>

--- a/app/templates/minor/sustainedCommunityEngagements.html
+++ b/app/templates/minor/sustainedCommunityEngagements.html
@@ -18,11 +18,18 @@
                 <div class="activity_section col-md-6 mb-3">
                   <table class="table mb-3">
                     <tbody>
+                      
                       {% for engagement in engagements %}
+
+                        {% if engagement['type'] == "course" %}
+                          {% set abbreviation = engagement['courseAbbreviation'] %}
+                        {% else %}
+                          {% set abbreviation = engagement['name'] %}
+                        {% endif %}
                       <tr class="engagement-row" data-engagement-data='{{ engagement|tojson }}'>
                         <td>
                           <input type="checkbox" {{ 'checked' if engagement['matched'] else '' }} />
-                          <button type="button" class="btn btn-link">{{ engagement[name]}}</button>
+                          <button type="button" class="btn btn-link">{{ abbreviation }}</button>
                         </td>
                       </tr>
                       {% endfor %}

--- a/app/templates/minor/sustainedCommunityEngagements.html
+++ b/app/templates/minor/sustainedCommunityEngagements.html
@@ -18,20 +18,23 @@
                 <div class="activity_section col-md-6 mb-3">
                   <table class="table mb-3">
                     <tbody>
-                      
-                      {% for engagement in engagements %}
 
-                        {% if engagement['type'] == "course" %}
-                          {% set abbreviation = engagement['courseAbbreviation'] %}
-                        {% else %}
-                          {% set abbreviation = engagement['name'] %}
+                      {% for engagement in engagements %}
+                        {% if engagement["type"] == "course" %}
+                          {% if engagement['courseAbbreviation'] == "" %}
+                              {% set test1 = engagement['name'] %}
+                          {% else %}
+                            {% set test1 = engagement['courseAbbreviation'] %}
+                          {% endif %}
+                        {% elif engagement["type"] == "program" %}
+                            {% set test1 = engagement['name'] %}
                         {% endif %}
-                      <tr class="engagement-row" data-engagement-data='{{ engagement|tojson }}'>
-                        <td>
-                          <input type="checkbox" {{ 'checked' if engagement['matched'] else '' }} />
-                          <button type="button" class="btn btn-link">{{ abbreviation }}</button>
-                        </td>
-                      </tr>
+                        <tr class="engagement-row" data-engagement-data='{{ engagement|tojson }}'>
+                          <td>
+                            <input type="checkbox" {{ 'checked' if engagement['matched'] else '' }} />
+                            <button type="button" class="btn btn-link">{{ test1 }}</button>
+                          </td>
+                        </tr>
                       {% endfor %}
                     </tbody>
                   </table>

--- a/app/templates/minor/sustainedCommunityEngagements.html
+++ b/app/templates/minor/sustainedCommunityEngagements.html
@@ -1,5 +1,7 @@
-<div class="tab-pane fade show {{ 'active' if activeTab == 'sustainedCommunityEngagements' or activeTab is not defined else '' }}" id="pills-sustainedCommunityEngagements" role="tabpanel" aria-labelledby="sustainedCommunityEngagements">
+
+<div class="tab-pane fade show {{ 'active' if activeTab == 'sustainedCommunityEngagements' or activeTab is not defined else '' }} text-center" id="pills-sustainedCommunityEngagements" role="tabpanel" aria-labelledby="sustainedCommunityEngagements">
     <p class="pt-2">Requires twenty hours of engagement over the ten weeks of a semester. Only two engagement activities can be credited in a single semester.</p>
+    <h3>Semesters:</h3>
     <div class="accordion" id="communityEngagement">
       {% if sustainedEngagementByTerm %}
       {% for term, engagements in sustainedEngagementByTerm.items() %}
@@ -11,15 +13,10 @@
         </h3>
         <div id="collapse{{ loop.index }}" class="accordion-collapse collapse" aria-labelledby="heading{{ loop.index }}" data-bs-parent="#communityEngagement">
           <div class="accordion-body">
-            <div class="container-fluid col-10">
+            <div class="container-fluid col-25">
               <div class="row d-flex justify-content-center mb-3">
                 <div class="col-md-6 mb-3">
                   <table class="table mb-3">
-                    <thead>
-                      <tr>
-                        <th scope="col">Community Engagement Activity</th>
-                      </tr>
-                    </thead>
                     <tbody>
                       {% for engagement in engagements %}
                       <tr class="engagement-row" data-engagement-data='{{ engagement|tojson }}'>

--- a/app/templates/minor/sustainedCommunityEngagements.html
+++ b/app/templates/minor/sustainedCommunityEngagements.html
@@ -22,7 +22,7 @@
                       <tr class="engagement-row" data-engagement-data='{{ engagement|tojson }}'>
                         <td>
                           <input type="checkbox" {{ 'checked' if engagement['matched'] else '' }} />
-                          <button type="button" class="btn btn-link">{{ engagement["name"] }}</button>
+                          <button type="button" class="btn btn-link">{{ engagement}}</button>
                         </td>
                       </tr>
                       {% endfor %}

--- a/app/templates/minor/sustainedCommunityEngagements.html
+++ b/app/templates/minor/sustainedCommunityEngagements.html
@@ -22,7 +22,7 @@
                       <tr class="engagement-row" data-engagement-data='{{ engagement|tojson }}'>
                         <td>
                           <input type="checkbox" {{ 'checked' if engagement['matched'] else '' }} />
-                          <button type="button" class="btn btn-link">{{ engagement}}</button>
+                          <button type="button" class="btn btn-link">{{ engagement[name]}}</button>
                         </td>
                       </tr>
                       {% endfor %}

--- a/tests/code/test_minor.py
+++ b/tests/code/test_minor.py
@@ -231,10 +231,11 @@ def test_getCommunityEngagementByTerm(testUser):
                                     isService = 1,
                                     startDate = "2021-12-12",
                                     isCanceled = False,
-                                    program = 1)        
+                                    program = 1,
+                                    )        
         
         testCourse = Course.create(courseName="test get course information",
-                                   courseAbbreviation="TGCI",
+                                   courseAbbreviation="TEST",
                                    sectionDesignation="something",
                                    courseCredit=1.0,
                                    term=3, # Summer 2021
@@ -254,7 +255,7 @@ def test_getCommunityEngagementByTerm(testUser):
         # write out what we expect the result to be as the getCommunityEngagementByTerm is suppose to return name, id, type, matched and term
         expectedServiceResult = OrderedDict({
                 ("Fall 2020", 1):[{"name":serviceEvent.program.programName, "id":serviceEvent.program.id, "type":"program", "matched": False, "term":serviceEvent.term.id}],
-                ("Summer 2021", 3):[{"name":serviceCourse.courseName, "id":serviceCourse.id, "type":"course", "matched": False, "term":serviceCourse.term.id}]})
+                ("Summer 2021", 3):[{"name":serviceCourse.courseName, "id":serviceCourse.id, "type":"course", "matched": False, "term":serviceCourse.term.id, "courseAbbreviation":serviceCourse.courseAbbreviation}]})
         
         # get the actual result from getCommunityEngagementByTerm
         actualServiceResult = getCommunityEngagementByTerm(testUser.username)
@@ -275,10 +276,11 @@ def test_getCommunityEngagementByTerm(testUser):
                                     isService = 0,
                                     startDate = "2021-1-1",
                                     isCanceled = False,
-                                    program = 2)
-        
+                                    program = 2,
+                                    )
+
         testCourse = Course.create(courseName="test get course information",
-                                courseAbbreviation="TGCI",
+                                courseAbbreviation="TEST",
                                 sectionDesignation="something",
                                 courseCredit=1.0,
                                 term=3,
@@ -298,12 +300,12 @@ def test_getCommunityEngagementByTerm(testUser):
         #This expected result is without the non-service event as the return value of getCommunityEngagementByTerm 
         #is suppose to return name, id, type, matched and term of events with only isService as True
         expectedNonServiceResult = OrderedDict({
-            ("Summer 2021", 3):[{"name":nonServiceCourse.courseName, "id":nonServiceCourse.id, "type":"course", "matched": False, "term":nonServiceCourse.term.id}]})
+            ("Summer 2021", 3):[{"name":nonServiceCourse.courseName, "id":nonServiceCourse.id, "type":"course", "matched": False, "term":nonServiceCourse.term.id, "courseAbbreviation":nonServiceCourse.courseAbbreviation}]})
         
         #This expected result is with the non-service event to test whether getCommunityEngagementByTerm is actualy returning only service events and courses
         unexpectedResultWithoutServiceEvent = OrderedDict({
             ("Spring 2021", 2):[{"name":nonServiceEvent.program.programName, "id":nonServiceEvent.program.id, "type":"program", "matched": False, "term":nonServiceEvent.term.id}],
-            ("Summer 2021", 3):[{"name":nonServiceCourse.courseName, "id":nonServiceCourse.id, "type":"course", "matched": False, "term":nonServiceCourse.term.id}]})
+            ("Summer 2021", 3):[{"name":nonServiceCourse.courseName, "id":nonServiceCourse.id, "type":"course", "matched": False, "term":nonServiceCourse.term.id, "courseAbbreviation":nonServiceCourse.courseAbbreviation}]})
         
         # get the actual result from getCommunityEngagementByTerm
         actualNonServiceResult = getCommunityEngagementByTerm(testUser.username)


### PR DESCRIPTION

Fixes #1573 
- redesigning minor profile page 

Changes
- how page looked before: 
<img width="1140" height="548" alt="Screenshot 2025-07-21 151244" src="https://github.com/user-attachments/assets/f70fc472-b635-4bf0-a262-ce6fdac1a930" />

- how it looks now: 
<img width="1896" height="898" alt="Screenshot 2025-07-21 151321" src="https://github.com/user-attachments/assets/11078bc8-8910-4a64-84ef-c69e73a77082" />

- what we changed:
- added/removed some padding where needed
- added the semesters heading for the accordions
- fixed the wording for the accordions 
- removed community engagement activity header 
- added course abbreviation to the getCommunityEngagementByTerm() to courses
- added the course abbreviation to any course that had one on the web page
- made programs just show up by their name 
- added a grey background to activity information 
- aligned elements accordingly 

Testing
- open up the CELTS website go to admin -> minor management
- click on Sreynit Khatt name
- open the accordions to see changes 