### PR TITLE
Events header

### DIFF
--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -26,7 +26,7 @@ from app.models.eventParticipant import EventParticipant
 from app.models.courseInstructor import CourseInstructor
 from app.models.backgroundCheckType import BackgroundCheckType
 
-from app.logic.events import getUpcomingEventsForUser, getParticipatedEventsForUser, getTrainingEvents, getEventRsvpCountsForTerm, getUpcomingVolunteerOpportunitiesCount, getVolunteerOpportunities, getBonnerEvents, getCeltsLabor, getEngagementEvents
+from app.logic.events import getUpcomingEventsForUser, getParticipatedEventsForUser, getTrainingEvents, getEventRsvpCountsForTerm, getUpcomingVolunteerOpportunitiesCount, getVolunteerOpportunities, getBonnerEvents, getCeltsLabor, getEngagementEvents, getpastVolunteerOpportunitiesCount
 from app.logic.transcript import *
 from app.logic.loginManager import logout
 from app.logic.searchUsers import searchUsers
@@ -92,6 +92,7 @@ def events(selectedTerm, activeTab, programID):
     currentEventRsvpAmount = getEventRsvpCountsForTerm(term)
     volunteerOpportunities = getVolunteerOpportunities(term)
     countUpcomingVolunteerOpportunities = getUpcomingVolunteerOpportunitiesCount(term, currentTime)
+    countPastVolunteerOpportunities = getpastVolunteerOpportunitiesCount(term, currentTime)
     trainingEvents = getTrainingEvents(term, g.current_user)
     engagementEvents = getEngagementEvents(term)
     bonnerEvents = getBonnerEvents(term)
@@ -109,6 +110,7 @@ def events(selectedTerm, activeTab, programID):
 
     # Get the count of all term events for each category to display in the event list page.
     volunteerOpportunitiesCount: int = len(studentEvents)
+    countPastVolunteerOpportunitiesCount: int = len(countPastVolunteerOpportunities)
     trainingEventsCount: int = len(trainingEvents)
     engagementEventsCount: int = len(engagementEvents)
     bonnerEventsCount: int = len(bonnerEvents)
@@ -133,6 +135,7 @@ def events(selectedTerm, activeTab, programID):
     if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
         return jsonify({
             "volunteerOpportunitiesCount": volunteerOpportunitiesCount,
+            "countPastVolunteerOpportunitiesCount": countPastVolunteerOpportunitiesCount,
             "trainingEventsCount": trainingEventsCount,
             "engagementEventsCount": engagementEventsCount,
             "bonnerEventsCount": bonnerEventsCount,
@@ -155,6 +158,7 @@ def events(selectedTerm, activeTab, programID):
                             programID = int(programID),
                             managersProgramDict = managersProgramDict,
                             countUpcomingVolunteerOpportunities = countUpcomingVolunteerOpportunities,
+                            countPastVolunteerOpportunities = countPastVolunteerOpportunities,
                             toggleState = toggleState,
                             )
 

--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -26,7 +26,7 @@ from app.models.eventParticipant import EventParticipant
 from app.models.courseInstructor import CourseInstructor
 from app.models.backgroundCheckType import BackgroundCheckType
 
-from app.logic.events import getUpcomingEventsForUser, getParticipatedEventsForUser, getTrainingEvents, getEventRsvpCountsForTerm, getUpcomingVolunteerOpportunitiesCount, getVolunteerOpportunities, getBonnerEvents, getCeltsLabor, getEngagementEvents, getpastVolunteerOpportunitiesCount
+from app.logic.events import getUpcomingEventsForUser, getParticipatedEventsForUser, getTrainingEvents, getEventRsvpCountsForTerm, getUpcomingVolunteerOpportunitiesCount, getVolunteerOpportunities, getBonnerEvents, getCeltsLabor, getEngagementEvents, getPastVolunteerOpportunitiesCount
 from app.logic.transcript import *
 from app.logic.loginManager import logout
 from app.logic.searchUsers import searchUsers
@@ -92,7 +92,7 @@ def events(selectedTerm, activeTab, programID):
     currentEventRsvpAmount = getEventRsvpCountsForTerm(term)
     volunteerOpportunities = getVolunteerOpportunities(term)
     countUpcomingVolunteerOpportunities = getUpcomingVolunteerOpportunitiesCount(term, currentTime)
-    countPastVolunteerOpportunities = getpastVolunteerOpportunitiesCount(term, currentTime)
+    countPastVolunteerOpportunities = getPastVolunteerOpportunitiesCount(term, currentTime)
     trainingEvents = getTrainingEvents(term, g.current_user)
     engagementEvents = getEngagementEvents(term)
     bonnerEvents = getBonnerEvents(term)

--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -110,6 +110,7 @@ def events(selectedTerm, activeTab, programID):
 
     # Get the count of all term events for each category to display in the event list page.
     volunteerOpportunitiesCount: int = len(studentEvents)
+    countUpcomingVolunteerOpportunitiesCount: int = len(countUpcomingVolunteerOpportunities)
     countPastVolunteerOpportunitiesCount: int = len(countPastVolunteerOpportunities)
     trainingEventsCount: int = len(trainingEvents)
     engagementEventsCount: int = len(engagementEvents)
@@ -136,6 +137,7 @@ def events(selectedTerm, activeTab, programID):
         return jsonify({
             "volunteerOpportunitiesCount": volunteerOpportunitiesCount,
             "countPastVolunteerOpportunitiesCount": countPastVolunteerOpportunitiesCount,
+            "countUpcomingVolunteerOpportunitiesCount": countUpcomingVolunteerOpportunitiesCount,
             "trainingEventsCount": trainingEventsCount,
             "engagementEventsCount": engagementEventsCount,
             "bonnerEventsCount": bonnerEventsCount,

--- a/app/logic/events.py
+++ b/app/logic/events.py
@@ -277,6 +277,32 @@ def getUpcomingVolunteerOpportunitiesCount(term, currentTime):
         programCountDict[programCount.id] = programCount.eventCount
     return programCountDict
 
+def getpastVolunteerOpportunitiesCount(term, currentTime):
+    """
+        Return a count of all past events for each volunteer opportunities program.
+    """
+    
+    pastCount = (
+        Program
+        .select(Program.id, fn.COUNT(Event.id).alias("eventCount"))
+        .join(Event, on=(Program.id == Event.program_id))
+        .where(
+            (Event.term == term) &
+            (Event.deletionDate.is_null(True)) &
+            (Event.isService == True) &
+            ((Event.isLaborOnly == False) | Event.isLaborOnly.is_null(True)) &
+            ((Event.startDate < currentTime) |
+             ((Event.startDate == currentTime) & (Event.timeStart <= currentTime))) &
+            (Event.isCanceled == False)
+        )
+        .group_by(Program.id)
+    )
+
+    programCountDict = {}
+    for programCount in pastCount:
+        programCountDict[programCount.id] = programCount.eventCount
+    return programCountDict
+
 def getTrainingEvents(term, user):
     """
         The allTrainingsEvent query is designed to select and count eventId's after grouping them

--- a/app/logic/events.py
+++ b/app/logic/events.py
@@ -277,7 +277,7 @@ def getUpcomingVolunteerOpportunitiesCount(term, currentDate):
         programCountDict[programCount.id] = programCount.eventCount
     return programCountDict
 
-def getpastVolunteerOpportunitiesCount(term, currentDate):
+def getPastVolunteerOpportunitiesCount(term, currentDate):
     """
         Return a count of all past events for each volunteer opportunities program.
     """

--- a/app/logic/events.py
+++ b/app/logic/events.py
@@ -268,7 +268,7 @@ def getUpcomingVolunteerOpportunitiesCount(term, currentDate):
             (Event.isService == True) &
             ((Event.isLaborOnly == False) | Event.isLaborOnly.is_null(True)) &
             ((Event.startDate > currentDate) |
-             ((Event.startDate == currentDate) & (Event.timeEnd >= currentDate))) &
+             ((Event.startDate == currentDate) & (Event.timeEnd >= currentDate.time()))) &
             (Event.isCanceled == False)
         )
         .group_by(Program.id)
@@ -294,7 +294,7 @@ def getPastVolunteerOpportunitiesCount(term, currentDate):
             (Event.isService == True) &
             ((Event.isLaborOnly == False) | Event.isLaborOnly.is_null(True)) &
             ((Event.startDate < currentDate) |
-             ((Event.startDate == currentDate) & (Event.timeStart <= currentDate))) &
+             ((Event.startDate == currentDate) & (Event.timeStart <= currentDate.time()))) &
             (Event.isCanceled == False)
         )
         .group_by(Program.id)

--- a/app/logic/events.py
+++ b/app/logic/events.py
@@ -251,7 +251,7 @@ def getEngagementEvents(term):
                                  .execute())
     return engagementEvents
 
-def getUpcomingVolunteerOpportunitiesCount(term, currentTime):
+def getUpcomingVolunteerOpportunitiesCount(term, currentDate):
     """
         Return a count of all upcoming events for each volunteer opportunitiesprogram.
     """
@@ -265,8 +265,8 @@ def getUpcomingVolunteerOpportunitiesCount(term, currentTime):
             (Event.deletionDate.is_null(True)) &
             (Event.isService == True) &
             ((Event.isLaborOnly == False) | Event.isLaborOnly.is_null(True)) &
-            ((Event.startDate > currentTime) |
-             ((Event.startDate == currentTime) & (Event.timeEnd >= currentTime))) &
+            ((Event.startDate > currentDate) |
+             ((Event.startDate == currentDate) & (Event.timeEnd >= currentDate))) &
             (Event.isCanceled == False)
         )
         .group_by(Program.id)
@@ -277,7 +277,7 @@ def getUpcomingVolunteerOpportunitiesCount(term, currentTime):
         programCountDict[programCount.id] = programCount.eventCount
     return programCountDict
 
-def getpastVolunteerOpportunitiesCount(term, currentTime):
+def getpastVolunteerOpportunitiesCount(term, currentDate):
     """
         Return a count of all past events for each volunteer opportunities program.
     """
@@ -291,8 +291,8 @@ def getpastVolunteerOpportunitiesCount(term, currentTime):
             (Event.deletionDate.is_null(True)) &
             (Event.isService == True) &
             ((Event.isLaborOnly == False) | Event.isLaborOnly.is_null(True)) &
-            ((Event.startDate < currentTime) |
-             ((Event.startDate == currentTime) & (Event.timeStart <= currentTime))) &
+            ((Event.startDate < currentDate) |
+             ((Event.startDate == currentDate) & (Event.timeStart <= currentDate))) &
             (Event.isCanceled == False)
         )
         .group_by(Program.id)

--- a/app/static/js/eventList.js
+++ b/app/static/js/eventList.js
@@ -96,7 +96,11 @@ function updateIndicatorCounts(isChecked){
       
       $("#viewPastEventsToggle").prop(toggleStatus, true);
       
-      // use ternary operators to populate the tab with a number if there are events, and clear the count if there are none
+      // Update tab labels with event counts:
+      // - When toggle is ON, show total volunteer opportunities (upcoming + past)
+      // - When toggle is OFF, show upcoming volunteer opportunities only
+      // - For all tabs, show counts only if greater than zero; otherwise show the label without a count
+
       if (toggleStatus === "checked") {
         // Toggle ON: show total (upcoming + past)
         if (volunteerOpportunitiesCount > 0) {

--- a/app/static/js/eventList.js
+++ b/app/static/js/eventList.js
@@ -94,7 +94,7 @@ function updateIndicatorCounts(isChecked){
       const celtsLaborCount = Number(eventsCount.celtsLaborCount);
       const toggleStatus = eventsCount.toggleStatus;
       
-      $("#viewPastEventsToggle").prop(toggleStatus, true);
+      $("#viewPastEventsToggle").prop("checked", toggleStatus === "checked");
       
       // Update tab labels with event counts:
       // - When toggle is ON, show total volunteer opportunities (upcoming + past)

--- a/app/static/js/eventList.js
+++ b/app/static/js/eventList.js
@@ -88,7 +88,6 @@ function updateIndicatorCounts(isChecked){
     success: function(eventsCount) {
       const volunteerOpportunitiesCount = Number(eventsCount.volunteerOpportunitiesCount);
       const upcomingVolunteerCount = Number(eventsCount.countUpcomingVolunteerOpportunitiesCount);
-      const pastVolunteerCount = Number(eventsCount.countPastVolunteerOpportunitiesCount);
       const trainingEventsCount = Number(eventsCount.trainingEventsCount);
       const engagementEventsCount = Number(eventsCount.engagementEventsCount);
       const bonnerEventsCount = Number(eventsCount.bonnerEventsCount);
@@ -96,11 +95,10 @@ function updateIndicatorCounts(isChecked){
       const toggleStatus = eventsCount.toggleStatus;
       
       $("#viewPastEventsToggle").prop(toggleStatus, true);
-
+      
       // use ternary operators to populate the tab with a number if there are events, and clear the count if there are none
-
       if (toggleStatus === "checked") {
-        // Toggle ON → show total (upcoming + past)
+        // Toggle ON: show total (upcoming + past)
         if (volunteerOpportunitiesCount > 0) {
           $("#volunteerOpportunities").html(
             `Volunteer Opportunities (${volunteerOpportunitiesCount})`
@@ -109,7 +107,7 @@ function updateIndicatorCounts(isChecked){
           $("#volunteerOpportunities").html(`Volunteer Opportunities`);
         }
       } else {
-        // Toggle OFF → show upcoming only
+        // Toggle OFF: show upcoming only
         if (upcomingVolunteerCount > 0) {
           $("#volunteerOpportunities").html(
             `Volunteer Opportunities (${upcomingVolunteerCount})`

--- a/app/static/js/eventList.js
+++ b/app/static/js/eventList.js
@@ -87,6 +87,8 @@ function updateIndicatorCounts(isChecked){
     },
     success: function(eventsCount) {
       const volunteerOpportunitiesCount = Number(eventsCount.volunteerOpportunitiesCount);
+      const upcomingVolunteerCount = Number(eventsCount.countUpcomingVolunteerOpportunitiesCount);
+      const pastVolunteerCount = Number(eventsCount.countPastVolunteerOpportunitiesCount);
       const trainingEventsCount = Number(eventsCount.trainingEventsCount);
       const engagementEventsCount = Number(eventsCount.engagementEventsCount);
       const bonnerEventsCount = Number(eventsCount.bonnerEventsCount);
@@ -96,7 +98,26 @@ function updateIndicatorCounts(isChecked){
       $("#viewPastEventsToggle").prop(toggleStatus, true);
 
       // use ternary operators to populate the tab with a number if there are events, and clear the count if there are none
-      volunteerOpportunitiesCount > 0 ? $("#volunteerOpportunities").html(`Volunteer Opportunities (${volunteerOpportunitiesCount})`) : $("#volunteerOpportunities").html(`Volunteer Opportunities`)
+
+      if (toggleStatus === "checked") {
+        // Toggle ON → show total (upcoming + past)
+        if (volunteerOpportunitiesCount > 0) {
+          $("#volunteerOpportunities").html(
+            `Volunteer Opportunities (${volunteerOpportunitiesCount})`
+          );
+        } else {
+          $("#volunteerOpportunities").html(`Volunteer Opportunities`);
+        }
+      } else {
+        // Toggle OFF → show upcoming only
+        if (upcomingVolunteerCount > 0) {
+          $("#volunteerOpportunities").html(
+            `Volunteer Opportunities (${upcomingVolunteerCount})`
+          );
+        } else {
+          $("#volunteerOpportunities").html(`Volunteer Opportunities`);
+        }
+      }
       trainingEventsCount > 0 ? $("#trainingEvents").html(`Trainings (${trainingEventsCount})`) : $("#trainingEvents").html(`Trainings`)
       engagementEventsCount > 0 ? $("#engagementEvents").html(`Education and Engagement (${engagementEventsCount})`) : $("#engagementEvents").html('Education and Engagement')
       bonnerEventsCount > 0 ? $("#bonnerScholarsEvents").html(`Bonner Scholars (${bonnerEventsCount})`) : $("#bonnerScholarsEvents").html(`Bonner Scholars`)

--- a/app/templates/events/eventList.html
+++ b/app/templates/events/eventList.html
@@ -209,19 +209,19 @@
       </div>
     {% else %}
        <div class="table-responsive">
-      <table class="table">
-        <thead>
-          <tr>
-            <th scope="col">Program</th>
-            <th scope="col">Event Name</th>
-            <th scope="col">Date</th>
-            <th scope="col">Time</th>
-            <th scope="col">Location</th>
-            <th scope="col"></th>
-          </tr>
-        </thead>
-      </table>
-    </div>
+        <table class="table">
+          <thead>
+            <tr>
+              <th scope="col">Program</th>
+              <th scope="col">Event Name</th>
+              <th scope="col">Date</th>
+              <th scope="col">Time</th>
+              <th scope="col">Location</th>
+              <th scope="col"></th>
+            </tr>
+          </thead>
+        </table>
+       </div>
         <td colspan="{{colspan_value}}" class="p-3 no-upcoming">There are no upcoming events for this program</td>
     {% endif %}
   </div>

--- a/app/templates/events/eventList.html
+++ b/app/templates/events/eventList.html
@@ -51,13 +51,13 @@
   <ul class="nav nav-tabs nav-fill mx-2 mb-2" id="pills-tab" role="tablist">
   <li class="col-md-2 col-12 nav-item" role="presentation">
     <button class="nav-link {{'active' if activeTab == 'volunteerOpportunities' else ''}}" id="volunteerOpportunities"
-    data-bs-toggle="pill" data-bs-target="#pills-volunteer-opportunities" type="button" role="tab" aria-controls="pills-volunteer-opportunities" aria-selected="true">Volunteer Opportunities</button>
+    data-bs-toggle="pill" data-bs-target="#pills-volunteer-opportunities" type="button" role="tab" aria-controls="pills-volunteer-opportunities" aria-selected="true">Volunteer Opportunities </button>
   </li>
 
   {% if trainingEvents and trainingEvents|length %}
   <li class="col-md-2 col-12 nav-item" role="presentation">
     <button class="nav-link {{'active' if activeTab == 'trainingEvents' else ''}}" id="trainingEvents"
-    data-bs-toggle="pill" data-bs-target="#pills-training" type="button" role="tab" aria-controls="pills-training" aria-selected="false">Training</button>
+    data-bs-toggle="pill" data-bs-target="#pills-training" type="button" role="tab" aria-controls="pills-training" aria-selected="false">Trainings</button>
   </li>
   {% endif %}
 
@@ -191,9 +191,9 @@
                     aria-controls="accordion__body_{{program}}">
                     {{program.programName}}
                     {% if program.id not in countUpcomingVolunteerOpportunities%}
-                      <span class="ms-auto fw-light fst-italic">0 upcoming events</span>
+                      <span class="ms-auto fw-light fst-italic"> 0 upcoming events and {{countPastVolunteerOpportunities[program.id]}} past events</span>
                     {% else %}
-                        <span class="ms-auto fw-light fst-italic">{{countUpcomingVolunteerOpportunities[program.id]}} upcoming event{% if countUpcomingVolunteerOpportunities[program.id] > 1 %}s{% endif %}</span>
+                        <span class="ms-auto fw-light fst-italic">{{countUpcomingVolunteerOpportunities[program.id]}} upcoming event{% if countUpcomingVolunteerOpportunities[program.id] > 1 %}s{% endif %} and {{countPastVolunteerOpportunities[program.id]}} past event{% if countUpcomingVolunteerOpportunities[program.id] > 1 %}s{% endif %}s</span>
                     {% endif %}
 
             </button>

--- a/app/templates/events/eventList.html
+++ b/app/templates/events/eventList.html
@@ -208,6 +208,20 @@
         {% endfor %}
       </div>
     {% else %}
+       <div class="table-responsive">
+      <table class="table">
+        <thead>
+          <tr>
+            <th scope="col">Program</th>
+            <th scope="col">Event Name</th>
+            <th scope="col">Date</th>
+            <th scope="col">Time</th>
+            <th scope="col">Location</th>
+            <th scope="col"></th>
+          </tr>
+        </thead>
+      </table>
+    </div>
         <td colspan="{{colspan_value}}" class="p-3 no-upcoming">There are no upcoming events for this program</td>
     {% endif %}
   </div>

--- a/app/templates/events/eventList.html
+++ b/app/templates/events/eventList.html
@@ -226,7 +226,7 @@
     {% endif %}
   </div>
   <div class="tab-pane fade show" id="pills-training" role="tabpanel" aria-labelledby="pills-training-tab">
-    {{createTable(trainingEvents, "trainings")}}
+    {{createTable(trainingEvents, "training")}}
   </div>
   <div class="tab-pane fade show" id="pills-engagement" role="tabpanel" aria-labelledby="pills-engagement-tab">
     {{createTable(engagementEvents, "education and engagement")}}

--- a/app/templates/events/eventList.html
+++ b/app/templates/events/eventList.html
@@ -208,7 +208,7 @@
         {% endfor %}
       </div>
     {% else %}
-        <p class="m-2 fs-4">There are no events that earn service for this term.</p>
+        <td colspan="{{colspan_value}}" class="p-3 no-upcoming">There are no upcoming events for this program</td>
     {% endif %}
   </div>
   <div class="tab-pane fade show" id="pills-training" role="tabpanel" aria-labelledby="pills-training-tab">

--- a/app/templates/events/eventList.html
+++ b/app/templates/events/eventList.html
@@ -175,29 +175,29 @@
   <p class="m-2 fs-4">There are no {{typemap[type]}} events for this term.</p>
 {% endif %}
 {% endmacro %}
-
 <div class="tab-content" id="pills-tabContent">
-  <div class="tab-pane fade show {{'active' if activeTab == 'volunteerOpportunities' else ''}}" id="pills-volunteer-opportunities" role="tabpanel" aria-labelledby="pills-volunteer-opportunities-tab">
-    {% if volunteerOpportunities %}
-    <div class="accordion" id="categoryAccordion">
-      {% for program,events in volunteerOpportunities.items() %}
-        <div class="accordion-item">
-          <div class="accordion-header" id="accordion__header_{{program}}">
-            <button class="accordion-button {{'show' if programID == program.id else 'collapsed'}}"
-                    type="button"
-                    data-bs-toggle="collapse"
-                    data-bs-target="#accordion__body_{{program}}_num_{{ loop.index }}"
-                    aria-expanded="true"
-                    aria-controls="accordion__body_{{program}}">
-                    {{program.programName}}
-                    {% if program.id not in countUpcomingVolunteerOpportunities%}
-                      <span class="ms-auto fw-light fst-italic"> 0 upcoming events and {{countPastVolunteerOpportunities[program.id]}} past events</span>
-                    {% else %}
-                        <span class="ms-auto fw-light fst-italic">{{countUpcomingVolunteerOpportunities[program.id]}} upcoming event{% if countUpcomingVolunteerOpportunities[program.id] > 1 %}s{% endif %} and {{countPastVolunteerOpportunities[program.id]}} past event{% if countUpcomingVolunteerOpportunities[program.id] > 1 %}s{% endif %}s</span>
-                    {% endif %}
+  <div class="tab-pane fade show {{ 'active' if activeTab == 'volunteerOpportunities' else '' }}"
+       id="pills-volunteer-opportunities"
+       role="tabpanel"
+       aria-labelledby="pills-volunteer-opportunities-tab">
 
-            </button>
-          </div>
+    {% if volunteerOpportunities %}
+      <div class="accordion" id="categoryAccordion">
+        {% for program, events in volunteerOpportunities.items() %}
+          <div class="accordion-item">
+            <div class="accordion-header" id="accordion__header_{{ program }}">
+              <button class="accordion-button {{ 'show' if programID == program.id else 'collapsed' }}"
+                      type="button"
+                      data-bs-toggle="collapse"
+                      data-bs-target="#accordion__body_{{ program }}_num_{{ loop.index }}"
+                      aria-expanded="true"
+                      aria-controls="accordion__body_{{ program }}">
+                {{ program.programName }}
+                {% set upcoming = countUpcomingVolunteerOpportunities.get(program.id, 0) %}
+                {% set past = countPastVolunteerOpportunities.get(program.id, 0) %}
+                  <span class="ms-auto fw-light fst-italic"> {{ upcoming }} upcoming event{% if upcoming != 1 %}s{% endif %} and {{ past }} past event{% if past != 1 %}s{% endif %} </span>
+              </button>
+            </div>
           <div id="accordion__body_{{program}}_num_{{ loop.index }}"
                 class="accordion-collapse collapse {{'show' if programID == program.id else ''}}"
                 aria-labelledby="accordion__header_{{program}}"

--- a/tests/code/test_event_list.py
+++ b/tests/code/test_event_list.py
@@ -9,7 +9,7 @@ from app.models.bonnerCohort import BonnerCohort
 from app.models.term import Term
 from app.models.user import User
 from app.models.eventViews import EventView
-from app.logic.events import getVolunteerOpportunities, getEngagementEvents, getTrainingEvents, getBonnerEvents, getCeltsLabor, addEventView, getUpcomingVolunteerOpportunitiesCount, getpastVolunteerOpportunitiesCount
+from app.logic.events import getVolunteerOpportunities, getEngagementEvents, getTrainingEvents, getBonnerEvents, getCeltsLabor, addEventView, getUpcomingVolunteerOpportunitiesCount, getPastVolunteerOpportunitiesCount
 
 @pytest.mark.integration
 @pytest.fixture
@@ -206,14 +206,14 @@ def test_getPastVolunteerOpportunitiesCount():
         )
 
         # Verify two past AGP events
-        pastVolunteerOpportunities = getpastVolunteerOpportunitiesCount(
+        pastVolunteerOpportunities = getPastVolunteerOpportunitiesCount(
             currentTestTerm, testDate
         )
         assert pastVolunteerOpportunities == {3: 2}
 
         # Cancel one past event → should reduce count
         Event.update(isCanceled=True).where(Event.id == pastAgpEvent.id).execute()
-        pastVolunteerOpportunities = getpastVolunteerOpportunitiesCount(
+        pastVolunteerOpportunities = getPastVolunteerOpportunitiesCount(
             currentTestTerm, testDate
         )
         assert pastVolunteerOpportunities == {3: 1}
@@ -232,7 +232,7 @@ def test_getPastVolunteerOpportunitiesCount():
             program=2
         )
 
-        pastVolunteerOpportunities = getpastVolunteerOpportunitiesCount(
+        pastVolunteerOpportunities = getPastVolunteerOpportunitiesCount(
             currentTestTerm, testDate
         )
         assert pastVolunteerOpportunities == {2: 1, 3: 1}

--- a/tests/code/test_event_list.py
+++ b/tests/code/test_event_list.py
@@ -178,7 +178,7 @@ def test_getPastVolunteerOpportunitiesCount():
         )
 
         # Past Volunteer Opportunity (same day, before test time)
-        pastSameDayEvent = Event.create(
+        Event.create(
             name="Test same-day past AGP event",
             term=currentTestTerm,
             description="Same day but earlier time.",
@@ -192,7 +192,7 @@ def test_getPastVolunteerOpportunitiesCount():
         )
 
         # Future Volunteer Opportunity (should NOT be counted)
-        futureAgpEvent = Event.create(
+        Event.create(
             name="Test future AGP event",
             term=currentTestTerm,
             description="Future volunteer opportunity.",

--- a/tests/code/test_event_list.py
+++ b/tests/code/test_event_list.py
@@ -9,7 +9,7 @@ from app.models.bonnerCohort import BonnerCohort
 from app.models.term import Term
 from app.models.user import User
 from app.models.eventViews import EventView
-from app.logic.events import getVolunteerOpportunities, getEngagementEvents, getTrainingEvents, getBonnerEvents, getCeltsLabor, addEventView, getUpcomingVolunteerOpportunitiesCount
+from app.logic.events import getVolunteerOpportunities, getEngagementEvents, getTrainingEvents, getBonnerEvents, getCeltsLabor, addEventView, getUpcomingVolunteerOpportunitiesCount, getpastVolunteerOpportunitiesCount
 
 @pytest.mark.integration
 @pytest.fixture
@@ -151,6 +151,91 @@ def test_getUpcomingVolunteerOpportunitiesCount():
         
         upcomingVolunteerOpportunities = getUpcomingVolunteerOpportunitiesCount(currentTestTerm, testDate)
         assert upcomingVolunteerOpportunities == {2:1, 3:1}
+
+        transaction.rollback()
+
+@pytest.mark.integration
+def test_getPastVolunteerOpportunitiesCount():
+    with mainDB.atomic() as transaction:
+        testDate = datetime.strptime("2021-08-01 05:00", "%Y-%m-%d %H:%M")
+        currentTestTerm = Term.get_by_id(5)
+
+        # Move any existing term-5 events into the future
+        Event.update(startDate=date(2021, 8, 5)).where(Event.term_id == 5).execute()
+
+        # Past Volunteer Opportunity (AGP)
+        pastAgpEvent = Event.create(
+            name="Test past AGP event",
+            term=currentTestTerm,
+            description="Past volunteer opportunity (AGP).",
+            timeStart="03:00:00",
+            timeEnd="04:00:00",
+            location="Mars",
+            isTraining=False,
+            isService=True,
+            startDate="2021-07-31",
+            program=3
+        )
+
+        # Past Volunteer Opportunity (same day, before test time)
+        pastSameDayEvent = Event.create(
+            name="Test same-day past AGP event",
+            term=currentTestTerm,
+            description="Same day but earlier time.",
+            timeStart="04:00:00",
+            timeEnd="04:30:00",
+            location="Venus",
+            isTraining=False,
+            isService=True,
+            startDate="2021-08-01",
+            program=3
+        )
+
+        # Future Volunteer Opportunity (should NOT be counted)
+        futureAgpEvent = Event.create(
+            name="Test future AGP event",
+            term=currentTestTerm,
+            description="Future volunteer opportunity.",
+            timeStart="06:00:00",
+            timeEnd="07:00:00",
+            location="Moon",
+            isTraining=False,
+            isService=True,
+            startDate="2021-08-02",
+            program=3
+        )
+
+        # Verify two past AGP events
+        pastVolunteerOpportunities = getpastVolunteerOpportunitiesCount(
+            currentTestTerm, testDate
+        )
+        assert pastVolunteerOpportunities == {3: 2}
+
+        # Cancel one past event → should reduce count
+        Event.update(isCanceled=True).where(Event.id == pastAgpEvent.id).execute()
+        pastVolunteerOpportunities = getpastVolunteerOpportunitiesCount(
+            currentTestTerm, testDate
+        )
+        assert pastVolunteerOpportunities == {3: 1}
+
+        # Create past event for another program (Buddies)
+        pastBuddiesEvent = Event.create(
+            name="Test past Buddies event",
+            term=currentTestTerm,
+            description="Past volunteer opportunity (Buddies).",
+            timeStart="02:00:00",
+            timeEnd="03:00:00",
+            location="Earth",
+            isTraining=False,
+            isService=True,
+            startDate="2021-07-30",
+            program=2
+        )
+
+        pastVolunteerOpportunities = getpastVolunteerOpportunitiesCount(
+            currentTestTerm, testDate
+        )
+        assert pastVolunteerOpportunities == {2: 1, 3: 1}
 
         transaction.rollback()
 


### PR DESCRIPTION
## Issue Description

Fixes #1636 

- When on the Events List page, some tabs do not display the same message when there are no upcoming events

## Changes

- Standardized display message format when there are no events 
- Added a new function for past events 
- Added a new logic for past and upcoming events notifications on the accordions 
- Corrected the number of events displayed on top of the tab. When the past toggle is not checked, we only see the number of upcoming events. However, when it is checked, we should see the number of upcoming AND past events. 

## Testing

- Go to events list 
- You will be able to see the different tabs with no upcoming events and the display. 
- You can create events in the tabs and play around to see what appears where. 