### PR TITLE
Save button now will always be visible on the create event page.

### DIFF
--- a/app/static/css/createEvent.css
+++ b/app/static/css/createEvent.css
@@ -55,3 +55,8 @@
     background-color: #fff
   }
 
+.fixedButton {
+    position: fixed;
+    right: 1.5rem;
+    bottom: 1.5rem;
+}

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -167,6 +167,23 @@ function verifyRepeatingFields(){
   return isEmpty
 }
 
+/*
+ * Update the position of the Save button so that it is always on the screen as 
+ * the window scrolls and changes size. The position on the screen is determined 
+ * in the fixedButton class */
+const saveBtn = $('#saveButton');
+function updateSavePosition() {
+  const originalTop = saveBtn.parent()[0].getBoundingClientRect().top; // relative to scroll
+  const buttonHeight = 40;
+
+  if ($(window).height() < originalTop + buttonHeight) {
+    saveBtn.addClass('fixedButton');
+  } else {
+    saveBtn.removeClass('fixedButton');
+  }
+}
+$(window).on('scroll resize load', updateSavePosition);
+
 $('#saveSeries').on('click', function(e) {
   e.preventDefault(); // Prevent default form submission at the start
   enableLiveCustomValidityClearing([".multipleOfferingNameField"])
@@ -393,6 +410,9 @@ function updateOfferingsTable() {
                                   "</tr>"
                                 );
   });
+
+  //recalculate the save button
+  updateSavePosition()
 }
 
 //visual date formatting for multi-event table
@@ -800,7 +820,6 @@ function handleTimeFormatting(timeArray){
   setCharacterLimit($("#inputCharacters"), "#remainingCharacters"); 
   
 });
-
 
 
 

--- a/app/templates/events/createEvent.html
+++ b/app/templates/events/createEvent.html
@@ -322,7 +322,7 @@
         <button type="button" class="btn btn-success" data-bs-toggle="modal" data-bs-target="#renewWarning">Renew
           Event</button>
         {% endif %}
-        <input type="button" class="btn btn-primary saveBtn" id="saveButton" value="Save" />
+        <input type="button" class="btn btn-primary" id="saveButton" value="Save" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
Starting point was https://github.com/BCStudentSoftwareDevTeam/celts/pull/1556/files

## Issue Description

Fixes #1444 
The save button sometimes is bumped off of the page and it would be nice for it to always be visible.

## Changes

- The save button will now be visible in the lower right corner of the page when it would otherwise have been outside of the viewing window.

## Testing

- Resize the width and height of the create event page, and the Save button should always be visible, either on the lower right, or in its original location
- Also test with a long list of files or a large event series