### PR TITLE
Fixed insurance check box issue.

### DIFF
--- a/app/static/js/volunteerDetails.js
+++ b/app/static/js/volunteerDetails.js
@@ -78,7 +78,7 @@ $(document).ready(function () {
 			$(e).addClass(i % 2 ? 'custom-odd' : 'custom-even')
 		})
 	}
-
+    $("#insuranceSelect").prop("checked", false);
 	getCheckBoxes()
 	hideDuplicateVolunteers()
 	sortVolunteers()

--- a/app/static/js/volunteerDetails.js
+++ b/app/static/js/volunteerDetails.js
@@ -78,7 +78,6 @@ $(document).ready(function () {
 			$(e).addClass(i % 2 ? 'custom-odd' : 'custom-even')
 		})
 	}
-    $("#insuranceSelect").prop("checked", false);
 	getCheckBoxes()
 	hideDuplicateVolunteers()
 	sortVolunteers()

--- a/app/templates/events/volunteerDetails.html
+++ b/app/templates/events/volunteerDetails.html
@@ -116,7 +116,7 @@
           <label for="statusSelect">Volunteer Status</label><br>
           <input class="displayCheckbox noprint" type="checkbox" name="selected_items" id="emailSelect" checked>
           <label for="emailSelect">Email</label><br>
-          <input class="displayCheckbox noprint" type="checkbox" name="selected_items" id="insuranceSelect" checked>
+          <input class="displayCheckbox noprint" type="checkbox" name="selected_items" id="insuranceSelect">
           <label for="InsuranceSelect">Insurance Information</label><br>
           <input class="displayCheckbox noprint bNumberSelect" type="checkbox" name="selected_items" id="barcodeSelect" checked>
           <label class="bNumberSelect" for="barcodeSelect">B-Number Barcode</label><br>


### PR DESCRIPTION
Fixes #1655 

Issue Description
After creating an event and navigating to the Volunteer Details tab, users see a table of volunteers along with a checklist that controls which columns are displayed. Currently, the Insurance Information option is checked by default, causing the insurance column to appear automatically.


Changes
Updated the default state of the Insurance Information checkbox (insuranceSelect) to be unchecked on page load
Ensured the insurance column is hidden by default
Kept existing behavior for all other checklist options and table functionality

<img width="1146" height="642" alt="Screenshot 2026-01-21 at 3 36 16 PM" src="https://github.com/user-attachments/assets/30aceed5-2931-4595-be0e-c3eb4feef61c" />

<img width="1013" height="646" alt="Screenshot 2026-01-21 at 3 45 53 PM" src="https://github.com/user-attachments/assets/d2358498-925e-42c2-88c9-833b51ede464" />


Image
Testing
Checked out the branch
git checkout insurance-info
git pull
Created or opened an event
Navigated to Volunteer Details
Verified the Insurance Information column is hidden by default
Verified checking the Insurance option displays the column
Verified unchecking it hides the column again

