### PR TITLE
Reports

### DIFF
--- a/app/logic/volunteerSpreadsheet.py
+++ b/app/logic/volunteerSpreadsheet.py
@@ -59,13 +59,13 @@ def onlyCompletedAllVolunteer(academicYear):
     subQuery = (EventParticipant.select(EventParticipant.user_id)
                 .join(Event)
                 .join(Term)
-                .where(Event.name != "All Volunteer Training", Term.academicYear == academicYear & (Event.isService == True)))
+                .where((Event.name != "All Volunteer Training") & (Term.academicYear == academicYear) & (Event.isService == True)))
 
     onlyAllVolunteer = (EventParticipant.select(EventParticipant.user_id, fn.CONCAT(User.firstName, " ", User.lastName))
                         .join(User).switch(EventParticipant)
                         .join(Event)
                         .join(Term)
-                        .where(Event.name == "All Volunteer Training", Term.academicYear == academicYear & (Event.isService == True), EventParticipant.user_id.not_in(subQuery)))
+                        .where((Event.name == "All Volunteer Training") & (Term.academicYear == academicYear) & (Event.isService == True) & (EventParticipant.user_id.not_in(subQuery))))
 
     return onlyAllVolunteer.tuples()
 

--- a/app/logic/volunteerSpreadsheet.py
+++ b/app/logic/volunteerSpreadsheet.py
@@ -17,7 +17,7 @@ def getUniqueVolunteers(academicYear):
                         .join(User).switch(EventParticipant)
                         .join(Event)
                         .join(Term)
-                        .where(Term.academicYear == academicYear)
+                        .where((Term.academicYear == academicYear) & (Event.isService == True))
                         .order_by(EventParticipant.user_id))
 
     return uniqueVolunteers.tuples()
@@ -38,7 +38,7 @@ def totalVolunteerHours(academicYear):
     query = (EventParticipant.select(fn.SUM(EventParticipant.hoursEarned))
                              .join(Event, on=(EventParticipant.event == Event.id))
                              .join(Term, on=(Event.term == Term.id))
-                             .where(Term.academicYear == academicYear) & (Event.isService == True)
+                             .where((Term.academicYear == academicYear) & (Event.isService == True))
              )
 
     return query.tuples()
@@ -49,7 +49,7 @@ def volunteerProgramHours(academicYear):
                              .join(Event, on=(EventParticipant.event_id == Event.id))
                              .join(Program, on=(Event.program_id == Program.id))
                              .join(Term, on=(Event.term == Term.id))
-                             .where(Term.academicYear == academicYear)
+                             .where((Term.academicYear == academicYear) & (Event.isService == True))
                              .group_by(Program.programName, EventParticipant.user_id))
 
     return volunteerProgramHours.tuples()
@@ -59,13 +59,13 @@ def onlyCompletedAllVolunteer(academicYear):
     subQuery = (EventParticipant.select(EventParticipant.user_id)
                 .join(Event)
                 .join(Term)
-                .where(Event.name != "All Volunteer Training", Term.academicYear == academicYear))
+                .where(Event.name != "All Volunteer Training", Term.academicYear == academicYear & (Event.isService == True)))
 
     onlyAllVolunteer = (EventParticipant.select(EventParticipant.user_id, fn.CONCAT(User.firstName, " ", User.lastName))
                         .join(User).switch(EventParticipant)
                         .join(Event)
                         .join(Term)
-                        .where(Event.name == "All Volunteer Training", Term.academicYear == academicYear, EventParticipant.user_id.not_in(subQuery)))
+                        .where(Event.name == "All Volunteer Training", Term.academicYear == academicYear & (Event.isService == True), EventParticipant.user_id.not_in(subQuery)))
 
     return onlyAllVolunteer.tuples()
 
@@ -75,7 +75,7 @@ def volunteerHoursByProgram(academicYear):
              .join(Event)
              .join(EventParticipant, on=(Event.id == EventParticipant.event_id))
              .join(Term, on=(Term.id == Event.term))
-             .where(Term.academicYear == academicYear)
+             .where((Term.academicYear == academicYear) & (Event.isService == True))
              .group_by(Program.programName)
              .order_by(Program.programName))
 
@@ -87,7 +87,7 @@ def volunteerMajorAndClass(academicYear, column, reorderClassLevel=False):
                      .join(EventParticipant, on=(User.username == EventParticipant.user_id))
                      .join(Event, on=(EventParticipant.event_id == Event.id))
                      .join(Term, on=(Event.term == Term.id))
-                     .where(Term.academicYear == academicYear)
+                     .where((Term.academicYear == academicYear) & (Event.isService == True))
                      .group_by(column))
 
     if reorderClassLevel:
@@ -113,7 +113,7 @@ def repeatVolunteersPerProgram(academicYear):
                              .join(Program, on=(Event.program == Program.id))
                              .join(User, on=(User.username == EventParticipant.user_id))
                              .join(Term, on=(Event.term == Term.id))
-                             .where(Term.academicYear == academicYear)  
+                             .where((Term.academicYear == academicYear) & (Event.isService == True))
                              .group_by(User.firstName, User.lastName, Event.program)
                              .having(fn.COUNT(EventParticipant.event_id) > 1)
                              .order_by(Event.program, User.lastName))
@@ -126,7 +126,7 @@ def repeatVolunteers(academicYear):
                              .join(User, on=(User.username == EventParticipant.user_id))
                              .join(Event, on=(EventParticipant.event == Event.id))
                              .join(Term, on=(Event.term == Term.id))
-                             .where(Term.academicYear == academicYear)
+                             .where((Term.academicYear == academicYear) & (Event.isService == True))
                              .group_by(User.firstName, User.lastName)
                              .having(fn.COUNT(EventParticipant.user_id) > 1))
 

--- a/app/logic/volunteerSpreadsheet.py
+++ b/app/logic/volunteerSpreadsheet.py
@@ -38,7 +38,7 @@ def totalVolunteerHours(academicYear):
     query = (EventParticipant.select(fn.SUM(EventParticipant.hoursEarned))
                              .join(Event, on=(EventParticipant.event == Event.id))
                              .join(Term, on=(Event.term == Term.id))
-                             .where(Term.academicYear == academicYear)
+                             .where(Term.academicYear == academicYear) & (Event.isService == True)
              )
 
     return query.tuples()

--- a/tests/code/test_spreadsheet.py
+++ b/tests/code/test_spreadsheet.py
@@ -22,10 +22,10 @@ def fixture_info():
         program3 = Program.create(id=503, programName='Program3')
         program4 = Program.create(id=504, programName='Program4')
 
-        event1 = Event.create(id=501, name='Event1', term=term1, program=program1)
-        event2 = Event.create(id=502, name='Event2', term=term1, program=program2)
-        event3 = Event.create(id=503, name='Event3', term=term1, program=program3)
-        event4 = Event.create(id=504, name='Event4', term=term2, program=program4)
+        event1 = Event.create(id=501, name='Event1', term=term1, program=program1, isService=True)
+        event2 = Event.create(id=502, name='Event2', term=term1, program=program2, isService=True)
+        event3 = Event.create(id=503, name='Event3', term=term1, program=program3, isService=True)
+        event4 = Event.create(id=504, name='Event4', term=term2, program=program4, isService=True)
 
         eventparticipant1 = EventParticipant.create(event=event1, user=user1, hoursEarned=5)
         eventparticipant2 = EventParticipant.create(event=event1, user=user2, hoursEarned=3)
@@ -138,7 +138,7 @@ def test_repeatVolunteers(fixture_info):
     #repeat volunteers people who participated in more than one event
     testEvent = Event.create(name="Test Event",
                                 term=fixture_info["term1"],
-                                program=fixture_info['program1'])
+                                program=fixture_info['program1'], isService=True)
     EventParticipant.create(user='doej',
                             event=testEvent,
                             hoursEarned=1)
@@ -148,16 +148,16 @@ def test_repeatVolunteers(fixture_info):
 
     testEvent2 = Event.create(name="Spring2021Event",
                                 term=fixture_info["term1"],
-                                program=fixture_info['program1'])
-    
-    EventParticipant.create(user = 'doej', event = testEvent2, hoursEarned=0)
-    
+                                program=fixture_info['program1'], isService=True)
+
+    EventParticipant.create(user='doej', event=testEvent2, hoursEarned=0)
+
     # Check for separate events
     assert sorted(list(repeatVolunteers("2023-2024"))) == [('John Doe', 3)]
 
     testEvent2 = Event.create(name="Spring2021Event",
                                 term=fixture_info["term1"],
-                                program=fixture_info['program2'])
+                                program=fixture_info['program2'], isService=True)
     EventParticipant.create(user='doej', 
                             event=testEvent2,
                             hoursEarned=1)
@@ -172,7 +172,7 @@ def test_repeatVolunteersPerProgram(fixture_info):
     
     testEvent3 = Event.create(name="Test Event",
                                 term=fixture_info['term1'], 
-                                program=fixture_info['program1'])
+                                program=fixture_info['program1'], isService=True)
     EventParticipant.create(user='doej',
                             event=testEvent3,
                             hoursEarned=1)
@@ -182,7 +182,7 @@ def test_repeatVolunteersPerProgram(fixture_info):
 
     testEvent4 = Event.create(name="Test Event 2",
                                 term=fixture_info['term1'], 
-                                program=fixture_info['program1'])
+                                program=fixture_info['program1'], isService=True)
     EventParticipant2 = EventParticipant.create(user='doej',
                                                 event=testEvent4,
                                                 hoursEarned=1)
@@ -240,7 +240,7 @@ def test_onlyCompletedAllVolunteer(fixture_info):
                                 term=fixture_info['term1'],
                                 program=fixture_info['program1'],
                                 isTraining=1,
-                                isAllVolunteerTraining=1)
+                                isAllVolunteerTraining=1, isService=True)
     EventParticipant.create(user = 'builderb', # Not participated in event
                             event = allVolunteerEvent, # Added to all volunteer training event
                             hoursEarned = 1)
@@ -250,7 +250,7 @@ def test_onlyCompletedAllVolunteer(fixture_info):
 
     testEvent = Event.create(name="Test Event",
                                 program=fixture_info['program1'],
-                                term=fixture_info['term1'])
+                                term=fixture_info['term1'], isService=True)
     EventParticipant.create(user = 'builderb', # Only participated in all volunteer event
                             event = testEvent,
                             hoursEarned = 1)
@@ -273,7 +273,7 @@ def test_volunteerProgramHours(fixture_info):
     
     testEvent = Event.create(name="Test Event",
                                 program=fixture_info['program1'],
-                                term=fixture_info['term1'])
+                                term=fixture_info['term1'], isService=True)
     EventParticipant.create(user = 'doej',
                             event = testEvent,
                             hoursEarned = 2)
@@ -366,7 +366,7 @@ def test_getUniqueVolunteers(fixture_info):
     User.create(username="testt", firstName="Test", lastName="Tester", bnumber="B55555")
     testEvent = Event.create(name="Test Event",
                                 term = fixture_info['term1'],
-                                program = fixture_info['program1'])
+                                program = fixture_info['program1'], isService=True)
     EventParticipant.create(user = 'testt',    
                             event = testEvent,
                             hoursEarned = 1)


### PR DESCRIPTION

Fixes #1618 
Remove labor meeting and bonner hours from volunteer hours generated. 

## Changes

- Added the isService condition to all the volunteers data. 

## Testing
- Go to Create Event
- When you create a Bonner event and add hours, they don't show up on the reports

<img width="1915" height="1077" alt="Screenshot 2025-09-05 130150" src="https://github.com/user-attachments/assets/04a8e54b-3924-4ca3-a6c2-11305f58e289" />

- When you add another program with the tag "earns service credit" then the hours and event name and other details should show up in the report. 

<img width="1908" height="1066" alt="Screenshot 2025-09-05 130136" src="https://github.com/user-attachments/assets/4a1027b3-50e6-4396-b72c-0a3a5d8985d4" />
