### PR TITLE
Added Edit Functionality to Notes on User Profile

### DIFF
--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -397,6 +397,51 @@ def deleteNote(username):
         flash("Failed to delete profile note", "danger")
     return "success"
 
+@main_bp.route('/<username>/editNote', methods=['POST'])
+def editProfileNote(username):
+    """
+    Edit an existing profile note.
+    """
+    profile_note_id = request.form.get('id')
+    new_text = (request.form.get('noteTextbox') or '').strip()
+    visibility = request.form.get('visibility')  # optional
+    bonner = request.form.get('bonner')          # optional
+
+    if not profile_note_id or not new_text:
+        return jsonify({"error": "Missing note id or content"}), 400
+
+    try:
+        pn = ProfileNote.get_by_id(profile_note_id)
+    except DoesNotExist:
+        return jsonify({"error": "ProfileNote not found"}), 404
+
+    # Ensure the note we are editing belongs to the profile in the URL
+    if pn.user.username != username:
+        abort(403)
+
+    # Only the creator OR an admin may edit the note
+    if (pn.note.createdBy != g.current_user) and (not g.current_user.isCeltsAdmin):
+        abort(403)
+
+    # Update the note text
+    pn.note.noteContent = new_text
+    pn.note.save()
+
+    # Optionally update visibility and bonner flag
+    if visibility is not None and visibility != '':
+        try:
+            pn.viewTier = int(visibility)
+        except ValueError:
+            return jsonify({"error": "Invalid visibility value"}), 400
+
+    if bonner is not None:
+        pn.isBonnerNote = (bonner == "yes")
+
+    pn.save()
+
+    flash("Successfully updated profile note", "success")
+    return jsonify({"status": "ok"})
+
 # ===========================Ban===============================================
 @main_bp.route('/<username>/ban/<program_id>', methods=['POST'])
 def ban(program_id, username):

--- a/app/static/js/userProfile.js
+++ b/app/static/js/userProfile.js
@@ -230,6 +230,99 @@ $(document).ready(function(){
     });
   });
 
+   /* =========================
+   * NOTES: Edit functionality
+   * ========================= */
+
+  // Open the Edit Note modal and prefill fields
+  $("#profileTable").on("click", ".editNoteButton", function () {
+    const noteId   = $(this).data("noteid");
+    const username = $(this).data("username");
+    const content  = $(this).data("content") || "";
+    const viewTier = String($(this).data("viewtier") || "");
+    const isBonner = (($(this).data("isbonner") || "") === "yes");
+
+    // Hidden fields
+    $("#editNoteId").val(noteId);
+    $("#editNoteUsername").val(username);
+
+    // Text
+    $("#editNoteTextArea").val(content);
+
+    // Visibility (if present for this user)
+    const $vis = $("#editNoteVisibility");
+    if ($vis.length) {
+      if ($vis.find(`option[value="${viewTier}"]`).length) {
+        $vis.val(viewTier);
+      } else {
+        $vis.val("1");
+      }
+    }
+
+    // Bonner toggle (if present)
+    const $bonnerToggle = $("#editBonnerToggle");
+    if ($bonnerToggle.length) {
+      $bonnerToggle.prop("checked", isBonner);
+    }
+
+    $("#editNoteModal").modal("show");
+  });
+
+  // Save changes from the Edit Note modal
+  $("#editNoteForm").on("submit", function (e) {
+    e.preventDefault();
+
+    const noteId   = $("#editNoteId").val();
+    const username = $("#editNoteUsername").val();
+    const content  = ($("#editNoteTextArea").val() || "").trim();
+
+    if (!noteId || !username) {
+      msgToast("Error", "Missing note or user information.");
+      return false;
+    }
+    if (!content) {
+      msgToast("Error", "Note text cannot be empty.");
+      $("#editNoteTextArea").focus();
+      return false;
+    }
+
+    const data = {
+      id: noteId,                 // id used by deleteNote; likely same for edit
+      noteTextbox: content        // matches addNote
+    };
+
+    const $vis = $("#editNoteVisibility");
+    if ($vis.length) {
+      data.visibility = $vis.val(); // "1" | "2" | "3"
+    }
+
+    const $bonnerToggle = $("#editBonnerToggle");
+    if ($bonnerToggle.length) {
+      data.bonner = $bonnerToggle.is(":checked") ? "yes" : "no";
+    }
+
+    $("#editNoteSaveButton").prop("disabled", true);
+
+    $.ajax({
+      method: "POST",
+      url: "/" + username + "/editNote",   // keep route style consistent with deleteNote
+      data: data,                          // form-encoded like addNote/deleteNote
+      success: function () {
+        msgFlash("Note updated", "success", 1300, true);
+        if (typeof reloadWithAccordion === "function") {
+          reloadWithAccordion("notes");
+        } else {
+          location.reload();
+        }
+      },
+      error: function (xhr, status, err) {
+        console.log("edit note error", status, err);
+        msgToast("Error", "Could not update the note.");
+        $("#editNoteSaveButton").prop("disabled", false);
+      }
+    });
+  }); 
+
   /*
     * Background Check Functionality
     */

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -411,8 +411,32 @@
                     {% endif %}
                   </td>
                   <td>
-                    {% if (g.current_user == row.note.createdBy) or g.current_user.isCeltsAdmin%}
-                      <button type="button" class="btn btn-sm btn-danger deleteNoteButton float-end" data-noteid="{{row.id}}" data-username="{{volunteer.username}}">Delete</button>
+                    {% if (g.current_user == row.note.createdBy) or g.current_user.isCeltsAdmin %}
+                      <!-- EDIT -->
+                      <button
+                        type="button"
+                        class="btn btn-sm btn-outline-secondary me-2 editNoteButton float-end"
+                        data-noteid="{{ row.id }}"
+                        data-username="{{ volunteer.username }}"
+                        data-content="{{ row.note.noteContent|e }}"
+                        data-viewtier="{{ row.viewTier }}"
+                        data-isbonner="{{ 'yes' if row.isBonnerNote else 'no' }}"
+                        title="Edit"
+                        aria-label="Edit note"
+                      >
+                        Edit
+                      </button>
+                      <!-- DELETE -->
+                      <button
+                        type="button"
+                        class="btn btn-sm btn-danger deleteNoteButton float-end"
+                        data-noteid="{{ row.id }}"
+                        data-username="{{ volunteer.username }}"
+                        title="Delete"
+                        aria-label="Delete note"
+                      >
+                        Delete
+                      </button>
                     {% else %}
                       <button type="button" class="btn btn-sm btn-danger deleteNoteButton float-end disabled" data-noteid="{{row.id}}" data-username="{{volunteer.username}}">Delete</button>
                     {% endif %}
@@ -560,6 +584,57 @@
   </form>
 </div>
 <!-- ################# Add Notes Modal ################ -->
+
+<!-- ################# Edit Note Modal ################ -->
+<div class="modal fade" id="editNoteModal" tabindex="-1" aria-labelledby="editProfileNoteModalLabel" aria-hidden="true">
+  <form id="editNoteForm">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Edit Note</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+
+        <div class="modal-body">
+          <!-- Hidden IDs -->
+          <input type="hidden" id="editNoteId" name="noteId" value="">
+          <input type="hidden" id="editNoteUsername" name="username" value="{{volunteer.username}}">
+
+          <div class="mb-3">
+            <label class="form-label"><strong>Note</strong></label>
+            <textarea required name="noteTextbox" rows="6" id="editNoteTextArea" class="form-control"
+              placeholder="Update your note"></textarea>
+          </div>
+
+          {% set vis_edit = "" if g.current_user.isCeltsStudentStaff or g.current_user.isCeltsAdmin else "d-none" %}
+          <div class="{{vis_edit}}">
+            <label class="form-label"><strong>Visibility</strong></label>
+            <select class="form-select" id="editNoteVisibility">
+              {% if g.current_user.isCeltsAdmin %}<option value="3">Admins</option>{% endif %}
+              {% if g.current_user.isCeltsAdmin or g.current_user.isCeltsStudentStaff %}
+                <option value="2">Admin/Student Staff</option>
+              {% endif %}
+              <option value="1">Everyone</option>
+            </select>
+          </div>
+
+          {% if volunteer.isBonnerScholar %}
+          <div class="form-check form-switch pt-3">
+            <input class="form-check-input" id="editBonnerToggle" type="checkbox" />
+            <label class="form-check-label" for="editBonnerToggle"><strong>Related to Bonner Scholars Program</strong></label>
+          </div>
+          {% endif %}
+        </div>
+
+        <div class="modal-footer justify-content-between">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button id="editNoteSaveButton" type="submit" class="btn btn-primary">Save changes</button>
+        </div>
+      </div>
+    </div>
+  </form>
+</div>
+<!-- ################# Edit Note Modal ################ -->
 
 <!-- ################# Ban or Unban Modal ################ -->
 <div class="modal fade" id="banModal" tabindex="-1" aria-labelledby="banVolunteerModalLabel" aria-hidden="true" style="width:-60px;">


### PR DESCRIPTION
## Issue Description
Add Edit Functionality to Profile Notes 

Fixes #1598 
- Users should be able to edit notes that they have made on a user profile

## Changes
- Added an Edit button next to the Delete button in the profile notes table
- Implemented a new Edit Note Modal that pre-fills with existing note content, visibility tier, and Bonner flag.
- Added and used Bootstrap Icons
- For JS, added event listener for .editNoteButton to open and populate the Edit Note modal with existing data.
- Added AJAX POST request to submit edited note data to the backend endpoint (/<username>/editNote).
- Implemented a new route: @main_bp.route('/<username>/editNote', methods=['POST']), which validates the user’s permission.
- Updates the corresponding Note and ProfileNote entries.
- Added a JSON success or error message for AJAX handling.
