### PR TITLE
The language has been changed to prevent confusion

### DIFF
--- a/app/templates/events/eventKiosk.html
+++ b/app/templates/events/eventKiosk.html
@@ -15,6 +15,18 @@
     <!--<button onclick="openFullscreen();">Open Video in Fullscreen Mode</button>-->
     <div>
       <h1 class="my-5" align="center">{{ event.name }}</h1>
+      {% if event.isService or event.program_id == 5 %}
+      <h3 class="text-danger" align="center">Attention</h3>
+      {% endif %}
+      {% if event.isService %}
+      <p align="center">
+        I understand that I am participating in this activity as a volunteer, that it is not part of my Work-Learning-Service (WLS) role, that I will not receive compensation, and that I am choosing to engage in this activity for service-learning or personal enrichment.
+      </p>
+      {% elif event.program_id == 5%}
+      <p align="center">
+        I acknowledge that when I sign in to this event, I am fulfilling a requirement for my Bonner Scholarship, and I am not clocked in for my labor position.
+      </p>
+      {% endif %}
       <h2 class="m-5" align="center">{{ bNumberToUser }}</h2>
     </div>
     <div id="signinData" class="mx-auto px-5 mb-2">

--- a/app/templates/events/eventView.html
+++ b/app/templates/events/eventView.html
@@ -86,6 +86,8 @@
                     {% endif %}
                     {% if eventData.isService %}
                         <p>This event earns service hours.</p>
+                        <h4 class="text-danger">Attention</h4>
+                        <p>Participating in this activity means that you are a volunteer, that it is not part of your Work-Learning-Service (WLS) role, that you will not receive compensation, and that you are choosing to engage in this activity for service-learning or personal enrichment.</p>
                     {% else %}
                         <p>This event does not earn service hours.</p>
                     {% endif %}


### PR DESCRIPTION
## Issue Description

Fixes #1606
- link to trello: https://trello.com/c/TdJcoB18
- Event Creation: When "This Event earns service hours" is selected, add the acknowledgement: "I understand that I am participating in this activity as a volunteer…" to the event description.
-Kiosk Display: Ensure the acknowledgement text appears directly under the event title on the kiosk entry page so that all volunteers/Bonner Scholars see it before signing in.
-Bonner Events: When "This Event is a Bonner requirement" is toggled, display: "I acknowledge that when I sign in to this event, I am fulfilling a requirement for my Bonner Scholarship, and I am not clocked in for my labor position."

## Changes
- On the eventView.html page we have added the Attention in red and if it is service or Bonner it will show it's corresponding statement 
- On the eventKiosk.html page we have added the Attention in red and if it is service or Bonner it will show it's corresponding statement underneath the event title.

## Testing
- No testing as this is purely front-end rendering

## PR review
- Checkout the branch `git checkout correctVolunteerLanguage`
- Pull the code when you are in the branch `git pull`
- Reset the database `database/reset_database.sh test`
- Run the test suite to make sure all the tests are working `tests/run_tests.sh`
- Run the application `flask run`
- Navigate to the sidebar and go to create event to create an event and toggle service event
- Then when the event page is in view go to "Manage Volunteers" and click on "Kiosk Entry" button.
- As it is the service event it should show an acknowledgement for service event.
- Repeat the same steps to create a Bonner event by going to Create Event > Bonner Scholars > create it (the toggle for Bonner is already toggled) > click create event and go to " Manage Volunteers" > click "Kiosk Entry"
- As it is the Bonner event it should show an acknowledgement for Bonner event.
- You will also see similar acknowledgments when you view them in the specific event page too.

##Image of the changes
-Bonner acknowledgement
<img width="1382" height="410" alt="image" src="https://github.com/user-attachments/assets/80ff718b-29d3-4c63-93db-1701f36a7b53" />
- Service volunteer acknowledgement on Kiosk Entry and event view
<img width="1288" height="440" alt="image" src="https://github.com/user-attachments/assets/0f3e20a7-c3f5-4e01-b324-1734606e8b5c" />
<img width="1417" height="616" alt="image" src="https://github.com/user-attachments/assets/03d159db-7c4d-4c67-ad81-8beba5777e85" />


