### PR TITLE
Frequency and name required

### DIFF
--- a/app/static/js/bonnerManagement.js
+++ b/app/static/js/bonnerManagement.js
@@ -218,12 +218,10 @@ function addRequirementsRowHandlers() {
     $(".frequency-select").change();
     // add this one after we trigger the first change event
     $(".frequency-select").change(function(e) {
-        enableSave();
     });
 
     // detect changes so we can enable saving
     $(".required-select").change(function(e) {
-        enableSave();
     });
     $("#requirements input").on("input blur", function(e) {
         if($(this).val() == "") {

--- a/app/static/js/bonnerManagement.js
+++ b/app/static/js/bonnerManagement.js
@@ -225,7 +225,7 @@ function addRequirementsRowHandlers() {
     $(".required-select").change(function(e) {
         enableSave();
     });
-    $("#requirements input").on("input blur",function(e) {
+    $("#requirements input").on("input blur", function(e) {
         if($(this).val() == "") {
             this.setCustomValidity('Please enter a name.');
             this.reportValidity();

--- a/app/static/js/bonnerManagement.js
+++ b/app/static/js/bonnerManagement.js
@@ -225,6 +225,22 @@ function addRequirementsRowHandlers() {
     $(".required-select").change(function(e) {
         enableSave();
     });
+    $("#requirements input").on("input blur",function(e) {
+        if($(this).val() == "") {
+            this.setCustomValidity('Please enter a name.');
+            this.reportValidity();
+            $(".saveBtn").attr("disabled", "disabled");
+            $("#reqAdd").attr("disabled", "disabled");
+        } else {
+            $(".saveBtn").removeAttr("disabled");
+            $("#reqAdd").removeAttr("disabled");
+            this.setCustomValidity('');
+            this.reportValidity();
+            enableSave();
+        }
+    });
+
+    
 
     // handle invalid and valid entries
     $("#requirements input").keyup(function(e) {

--- a/app/templates/admin/bonnerManagement.html
+++ b/app/templates/admin/bonnerManagement.html
@@ -147,7 +147,6 @@
                         </td>
                         <td>
                             <select class="flex-column form-select empty frequency-select" name="frequency_{{req.id}}">
-                                <option value="" {{ "selected" if not req.frequency else "" }}>Frequency</option>
                                 <option value="once" {{ "selected" if req.frequency == "once" else "" }}>Once</option>
                                 <option value="annual" {{ "selected" if req.frequency == "annual" else "" }}>Annual</option>
                                 <option value="term" {{ "selected" if req.frequency == "term" else "" }}>Every Term</option>


### PR DESCRIPTION
Enforce Required Frequency on Bonner Requirements

Fixes #1468 
- People were able to select an empty frequency 
- People were able to save an empty name

## Changes

- Implemented validity tag for the name field
- Removed the empty frequency option 

<img width="1905" height="1074" alt="image" src="https://github.com/user-attachments/assets/3e3c4395-0672-4cec-95f5-8a4fda2d28eb" />


## Testing

- Go to admin
- Select bonner management then requirements
- try to save a requirement with an empty name - you should normally see a validity tag.
- it is no longer possible to save requirement without frequency, there will be a default of 'once' that the person can change if they wish to