### PR TITLE
fix: allow sidebar to scroll on small screen heights

### DIFF
--- a/app/static/css/sidebar.css
+++ b/app/static/css/sidebar.css
@@ -18,7 +18,7 @@
     height: 100vh;
     max-height: 100vh;
     overflow-x: auto;
-    overflow-y: hidden;
+    overflow-y: auto;
 }
 
 .b-example-divider {


### PR DESCRIPTION
## Summary
Fixes #1642

On small screen heights, the sidebar was getting cut off and the bottom was inaccessible because \overflow-y\ was set to \hidden\.

## Changes
- Changed \overflow-y\ from \hidden\ to \uto\ on the \#sidebar\ element in \sidebar.css\

## Result
Users can now scroll the sidebar when the viewport height is too small to display all sidebar content.

## Testing
Tested by resizing the browser window to a small height and verifying the sidebar is now scrollable.