### PR TITLE
Fixed issue with syncing hours on service transcript and spreasheet

### DIFF
--- a/app/logic/transcript.py
+++ b/app/logic/transcript.py
@@ -18,12 +18,16 @@ def getProgramTranscript(username):
     """
     # Add up hours earned in a term for each program they've participated in
 
+    print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
     EventData = (Event.select(Event, fn.SUM(EventParticipant.hoursEarned).alias("hoursEarned"))
                       .join(EventParticipant)
-                      .where((EventParticipant.user == username) & (Event.deletionDate == None))
+                      .where((EventParticipant.user == username) & (Event.deletionDate == None)
+                             & (Event.isService == True) & (Event.isCanceled == False) & (Event.isTraining == False))
                       .group_by(Event.program, Event.term)
                       .order_by(Event.term)
                       .having(fn.SUM(EventParticipant.hoursEarned > 0)))
+
+    print(EventData)
 
     # Fetch all ProgramBan objects for the user
     bannedProgramsForParticipant = ProgramBan.select().where(ProgramBan.user == username)

--- a/app/logic/transcript.py
+++ b/app/logic/transcript.py
@@ -18,7 +18,6 @@ def getProgramTranscript(username):
     """
     # Add up hours earned in a term for each program they've participated in
 
-    print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
     EventData = (Event.select(Event, fn.SUM(EventParticipant.hoursEarned).alias("hoursEarned"))
                       .join(EventParticipant)
                       .where((EventParticipant.user == username) & (Event.deletionDate == None)
@@ -26,8 +25,6 @@ def getProgramTranscript(username):
                       .group_by(Event.program, Event.term)
                       .order_by(Event.term)
                       .having(fn.SUM(EventParticipant.hoursEarned > 0)))
-
-    print(EventData)
 
     # Fetch all ProgramBan objects for the user
     bannedProgramsForParticipant = ProgramBan.select().where(ProgramBan.user == username)

--- a/app/logic/volunteerSpreadsheet.py
+++ b/app/logic/volunteerSpreadsheet.py
@@ -38,7 +38,8 @@ def totalVolunteerHours(academicYear):
     query = (EventParticipant.select(fn.SUM(EventParticipant.hoursEarned))
                              .join(Event, on=(EventParticipant.event == Event.id))
                              .join(Term, on=(Event.term == Term.id))
-                             .where(Term.academicYear == academicYear)
+                             .where((Term.academicYear == academicYear) & (Event.deletionDate == None)
+                                    & (Event.isService == True) & (Event.isCanceled == False) & (Event.isTraining == False))
              )
 
     return query.tuples()
@@ -49,7 +50,8 @@ def volunteerProgramHours(academicYear):
                              .join(Event, on=(EventParticipant.event_id == Event.id))
                              .join(Program, on=(Event.program_id == Program.id))
                              .join(Term, on=(Event.term == Term.id))
-                             .where(Term.academicYear == academicYear)
+                             .where((Term.academicYear == academicYear) & (Event.deletionDate == None)
+                                    & (Event.isService == True) & (Event.isCanceled == False) & (Event.isTraining == False))
                              .group_by(Program.programName, EventParticipant.user_id))
 
     return volunteerProgramHours.tuples()


### PR DESCRIPTION
## Issue Description

Fixes #1617 
- There are hours in the reports spreadsheet that exceed for some students compared to their hours on their service transcript

## Changes

- Now we are checking if events are not cancelled, and they are not trainings, and not deleted for all events that earn service hours in the transcript and spreadsheet for volunteers

## Testing

- In production db, check the user collinsc2, view hours at their service transcript
- Go to reports and download reports for AY 2024-2025, and check volunteer hours for collinsc2
- The hours in the reports spreadsheet and on the user's transcript should reflect the same number