### PR TITLE
Fix volunteer RSVP language in non-RSVP event

### DIFF
--- a/app/controllers/admin/routes.py
+++ b/app/controllers/admin/routes.py
@@ -33,7 +33,7 @@ from app.logic.createLogs import createActivityLog
 from app.logic.certification import getCertRequirements, updateCertRequirements
 from app.logic.utils import selectSurroundingTerms, getFilesFromRequest, getRedirectTarget, setRedirectTarget
 from app.logic.events import attemptSaveMultipleOfferings, cancelEvent, deleteEvent, attemptSaveEvent, preprocessEventData, getRepeatingEventsData, deleteEventAndAllFollowing, deleteAllEventsInSeries, getBonnerEvents,addEventView, getEventRsvpCount, copyRsvpToNewEvent, getCountdownToEvent, calculateNewSeriesId, inviteCohortsToEvent, updateEventCohorts
-from app.logic.participants import getParticipationStatusForTrainings, checkUserRsvp
+from app.logic.participants import getParticipationStatusForTrainings, checkUserRsvp, getTargetList
 from app.logic.minor import getMinorInterest
 from app.logic.fileHandler import FileHandler
 from app.logic.bonner import getBonnerCohorts, makeBonnerXls, rsvpForBonnerCohort, addBonnerCohortToRsvpLog
@@ -209,13 +209,15 @@ def rsvpLogDisplay(eventId):
         allLogs = []
         allLogs.extend(event_logs)
 
-        for rsvp in invited_rsvps:
-            # Provide an explicit invitation action for EventRsvp records
-            allLogs.append(LogEntry(
-                createdOn=rsvp.rsvpTime,
-                createdBy=rsvp.user,
-                rsvpLogContent=f"Invited {rsvp.user.fullName} to event"
-            ))
+        # Only add invitation logs for non-RSVP events, as for RSVP events, EventRsvp represents RSVPs, not invitations
+        if not event.isRsvpRequired:
+            for rsvp in invited_rsvps:
+                # Provide an explicit invitation action for EventRsvp records
+                allLogs.append(LogEntry(
+                    createdOn=rsvp.rsvpTime,
+                    createdBy=rsvp.user,
+                    rsvpLogContent=f"Invited {rsvp.user.fullName} to {getTargetList(event)}"
+                ))
 
         allLogs.sort(key=lambda entry: entry.createdOn, reverse=True)
 

--- a/app/controllers/admin/routes.py
+++ b/app/controllers/admin/routes.py
@@ -5,6 +5,7 @@ from playhouse.shortcuts import model_to_dict
 import json
 from datetime import datetime
 import os
+from collections import namedtuple
 
 from app import app
 from app.models.backgroundCheck import BackgroundCheck
@@ -196,22 +197,21 @@ def rsvpLogDisplay(eventId):
     event = Event.get_by_id(eventId)
     if g.current_user.isCeltsAdmin or (g.current_user.isCeltsStudentStaff and g.current_user.isProgramManagerFor(event.program)):
         # Existing RSVP-specific log entries
-        event_logs = list(EventRsvpLog.select(EventRsvpLog, User)
+        eventLogs = list(EventRsvpLog.select(EventRsvpLog, User)
                                     .join(User, on=(EventRsvpLog.createdBy == User.username))
                                     .where(EventRsvpLog.event_id == eventId))
 
         # Include invited users from EventRsvp so the log display reflects invitations too
-        invited_rsvps = EventRsvp.select(EventRsvp, User).join(User).where(EventRsvp.event == eventId)
+        invitedRsvps = EventRsvp.select(EventRsvp, User).join(User).where(EventRsvp.event == eventId)
 
-        from collections import namedtuple
         LogEntry = namedtuple('LogEntry', ['createdOn', 'createdBy', 'rsvpLogContent'])
 
         allLogs = []
-        allLogs.extend(event_logs)
+        allLogs.extend(eventLogs)
 
         # Only add invitation logs for non-RSVP events, as for RSVP events, EventRsvp represents RSVPs, not invitations
         if not event.isRsvpRequired:
-            for rsvp in invited_rsvps:
+            for rsvp in invitedRsvps:
                 # Provide an explicit invitation action for EventRsvp records
                 allLogs.append(LogEntry(
                     createdOn=rsvp.rsvpTime,

--- a/app/controllers/admin/routes.py
+++ b/app/controllers/admin/routes.py
@@ -195,7 +195,30 @@ def createEvent(templateid, programid):
 def rsvpLogDisplay(eventId):
     event = Event.get_by_id(eventId)
     if g.current_user.isCeltsAdmin or (g.current_user.isCeltsStudentStaff and g.current_user.isProgramManagerFor(event.program)):
-        allLogs = EventRsvpLog.select(EventRsvpLog, User).join(User, on=(EventRsvpLog.createdBy == User.username)).where(EventRsvpLog.event_id == eventId).order_by(EventRsvpLog.createdOn.desc())
+        # Existing RSVP-specific log entries
+        event_logs = list(EventRsvpLog.select(EventRsvpLog, User)
+                                    .join(User, on=(EventRsvpLog.createdBy == User.username))
+                                    .where(EventRsvpLog.event_id == eventId))
+
+        # Include invited users from EventRsvp so the log display reflects invitations too
+        invited_rsvps = EventRsvp.select(EventRsvp, User).join(User).where(EventRsvp.event == eventId)
+
+        from collections import namedtuple
+        LogEntry = namedtuple('LogEntry', ['createdOn', 'createdBy', 'rsvpLogContent'])
+
+        allLogs = []
+        allLogs.extend(event_logs)
+
+        for rsvp in invited_rsvps:
+            # Provide an explicit invitation action for EventRsvp records
+            allLogs.append(LogEntry(
+                createdOn=rsvp.rsvpTime,
+                createdBy=rsvp.user,
+                rsvpLogContent=f"Invited {rsvp.user.fullName} to event"
+            ))
+
+        allLogs.sort(key=lambda entry: entry.createdOn, reverse=True)
+
         return render_template("/events/rsvpLog.html",
                                 event = event,
                                 allLogs = allLogs)

--- a/app/controllers/admin/routes.py
+++ b/app/controllers/admin/routes.py
@@ -216,7 +216,7 @@ def rsvpLogDisplay(eventId):
                 allLogs.append(LogEntry(
                     createdOn=rsvp.rsvpTime,
                     createdBy=rsvp.user,
-                    rsvpLogContent=f"Invited {rsvp.user.fullName} to {getTargetList(event)}"
+                    rsvpLogContent=f"Added {rsvp.user.fullName} to {getTargetList(event)}"
                 ))
 
         allLogs.sort(key=lambda entry: entry.createdOn, reverse=True)

--- a/app/controllers/admin/volunteers.py
+++ b/app/controllers/admin/volunteers.py
@@ -113,9 +113,10 @@ def volunteerDetailsPage(eventID):
                                                 .where(EventParticipant.event==event))
     
     
-    waitlistUser = list(set([obj for obj in eventRsvpData if obj.rsvpWaitlist]))
-    rsvpUser = list(set([obj for obj in eventRsvpData if not obj.rsvpWaitlist ]))
     attendedUser = list(set([obj for obj in eventParticipantData if not obj.rsvpWaitlist]))
+    attendedUserIds = {obj.user.id for obj in attendedUser}
+    waitlistUser = [obj for obj in eventRsvpData if obj.rsvpWaitlist and obj.user.id not in attendedUserIds]
+    rsvpUser = [obj for obj in eventRsvpData if not obj.rsvpWaitlist and obj.user.id not in attendedUserIds]
     
     return render_template("/events/volunteerDetails.html",
                             waitlistUser = waitlistUser,

--- a/app/logic/participants.py
+++ b/app/logic/participants.py
@@ -65,7 +65,7 @@ def addBnumberAsParticipant(bnumber, eventId):
                     currentRsvp = getEventRsvpCountsForTerm(event.term)
                     waitlist = currentRsvp[event.id] >= event.rsvpLimit if event.rsvpLimit is not None else False
                     EventRsvp.create(user=kioskUser, event=event, rsvpWaitlist=waitlist)
-                    targetList = "the waitlist" if waitlist else "the RSVP list"
+                    targetList = getTargetList(event, waitlist)
                     try:
                         if g.current_user.username == kioskUser.username:
                             createRsvpLog(event.id, f"{kioskUser.fullName} joined {targetList}.")
@@ -85,6 +85,9 @@ def checkUserRsvp(user,  event):
 
 def checkUserVolunteer(user,  event):
     return EventParticipant.select().where(EventParticipant.user == user, EventParticipant.event == event).exists()
+
+def getTargetList(event, waitlist=False):
+    return "the waitlist" if waitlist else "the Invited list" if not event.isRsvpRequired else "the RSVP list"
 
 def addPersonToEvent(user, event):
     """

--- a/app/logic/participants.py
+++ b/app/logic/participants.py
@@ -107,6 +107,10 @@ def addPersonToEvent(user, event):
                 if not volunteerExists:
                     eventHours = getEventLengthInHours(event.timeStart, event.timeEnd, event.startDate)
                     EventParticipant.create(user = user, event = event, hoursEarned = eventHours)
+                    # try:
+                        createRsvpLog(event.id, f"Marked {user.fullName} as attended.")
+                    except Exception:
+                        pass
             else:
                 if not rsvpExists:
                     currentRsvp = getEventRsvpCountsForTerm(event.term)
@@ -124,6 +128,10 @@ def addPersonToEvent(user, event):
                 if not volunteerExists:
                     eventHours = getEventLengthInHours(event.timeStart, event.timeEnd, event.startDate)
                     EventParticipant.create(user = user, event = event, hoursEarned = eventHours)
+                    try:
+                        createRsvpLog(event.id, f"Marked {user.fullName} as attended.")
+                    except Exception:
+                        pass
             else:
                 # Before event: create EventRsvp (invited status)
                 if not rsvpExists:

--- a/app/logic/participants.py
+++ b/app/logic/participants.py
@@ -53,28 +53,30 @@ def addBnumberAsParticipant(bnumber, eventId):
         userStatus = "already signed in"
 
     else:
-        # If the event has already started, record as an EventParticipant (attendance).
-        # If the event is in the future, create an EventRsvp so RSVP lists remain consistent
-        # with templates that expect RSVP objects (which have `rsvpTime`).
+        # Non-RSVP and RSVP event handling
         userStatus = "success"
-        if event.isPastStart:
+        if event.isRsvpRequired:
+            # RSVP event: standard logic (RSVP before event, attend after)
+            if event.isPastStart:
+                totalHours = getEventLengthInHours(event.timeStart, event.timeEnd,  event.startDate)
+                EventParticipant.create(user=kioskUser, event=event, hoursEarned=totalHours)
+            else:
+                if not checkUserRsvp(kioskUser, event):
+                    currentRsvp = getEventRsvpCountsForTerm(event.term)
+                    waitlist = currentRsvp[event.id] >= event.rsvpLimit if event.rsvpLimit is not None else False
+                    EventRsvp.create(user=kioskUser, event=event, rsvpWaitlist=waitlist)
+                    targetList = "the waitlist" if waitlist else "the RSVP list"
+                    try:
+                        if g.current_user.username == kioskUser.username:
+                            createRsvpLog(event.id, f"{kioskUser.fullName} joined {targetList}.")
+                        else:
+                            createRsvpLog(event.id, f"Added {kioskUser.fullName} to {targetList}.")
+                    except Exception:
+                        pass
+        else:
+            # Non-RSVP event: scanner entry ALWAYS marks as attended regardless of timing
             totalHours = getEventLengthInHours(event.timeStart, event.timeEnd,  event.startDate)
             EventParticipant.create(user=kioskUser, event=event, hoursEarned=totalHours)
-        else:
-            # create RSVP if one doesn't already exist
-            if not checkUserRsvp(kioskUser, event):
-                currentRsvp = getEventRsvpCountsForTerm(event.term)
-                waitlist = currentRsvp[event.id] >= event.rsvpLimit if event.rsvpLimit is not None else False
-                EventRsvp.create(user=kioskUser, event=event, rsvpWaitlist=waitlist)
-                targetList = "the waitlist" if waitlist else "the RSVP list"
-                try:
-                    if g.current_user.username == kioskUser.username:
-                        createRsvpLog(event.id, f"{kioskUser.fullName} joined {targetList}.")
-                    else:
-                        createRsvpLog(event.id, f"Added {kioskUser.fullName} to {targetList}.")
-                except Exception:
-                    # logging should not break kiosk flow
-                    pass
 
     return kioskUser, userStatus
 
@@ -95,22 +97,34 @@ def addPersonToEvent(user, event):
     try:
         volunteerExists = checkUserVolunteer(user, event)
         rsvpExists = checkUserRsvp(user, event)
-        if event.isPastStart:
-            if not volunteerExists:
-                # We duplicate these two lines in addBnumberAsParticipant
-                eventHours = getEventLengthInHours(event.timeStart, event.timeEnd, event.startDate)
-                EventParticipant.create(user = user, event = event, hoursEarned = eventHours)
+        
+        if event.isRsvpRequired:
+            # RSVP event logic
+            if event.isPastStart:
+                if not volunteerExists:
+                    eventHours = getEventLengthInHours(event.timeStart, event.timeEnd, event.startDate)
+                    EventParticipant.create(user = user, event = event, hoursEarned = eventHours)
+            else:
+                if not rsvpExists:
+                    currentRsvp = getEventRsvpCountsForTerm(event.term)
+                    waitlist = currentRsvp[event.id] >= event.rsvpLimit if event.rsvpLimit is not None else 0
+                    EventRsvp.create(user = user, event = event, rsvpWaitlist = waitlist)
+                    targetList = "the waitlist" if waitlist else "the RSVP list"
+                    if g.current_user.username == user.username:
+                        createRsvpLog(event.id, f"{user.fullName} joined {targetList}.")
+                    else:
+                        createRsvpLog(event.id, f"Added {user.fullName} to {targetList}.")
         else:
-            if not rsvpExists:
-                currentRsvp = getEventRsvpCountsForTerm(event.term)
-                waitlist = currentRsvp[event.id] >= event.rsvpLimit if event.rsvpLimit is not None else 0
-                EventRsvp.create(user = user, event = event, rsvpWaitlist = waitlist)
-
-                targetList = "the waitlist" if waitlist else "the RSVP list"
-                if g.current_user.username == user.username:
-                    createRsvpLog(event.id, f"{user.fullName} joined {targetList}.")
-                else:
-                    createRsvpLog(event.id, f"Added {user.fullName} to {targetList}.")
+            # Non-RSVP event logic
+            if event.isPastStart:
+                # After event: create EventParticipant (attended)
+                if not volunteerExists:
+                    eventHours = getEventLengthInHours(event.timeStart, event.timeEnd, event.startDate)
+                    EventParticipant.create(user = user, event = event, hoursEarned = eventHours)
+            else:
+                # Before event: create EventRsvp (invited status)
+                if not rsvpExists:
+                    EventRsvp.create(user = user, event = event, rsvpWaitlist = False)
 
         if volunteerExists or rsvpExists:
             return "already in"

--- a/app/logic/participants.py
+++ b/app/logic/participants.py
@@ -107,7 +107,7 @@ def addPersonToEvent(user, event):
                 if not volunteerExists:
                     eventHours = getEventLengthInHours(event.timeStart, event.timeEnd, event.startDate)
                     EventParticipant.create(user = user, event = event, hoursEarned = eventHours)
-                    # try:
+                    try:
                         createRsvpLog(event.id, f"Marked {user.fullName} as attended.")
                     except Exception:
                         pass

--- a/app/logic/participants.py
+++ b/app/logic/participants.py
@@ -53,13 +53,28 @@ def addBnumberAsParticipant(bnumber, eventId):
         userStatus = "already signed in"
 
     else:
+        # If the event has already started, record as an EventParticipant (attendance).
+        # If the event is in the future, create an EventRsvp so RSVP lists remain consistent
+        # with templates that expect RSVP objects (which have `rsvpTime`).
         userStatus = "success"
-        # We are not using addPersonToEvent to do this because 
-        # that function checks if the event is in the past, but
-        # someone could start signing people up via the kiosk
-        # before an event has started
-        totalHours = getEventLengthInHours(event.timeStart, event.timeEnd,  event.startDate)
-        EventParticipant.create (user=kioskUser, event=event, hoursEarned=totalHours)
+        if event.isPastStart:
+            totalHours = getEventLengthInHours(event.timeStart, event.timeEnd,  event.startDate)
+            EventParticipant.create(user=kioskUser, event=event, hoursEarned=totalHours)
+        else:
+            # create RSVP if one doesn't already exist
+            if not checkUserRsvp(kioskUser, event):
+                currentRsvp = getEventRsvpCountsForTerm(event.term)
+                waitlist = currentRsvp[event.id] >= event.rsvpLimit if event.rsvpLimit is not None else False
+                EventRsvp.create(user=kioskUser, event=event, rsvpWaitlist=waitlist)
+                targetList = "the waitlist" if waitlist else "the RSVP list"
+                try:
+                    if g.current_user.username == kioskUser.username:
+                        createRsvpLog(event.id, f"{kioskUser.fullName} joined {targetList}.")
+                    else:
+                        createRsvpLog(event.id, f"Added {kioskUser.fullName} to {targetList}.")
+                except Exception:
+                    # logging should not break kiosk flow
+                    pass
 
     return kioskUser, userStatus
 

--- a/app/logic/volunteers.py
+++ b/app/logic/volunteers.py
@@ -6,7 +6,7 @@ from app.models.program import Program
 from app.models.backgroundCheck import BackgroundCheck
 from app.models.programManager import ProgramManager
 from datetime import datetime, date
-from app.logic.createLogs import createActivityLog
+from app.logic.createLogs import createActivityLog, createRsvpLog
 
 def getEventLengthInHours(startTime, endTime, eventDate):
     """
@@ -46,6 +46,10 @@ def updateEventParticipants(participantData):
                                       .execute())
                 else:
                     EventParticipant.create(user=userObject, event=event, hoursEarned=hoursEarned)
+                    try:
+                        createRsvpLog(event.id, f"Marked {userObject.fullName} as attended.")
+                    except Exception:
+                        pass
             else:
                 ((EventParticipant.delete()
                                   .where(EventParticipant.user==userObject.username, EventParticipant.event==event.id))

--- a/app/models/eventRsvp.py
+++ b/app/models/eventRsvp.py
@@ -9,6 +9,10 @@ class EventRsvp(baseModel):
     rsvpTime = DateTimeField(default=datetime.now)
     rsvpWaitlist = BooleanField(default=False)
 
+    @property
+    def rsvp(self):
+        # EventRsvp always represents an RSVP record, including invited participants.
+        return True
 
     class Meta:
         indexes = ( (('user', 'event'), True), )

--- a/app/static/js/volunteerDetails.js
+++ b/app/static/js/volunteerDetails.js
@@ -29,7 +29,7 @@ $(document).ready(function () {
 		if (status === 'attended' && !$('#attendedSelect').is(':checked')) return false;
 		if (status === 'rsvp' && !$('#rsvpSelect').is(':checked')) return false;
 		if (status === 'invited' && !$('#invitedSelect').is(':checked')) return false;
-		if (status === 'waitlist' && !$('#waitlistSelect').is(':checked')) return false;
+		if (status === 'waitlisted' && !$('#waitlistSelect').is(':checked')) return false;
 		return true;
 	});
 	function hideDuplicateVolunteers() {

--- a/app/static/js/volunteerDetails.js
+++ b/app/static/js/volunteerDetails.js
@@ -28,6 +28,7 @@ $(document).ready(function () {
 		const status = data[3].toLowerCase(); 
 		if (status === 'attended' && !$('#attendedSelect').is(':checked')) return false;
 		if (status === 'rsvp' && !$('#rsvpSelect').is(':checked')) return false;
+		if (status === 'invited' && !$('#invitedSelect').is(':checked')) return false;
 		if (status === 'waitlist' && !$('#waitlistSelect').is(':checked')) return false;
 		return true;
 	});

--- a/app/templates/events/manageVolunteers.html
+++ b/app/templates/events/manageVolunteers.html
@@ -239,7 +239,11 @@
     <div class="accordion-item">
       <h2 class="accordion-header">
         <button class="accordion-button collapsed fs-4" type="button" data-bs-toggle="collapse" data-bs-target="#non-attended-collapse">
-          RSVP, Invited, and Waitlist
+          {% if event.isRsvpRequired %}
+            RSVP and Waitlist
+          {% else %}
+            Invited and Waitlist
+          {% endif %}
         </button>
       </h2>
       <div class="accordion-collapse collapse" id="non-attended-collapse">

--- a/app/templates/events/manageVolunteers.html
+++ b/app/templates/events/manageVolunteers.html
@@ -239,7 +239,7 @@
     <div class="accordion-item">
       <h2 class="accordion-header">
         <button class="accordion-button collapsed fs-4" type="button" data-bs-toggle="collapse" data-bs-target="#non-attended-collapse">
-          RSVP and Waitlist
+          RSVP, Invited, and Waitlist
         </button>
       </h2>
       <div class="accordion-collapse collapse" id="non-attended-collapse">
@@ -275,7 +275,7 @@
                   </td>
                   <td>{{participant.user.email}}</td>
                   <td>{{participant.user.phoneNumber}}</td>
-                  <td>{{ 'Waitlist' if participant.rsvpWaitlist else 'RSVP' }}</td>
+                  <td>{{ 'Waitlist' if participant.rsvpWaitlist else ('RSVP' if event.isRsvpRequired else 'Invited') }}</td>
                   <td>
                   <input
                     class="form-control number-only form-control input-sm"

--- a/app/templates/events/volunteerDetails.html
+++ b/app/templates/events/volunteerDetails.html
@@ -59,7 +59,6 @@
 {% macro printParticipants(type, attended, rsvp, waitlist) %}
     {% set seen = [] %}
     {% set combinedParticipants = attended + rsvp + waitlist %}
-<<<<<<< HEAD
     {% for p in combinedParticipants | unique %}
       {% if p in attended %}
           {{createTable(p, 'attended') if type == 'table' else createCard(p, 'attended') }}
@@ -70,28 +69,7 @@
       {% elif p in waitlist %}
           {{createTable(p, 'waitlisted') if type == 'table' else createCard(p, 'waitlisted') }}
       {% endif %}
-=======
-    {% for p in combinedParticipants %}
-        {% set username = p.user.username %}
-        {% if username not in seen %}
-            {% set _ = seen.append(username) %}
-            {% set status = none %}
-            {% if p in attended %}
-                {% set status = 'attended'%}
-            {% elif p in rsvp %}
-                {% set status = 'rsvp'%}
-            {% elif p in waitlist %}
-                {% set status = 'waitlist'%}
-            {% endif %}
-            {% if status %}
-                {% if type == 'card' %}
-                    {{ createCard(p, status) }}
-                {% elif type == 'table' %}
-                    {{ createTable(p, status) }}
-                {% endif %}
-            {% endif %}
-        {% endif %}
->>>>>>> 00969230e5d6ad117348383fe467c68ae96700f3
+
     {% endfor %}
 {% endmacro %}
 

--- a/app/templates/events/volunteerDetails.html
+++ b/app/templates/events/volunteerDetails.html
@@ -60,16 +60,13 @@
     {% set seen = [] %}
     {% set combinedParticipants = attended + rsvp + waitlist %}
     {% for p in combinedParticipants | unique %}
-      {% if p in rsvp and not event.isRsvpRequired %}
-      {{createTable(p, 'invited') if type == 'table' else createCard(p, 'invited') }}
-      {% endif %}
-      {% if p in rsvp and event.isRsvpRequired %}
-          {{createTable(p, 'rsvp') if type == 'table' else createCard(p, 'rsvp') }}
-      {% endif %}
-      {% if p in attended%}
+      {% if p in attended %}
           {{createTable(p, 'attended') if type == 'table' else createCard(p, 'attended') }}
-      {% endif %}
-      {% if p in waitlist %}
+      {% elif p in rsvp and not event.isRsvpRequired %}
+      {{createTable(p, 'invited') if type == 'table' else createCard(p, 'invited') }}
+      {% elif p in rsvp and event.isRsvpRequired %}
+          {{createTable(p, 'rsvp') if type == 'table' else createCard(p, 'rsvp') }}
+      {% elif p in waitlist %}
           {{createTable(p, 'waitlisted') if type == 'table' else createCard(p, 'waitlisted') }}
       {% endif %}
     {% endfor %}

--- a/tests/code/test_participants.py
+++ b/tests/code/test_participants.py
@@ -13,7 +13,7 @@ from app.models.term import Term
 from app.models.program import Program
 from app.models.eventParticipant import EventParticipant
 from app.logic.volunteers import getEventLengthInHours, updateEventParticipants
-from app.logic.participants import unattendedRequiredEvents, addBnumberAsParticipant, getEventParticipants, trainedParticipants, getParticipationStatusForTrainings, checkUserRsvp, checkUserVolunteer, addPersonToEvent, sortParticipantsByStatus
+from app.logic.participants import getTargetList, unattendedRequiredEvents, addBnumberAsParticipant, getEventParticipants, trainedParticipants, getParticipationStatusForTrainings, checkUserRsvp, checkUserVolunteer, addPersonToEvent, sortParticipantsByStatus
 from app.models.eventRsvp import EventRsvp
 
 
@@ -141,6 +141,28 @@ def test_addPersonToEvent():
             assert addWaitlist == True
             assert len(rsvpWaitlist) == 1
             assert len(rsvpNoWaitlist) == 1
+        
+        transaction.rollback()
+
+@pytest.mark.integration
+def test_getTargetList():
+    with mainDB.atomic() as transaction:
+        current_term = Term.get(Term.isCurrentTerm == True)
+        
+        # Test case 1: waitlist=True should always return "the waitlist"
+        event_rsvp = Event.create(term=current_term, program=9, isRsvpRequired=True)
+        assert getTargetList(event_rsvp, waitlist=True) == "the waitlist"
+        
+        event_invited = Event.create(term=current_term, program=9, isRsvpRequired=False)
+        assert getTargetList(event_invited, waitlist=True) == "the waitlist"
+        
+        # Test case 2: waitlist=False and isRsvpRequired=False should return "the Invited list"
+        assert event_invited.isRsvpRequired == False  # Ensure the event has RSVP not required
+        assert getTargetList(event_invited, waitlist=False) == "the Invited list"
+        
+        # Test case 3: waitlist=False and isRsvpRequired=True should return "the RSVP list"
+        assert event_rsvp.isRsvpRequired == True  # Ensure the event has RSVP required
+        assert getTargetList(event_rsvp, waitlist=False) == "the RSVP list"
         
         transaction.rollback()
 


### PR DESCRIPTION
## Issue Description

Fixes #1663
For events that are not expecting RSVP, we need to change our language to 'Invited' students, if people are added ahead of time. Wherever we display those RSVP students, both before and after the event, should reflect this change.

Current Issue:
Addressing how when saving individuals as attended after an event has started causes the filter to only show attended individiduals.

## New Changes (2/23/26)
-  Added a feature in participants.py in which if the event is in the past, an eventParticipant will be created assigning hours to the volunteer and if the event is in the future, then an EventRSVP will be made labeling them as an RSVP.

## New Changes (2/9/26)
- Removed the invitedUser variable in Volunteer.py, also used in VolunteerDetails.html
- Removed time restraints to the invitedUser variable and attendedUser variable .
- Added condition to tables under 'manage volunteers' and 'volunteer details' that would check if RsvpRequired  was required or not. This resulted in 'invited' only showing on the tables within a Non-RSVP event and 'RSVP' only showing on the tables within a RSVP event.
- changed eventVolunteerData to include non-waitlist RSVP's so that the manage volunteer table can see ALL the volunteers added to the event

## Changes (Original)

- Created the invitedUser variable in Volunteer.py, also used in VolunteerDetails.html
- Added time restraints to the invitedUser variable and attendedUser variable so that the code could differentiate between them based on whether the student joined before or after the event. (Also adjusts so that if the event starts, they are considered attended)

## Testing
- Go to "Settings" under the "Admin" tab
- Click on the "Term Management" drop down section
- Click on the most recent year and then click add new term (Repeat until you can click on Spring 2026)
<img width="1585" height="621" alt="image" src="https://github.com/user-attachments/assets/6a154c0d-9d56-41c3-8d9c-e5ce6766cc94" />

Under "Create Events":
- Create two events of any type with under admin permissions (one event needs to have RSVP and the other shouldn't)
- They both need to have a date after your current day (nothing on or before your current date in real life)
- Switch to student and sign up for both events:
       Note: To add the student to the non-RSVP event:
                - retrieve the student's B# from their profile
                - Switch back to Brian's Admin Profile
                - Go to event's list and click on the non-Rsvp event
                - Click on Manage Volunteers, click Scanner Entry, then past the B# 
                - This should result in the 'Invited' status in a non-RSVP event, and 'RSVP' status on a RSVP Event. 
- Once you go to "Volunteer Details", within "Events List", you will see that the student has been added as well as their status
- Look at the table view, under volunteer status, the student will either be "RSVP", "Invited", "Waitlisted, or "Attended"
<img width="1576" height="603" alt="image" src="https://github.com/user-attachments/assets/dd564bce-3dbc-490b-985c-ce4344311a3d" />

Note (UPDATED-2/9/26): 
RSVP- A person who registered for an RSVP event online 
Attended- An RSVP individual entered manually through Barcode to an RSVP event
Invited- An individual manually added to a non-RSVP event (using name search)
Waitlisted- A person who registered for the event after the RSVP limit was reached

The creation of these two previous events is to make sure that' RSVP' shows up under the RSVP event and 'Invited' shows up for the non-RSVP event.  The ATTENDED status will only show if entered through the barcode. This is because the barcode and B# scanner is only used during and at the start of school events meaning the student is already there. Now you will create the third.