### PR TITLE
Cce minor management

### DIFF
--- a/app/static/css/minor.css
+++ b/app/static/css/minor.css
@@ -2,3 +2,22 @@
     cursor: pointer;
     background-color: #f0f0f0;
 }
+
+.dataTables_length {
+    float: right !important;
+}
+
+.dataTables_wrapper .dataTables_filter {
+    float: left !important;
+    text-align: left !important;
+}
+
+th {
+    padding: 10px 9px !important;
+}
+
+.paginate_button {
+    padding: 0.1em 0.5em !important;
+    margin-top: 5px !important;
+}
+

--- a/app/static/css/volunteerDetails.css
+++ b/app/static/css/volunteerDetails.css
@@ -29,7 +29,7 @@
         break-inside: avoid;
     }
 
-    .dataTables_info, .dataTables_length, .dataTables_filter, .dataTables_paginate {
+    .dataTables_info, .dataTables_filter, .dataTables_length, .dataTables_paginate {
         display:none;
     }  
 

--- a/app/templates/admin/cceMinor.html
+++ b/app/templates/admin/cceMinor.html
@@ -130,7 +130,7 @@
             <ul 
               class="list-unstyled mx-3 mt-2" id= "interestedStudentList">
             </ul>
-          <div class="modal-footer d-flex justify-content-between align-items-center p-2">
+          <div class="modal-footer d-flex justify-content-between align-items-center">
             <button type="button" class="btn btn-secondary me-auto" data-bs-dismiss="modal">Close</button>
             <button id="addInterestedStudentsbtn" type="submit" class="btn btn-success" disabled>Add Students</button>
           </div>

--- a/app/templates/admin/cceMinor.html
+++ b/app/templates/admin/cceMinor.html
@@ -10,6 +10,7 @@
     {{super()}}
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.11.3/css/jquery.dataTables.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+     <link rel="stylesheet" href="{{ url_for('static', filename='css/minor.css') }}?u={{ lastStaticUpdate }}">
   {% endblock %}
 {% endblock %}
 {% block app_content %}


### PR DESCRIPTION

Fixes #1573 
- we had to redesign the minor management  page 

 Changes
linked the minor.css file with cceMinor.html file, and did all the style related changes in css file
changed the positioning of “search” and “show 10 entries” by switching them 
changed the padding of table.data th to make the headers inside the table “CCE Minor Progress” aligned (10px 9px) 
changed the padding for the “previous 1 next button” (made it smaller)
added !important to override bootstrap 

Testing
- go to celts - admin  - minor management - and see the page redesign