### PR TITLE
Non enrolled and graduated students

### DIFF
--- a/app/logic/graduationManagement.py
+++ b/app/logic/graduationManagement.py
@@ -27,16 +27,26 @@ def getGraduationManagementUsers():
 
     return graduationManagementUsers
 
-
 def setGraduatedStatus(username, status):
     """
-    Update a students graduation status based on the parameter status.
+    Update a student's graduation status.
     """
     gradStudent = User.get(User.username == username)
-    
+
     # it is necessary we cast this to an int instead of a bool because the
     # status is passed as a string and if we cast it to a bool it will always be True
-    gradStudent.hasGraduated = int(status)
+
+    status = int(status)
+
+    if status == 1:
+        # Mark as alumni
+        gradStudent.hasGraduated = True
+        gradStudent.rawClassLevel = "Graduating"
+    else:
+        # Revert to currently enrolled senior
+        gradStudent.hasGraduated = False
+        gradStudent.rawClassLevel = "Senior"
 
     gradStudent.save()
+
  

--- a/app/logic/graduationManagement.py
+++ b/app/logic/graduationManagement.py
@@ -13,7 +13,7 @@ def getGraduationManagementUsers():
 
     eligibleUsers = (User.select(User.username, User.hasGraduated, User.rawClassLevel, User.firstName, User.lastName, BonnerCohort.year)
                  .join(BonnerCohort, JOIN.LEFT_OUTER, on=(BonnerCohort.user == User.username))
-                 .where((User.rawClassLevel == 'Senior') | (User.rawClassLevel == "Graduating") | (User.hasGraduated == True) | (User.rawClassLevel == "Alumni")))
+                 .where((User.rawClassLevel == 'Senior') | (User.rawClassLevel == "Graduating") | (User.hasGraduated == True) ))
 
     cceStudents = set([user["username"] for user in getMinorProgress()])
 

--- a/app/logic/graduationManagement.py
+++ b/app/logic/graduationManagement.py
@@ -13,7 +13,7 @@ def getGraduationManagementUsers():
 
     eligibleUsers = (User.select(User.username, User.hasGraduated, User.rawClassLevel, User.firstName, User.lastName, BonnerCohort.year)
                  .join(BonnerCohort, JOIN.LEFT_OUTER, on=(BonnerCohort.user == User.username))
-                 .where((User.rawClassLevel == 'Senior') | (User.rawClassLevel == "Graduating") | (User.hasGraduated == True)))
+                 .where((User.rawClassLevel == 'Senior') | (User.rawClassLevel == "Graduating") | (User.hasGraduated == True) | (User.rawClassLevel == "Alumni")))
 
     cceStudents = set([user["username"] for user in getMinorProgress()])
 

--- a/app/logic/graduationManagement.py
+++ b/app/logic/graduationManagement.py
@@ -10,6 +10,7 @@ def getGraduationManagementUsers():
     """
     Function to fetch all senior students along with their CCE Minor Progress and Bonner Status 
     """
+    # in case you are wondering, "Graduating" means: graduation term has passed but hasGraduated may not yet be set
 
     eligibleUsers = (User.select(User.username, User.hasGraduated, User.rawClassLevel, User.firstName, User.lastName, BonnerCohort.year)
                  .join(BonnerCohort, JOIN.LEFT_OUTER, on=(BonnerCohort.user == User.username))
@@ -42,6 +43,7 @@ def setGraduatedStatus(username, status):
         # Mark as alumni
         gradStudent.hasGraduated = True
         gradStudent.rawClassLevel = "Graduating"
+        # in case you are wondering, "Graduating" means: graduation term has passed but hasGraduated may not yet be set
     else:
         # Revert to currently enrolled senior
         gradStudent.hasGraduated = False

--- a/app/logic/graduationManagement.py
+++ b/app/logic/graduationManagement.py
@@ -28,26 +28,12 @@ def getGraduationManagementUsers():
     return graduationManagementUsers
 
 def setGraduatedStatus(username, status):
-    """
-    Update a student's graduation status.
-    "Graduating" means: graduation term has passed but hasGraduated may not yet be set. Graduating students are treated as alumni once their graduation term has passed
-    """
     gradStudent = User.get(User.username == username)
 
     # it is necessary we cast this to an int instead of a bool because the
     # status is passed as a string and if we cast it to a bool it will always be True
 
-    status = int(status)
-
-    if status:
-        # Mark as alumni
-        gradStudent.hasGraduated = True
-        gradStudent.rawClassLevel = "Graduating"
-    else:
-        # Revert to currently enrolled senior
-        gradStudent.hasGraduated = False
-        gradStudent.rawClassLevel = "Senior"
-
+    gradStudent.hasGraduated = int(status)
     gradStudent.save()
 
  

--- a/app/logic/graduationManagement.py
+++ b/app/logic/graduationManagement.py
@@ -38,7 +38,7 @@ def setGraduatedStatus(username, status):
 
     status = int(status)
 
-    if status == 1:
+    if status:
         # Mark as alumni
         gradStudent.hasGraduated = True
         gradStudent.rawClassLevel = "Graduating"

--- a/app/logic/graduationManagement.py
+++ b/app/logic/graduationManagement.py
@@ -9,8 +9,8 @@ from app.logic.minor import getMinorProgress
 def getGraduationManagementUsers():
     """
     Function to fetch all senior students along with their CCE Minor Progress and Bonner Status 
+    "Graduating" means: graduation term has passed but hasGraduated may not yet be set
     """
-    # in case you are wondering, "Graduating" means: graduation term has passed but hasGraduated may not yet be set
 
     eligibleUsers = (User.select(User.username, User.hasGraduated, User.rawClassLevel, User.firstName, User.lastName, BonnerCohort.year)
                  .join(BonnerCohort, JOIN.LEFT_OUTER, on=(BonnerCohort.user == User.username))

--- a/app/logic/graduationManagement.py
+++ b/app/logic/graduationManagement.py
@@ -9,7 +9,6 @@ from app.logic.minor import getMinorProgress
 def getGraduationManagementUsers():
     """
     Function to fetch all senior students along with their CCE Minor Progress and Bonner Status 
-    "Graduating" means: graduation term has passed but hasGraduated may not yet be set
     """
 
     eligibleUsers = (User.select(User.username, User.hasGraduated, User.rawClassLevel, User.firstName, User.lastName, BonnerCohort.year)
@@ -31,6 +30,7 @@ def getGraduationManagementUsers():
 def setGraduatedStatus(username, status):
     """
     Update a student's graduation status.
+    "Graduating" means: graduation term has passed but hasGraduated may not yet be set. Graduating students are treated as alumni once their graduation term has passed
     """
     gradStudent = User.get(User.username == username)
 
@@ -43,7 +43,6 @@ def setGraduatedStatus(username, status):
         # Mark as alumni
         gradStudent.hasGraduated = True
         gradStudent.rawClassLevel = "Graduating"
-        # in case you are wondering, "Graduating" means: graduation term has passed but hasGraduated may not yet be set
     else:
         # Revert to currently enrolled senior
         gradStudent.hasGraduated = False

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -36,7 +36,7 @@ class User(baseModel):
         return "Graduated" if (self.hasGraduated) else self.rawClassLevel
 
     @property
-    def isAnAlum(self):
+    def isAlumni(self):
         "function to determine if user is an alum"
         alumLevels = ["Graduated", "Alum"]
         return self.processedClassLevel in alumLevels

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -31,15 +31,13 @@ class User(baseModel):
     
     @property
     def processedClassLevel(self):
-        if not self.rawClassLevel:
-            return ""
-        return "Graduated" if (self.hasGraduated) else self.rawClassLevel
+        if self.hasGraduated:
+            return "Alumni"
+        return self.rawClassLevel or "Not Enrolled"
 
     @property
     def isAlumni(self):
-        "function to determine if user is an alum"
-        alumLevels = ["Graduated", "Alum"]
-        return self.processedClassLevel in alumLevels
+        return self.hasGraduated
     
     @property 
     def isNotEnrolled(self):

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -37,6 +37,7 @@ class User(baseModel):
 
     @property
     def isAlumni(self):
+        # in case you are wondering, "Graduating" means: graduation term has passed but hasGraduated may not yet be set
         return self.hasGraduated or self.rawClassLevel == "Graduating"
     
     @property 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -38,6 +38,7 @@ class User(baseModel):
     @property
     def isAlumni(self):
         # in case you are wondering, "Graduating" means: graduation term has passed but hasGraduated may not yet be set
+        # Graduating students are treated as alumni once their graduation term has passed
         return self.hasGraduated or self.rawClassLevel == "Graduating"
     
     @property 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -37,8 +37,9 @@ class User(baseModel):
 
     @property
     def isAlumni(self):
-        # in case you are wondering, "Graduating" means: graduation term has passed but hasGraduated may not yet be set
-        # Graduating students are treated as alumni once their graduation term has passed
+        """
+        "Graduating" means: graduation term has passed but hasGraduated may not yet be set
+        """
         return self.hasGraduated or self.rawClassLevel == "Graduating"
     
     @property 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -31,17 +31,17 @@ class User(baseModel):
     
     @property
     def processedClassLevel(self):
-        if self.hasGraduated:
+        if self.hasGraduated or self.rawClassLevel == "Graduating":
             return "Alumni"
         return self.rawClassLevel or "Not Enrolled"
 
     @property
     def isAlumni(self):
-        return self.hasGraduated
+        return self.hasGraduated or self.rawClassLevel == "Graduating"
     
     @property 
     def isCurrentlyEnrolled(self):
-        return self.isStudent and not self.hasGraduated
+        return self.isStudent and not self.isAlumni
 
     @property
     def isAdmin(self):

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -31,7 +31,7 @@ class User(baseModel):
     
     @property
     def processedClassLevel(self):
-        if self.hasGraduated or self.rawClassLevel == "Graduating":
+        if self.isAlumni:
             return "Alumni"
         return self.rawClassLevel or "Not Enrolled"
 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -37,9 +37,6 @@ class User(baseModel):
 
     @property
     def isAlumni(self):
-        """
-        "Graduating" means: graduation term has passed but hasGraduated may not yet be set
-        """
         return self.hasGraduated or self.rawClassLevel == "Graduating"
     
     @property 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -36,6 +36,18 @@ class User(baseModel):
         return "Graduated" if (self.hasGraduated) else self.rawClassLevel
 
     @property
+    def isAnAlum(self):
+        "function to determine if user is an alum"
+        alumLevels = ["Graduated", "Alum"]
+        return self.processedClassLevel in alumLevels
+    
+    @property 
+    def isNotEnrolled(self):
+        "function to determine if user is not enrolled, i.e. when the student is neither a freshman, sophomore, junior, or senior or has graduated"
+        notEnrolledLevels = ["Not Enrolled", "Graduated", "Alum"]
+        return self.processedClassLevel in notEnrolledLevels
+
+    @property
     def isAdmin(self):
         return (self.isCeltsAdmin or self.isCeltsStudentStaff)
 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -40,10 +40,8 @@ class User(baseModel):
         return self.hasGraduated
     
     @property 
-    def isNotEnrolled(self):
-        "function to determine if user is not enrolled, i.e. when the student is neither a freshman, sophomore, junior, or senior or has graduated"
-        notEnrolledLevels = ["Not Enrolled", "Graduated", "Alum"]
-        return self.processedClassLevel in notEnrolledLevels
+    def isCurrentlyEnrolled(self):
+        return self.isStudent and not self.hasGraduated
 
     @property
     def isAdmin(self):

--- a/app/static/js/graduationManagement.js
+++ b/app/static/js/graduationManagement.js
@@ -46,6 +46,7 @@ $(document).ready(function() {
     function getRowStatus(row) {
         return $(row).data('status');
     }
+    
     function filterTable(dataField, expectedValue) {
         gradStudentsTable.rows().every(function() {
             const row = this.node();

--- a/app/static/js/graduationManagement.js
+++ b/app/static/js/graduationManagement.js
@@ -43,22 +43,26 @@ $(document).ready(function() {
 
     })
 
+    function getRowStatus(row) {
+        return $(row).data('status');
+    }
     function filterTable(dataField, expectedValue) {
         gradStudentsTable.rows().every(function() {
-            var hasGraduated = $(this.node()).find('input[type="checkbox"]').is(':checked');
-            if (!showGraduatedStudents() && hasGraduated) {
-                $(this.node()).addClass('hidden')
-                return 
+            const row = this.node();
+            const status = getRowStatus(row);
+            if (!showGraduatedStudents() && status === 'alumni') {
+                $(row).addClass('hidden');
+                return;
             }
-            var data = $(this.node()).data(dataField); 
+            const data = $(row).data(dataField);
 
             if (data === expectedValue) {
-                $(this.node()).removeClass('hidden')
+                $(row).removeClass('hidden');
             } else {
-                $(this.node()).addClass('hidden')
+                $(row).addClass('hidden');
             }
         });
-        redrawTable()
+        redrawTable();
     }
 
     function handleBonnerFilterChange(cohortYear, buttonText) {
@@ -94,10 +98,10 @@ $(document).ready(function() {
 
             gradStudentsTable.search('').draw();
             gradStudentsTable.rows().every(function() {
-                var hasGraduated = $(this.node()).find('input[type="checkbox"]').is(':checked');
-                if (!showGraduatedStudents() && hasGraduated) {
-                    $(this.node()).addClass('hidden')
-                    return 
+                const status = getRowStatus(this.node());
+                if (!showGraduatedStudents() && status === 'alumni') {
+                    $(this.node()).addClass('hidden');
+                    return;
                 }
                 $(this.node()).removeClass('hidden');
             });
@@ -134,7 +138,14 @@ $(document).ready(function() {
             success: function(response) {
                 initializePage()
                 msgFlash(`Saved graduation status for ${username}.`, "success", 1000)
-                $(`#${username}ClassLevel`).html(hasGraduated ? "Graduated" : "Senior")
+                const row = $(`tr[data-username="${username}"]`);
+                if (hasGraduated) {
+                    row.data('status', 'alumni');
+                    $(`#${username}ClassLevel`).text("Alumni");
+                } else {
+                    row.data('status', 'enrolled');
+                    $(`#${username}ClassLevel`).text("Senior");
+                }
             },
             error: function(status, error) {
                 console.error("Error updating graduation status:", error);

--- a/app/static/js/graduationManagement.js
+++ b/app/static/js/graduationManagement.js
@@ -142,6 +142,10 @@ $(document).ready(function() {
                 if (hasGraduated) {
                     row.data('status', 'alumni');
                     $(`#${username}ClassLevel`).text("Alumni");
+                    if (!showGraduatedStudents()) {
+                        row.addClass('hidden');
+                        redrawTable();
+                    }
                 } else {
                     row.data('status', 'enrolled');
                     $(`#${username}ClassLevel`).text("Senior");

--- a/app/templates/admin/graduationManagement.html
+++ b/app/templates/admin/graduationManagement.html
@@ -61,7 +61,7 @@
   <tbody>
     {% for userData in users %}
     {% set user = userData['user'] %}
-    <tr data-cce-progress="{{userData['minorProgress']}}" data-cohort-year="{{userData['cohort']}}" data-student-type="{% if user.isBonnerScholar %}bonner{% else %}all{% endif %}" data-username="{{user.username}}">
+    <tr data-status="{% if user.isAlumni %}alumni{% elif user.isCurrentlyEnrolled %}enrolled{% else %}non-enrolled{% endif %}" data-cce-progress="{{ userData['minorProgress'] }}" data-cohort-year="{{ userData['cohort'] }}" data-student-type="{% if user.isBonnerScholar %}bonner{% else %}all{% endif %}" data-username="{{ user.username }}" >
       <td style="width: 5%;"><input type="checkbox" class="mx-auto w-100 graduated-checkbox" id="gradCheck" data-username="{{ user.username }}" {% if user.hasGraduated %}checked{% endif %}></td>
       <td><a href="/profile/{{ user.username }}" target="_blank">{{ user.firstName }} {{ user.lastName }}</a></td>
       <td id="{{user.username}}ClassLevel">{{user.processedClassLevel if user.processedClassLevel != "Graduating" else "Senior"}}</td>

--- a/app/templates/admin/graduationManagement.html
+++ b/app/templates/admin/graduationManagement.html
@@ -62,7 +62,7 @@
     {% for userData in users %}
     {% set user = userData['user'] %}
     <tr data-status="{% if user.isAlumni %}alumni{% elif user.isCurrentlyEnrolled %}enrolled{% else %}non-enrolled{% endif %}" data-cce-progress="{{ userData['minorProgress'] }}" data-cohort-year="{{ userData['cohort'] }}" data-student-type="{% if user.isBonnerScholar %}bonner{% else %}all{% endif %}" data-username="{{ user.username }}" >
-      <td style="width: 5%;"><input type="checkbox" class="mx-auto w-100 graduated-checkbox" id="gradCheck" data-username="{{ user.username }}" {% if user.hasGraduated %}checked{% endif %}></td>
+      <td style="width: 5%;"><input type="checkbox" class="mx-auto w-100 graduated-checkbox" id="gradCheck" data-username="{{ user.username }}" {% if user.isAlumni %}checked{% endif %}></td>
       <td><a href="/profile/{{ user.username }}" target="_blank">{{ user.firstName }} {{ user.lastName }}</a></td>
       <td id="{{ user.username }}ClassLevel"> {{ user.processedClassLevel }} </td>
     </tr>

--- a/app/templates/admin/graduationManagement.html
+++ b/app/templates/admin/graduationManagement.html
@@ -64,7 +64,7 @@
     <tr data-status="{% if user.isAlumni %}alumni{% elif user.isCurrentlyEnrolled %}enrolled{% else %}non-enrolled{% endif %}" data-cce-progress="{{ userData['minorProgress'] }}" data-cohort-year="{{ userData['cohort'] }}" data-student-type="{% if user.isBonnerScholar %}bonner{% else %}all{% endif %}" data-username="{{ user.username }}" >
       <td style="width: 5%;"><input type="checkbox" class="mx-auto w-100 graduated-checkbox" id="gradCheck" data-username="{{ user.username }}" {% if user.hasGraduated %}checked{% endif %}></td>
       <td><a href="/profile/{{ user.username }}" target="_blank">{{ user.firstName }} {{ user.lastName }}</a></td>
-      <td id="{{user.username}}ClassLevel">{{user.processedClassLevel if user.processedClassLevel != "Graduating" else "Senior"}}</td>
+      <td id="{{ user.username }}ClassLevel"> {{ user.processedClassLevel }} </td>
     </tr>
     {% endfor %}
   </tbody>  

--- a/database/reset_database.sh
+++ b/database/reset_database.sh
@@ -29,10 +29,10 @@ fi
 
 ########### Recreate Database Schema ###########
 echo "Dropping databases"
-mysql -u root --execute="DROP DATABASE \`celts\`; DROP USER 'celts_user';"
+mysql -u root -proot --execute="DROP DATABASE \`celts\`; DROP USER 'celts_user';"
 
 echo "Recreating databases and users"
-mysql -u root --execute="CREATE DATABASE IF NOT EXISTS \`celts\`; CREATE USER IF NOT EXISTS 'celts_user'@'%' IDENTIFIED BY 'password'; GRANT ALL PRIVILEGES ON *.* TO 'celts_user'@'%';"
+mysql -u root -proot --execute="CREATE DATABASE IF NOT EXISTS \`celts\`; CREATE USER IF NOT EXISTS 'celts_user'@'%' IDENTIFIED BY 'password'; GRANT ALL PRIVILEGES ON *.* TO 'celts_user'@'%';"
 
 
 # remove ahead of time in case we didn't clean up last time
@@ -42,7 +42,7 @@ rm -rf migrations.json
 echo -n "Creating database objects"
 if [ $BACKUP -eq 1 ]; then
     echo " from backup"
-    mysql -u root celts < prod-backup.sql
+    mysql -u root -proot celts < prod-backup.sql
 else
     echo " empty"
     ./migrate_db.sh no-backup

--- a/database/reset_database.sh
+++ b/database/reset_database.sh
@@ -29,10 +29,10 @@ fi
 
 ########### Recreate Database Schema ###########
 echo "Dropping databases"
-mysql -u root -proot --execute="DROP DATABASE \`celts\`; DROP USER 'celts_user';"
+mysql -u root --execute="DROP DATABASE \`celts\`; DROP USER 'celts_user';"
 
 echo "Recreating databases and users"
-mysql -u root -proot --execute="CREATE DATABASE IF NOT EXISTS \`celts\`; CREATE USER IF NOT EXISTS 'celts_user'@'%' IDENTIFIED BY 'password'; GRANT ALL PRIVILEGES ON *.* TO 'celts_user'@'%';"
+mysql -u root --execute="CREATE DATABASE IF NOT EXISTS \`celts\`; CREATE USER IF NOT EXISTS 'celts_user'@'%' IDENTIFIED BY 'password'; GRANT ALL PRIVILEGES ON *.* TO 'celts_user'@'%';"
 
 
 # remove ahead of time in case we didn't clean up last time
@@ -42,7 +42,7 @@ rm -rf migrations.json
 echo -n "Creating database objects"
 if [ $BACKUP -eq 1 ]; then
     echo " from backup"
-    mysql -u root -proot celts < prod-backup.sql
+    mysql -u root celts < prod-backup.sql
 else
     echo " empty"
     ./migrate_db.sh no-backup

--- a/tests/code/test_graduationManagement.py
+++ b/tests/code/test_graduationManagement.py
@@ -25,27 +25,34 @@ from app.models.activityLog import ActivityLog
 @pytest.mark.integration
 def test_setGraduationStatus():
     with mainDB.atomic() as transaction:
-        # Create a user to run the tests with
-        testUser = User.create(username = 'usrtst',
-                           firstName = 'Test',
-                           lastName = 'User',
-                           bnumber = '03522492',
-                           email = 'usert@berea.deu',
-                           hasGraduated = False)
-        
-        # make sure users have the default values of false and not interested, respectively
-        assert testUser.hasGraduated == False
-        setGraduatedStatus(testUser.username, 1)
-        
-        testUser = User.get_by_id(testUser.username)
-        # make sure setGraduatedStatus works correctly
-        assert testUser.hasGraduated == True
-        
-        # verify unchecking box will restore defaults
-        setGraduatedStatus(testUser.username, 0)
-        
-        testUser = User.get_by_id(testUser.username)
-        assert testUser.hasGraduated == False
+        # Create a senior student
+        user = User.create(
+            username="gradtoggle",
+            firstName="Grad",
+            lastName="Toggle",
+            bnumber="B00888888",
+            email="gradtoggle@berea.edu",
+            isStudent=True,
+            rawClassLevel="Senior",
+            hasGraduated=False
+        )
+
+        # Mark as graduated
+        setGraduatedStatus("gradtoggle", 1)
+        user = User.get_by_id("gradtoggle")
+
+        assert user.hasGraduated is True
+        assert user.rawClassLevel == "Graduating"
+        assert user.processedClassLevel == "Alumni"
+
+        # Unmark as graduated
+        setGraduatedStatus("gradtoggle", 0)
+        user = User.get_by_id("gradtoggle")
+
+        assert user.hasGraduated is False
+        assert user.rawClassLevel == "Senior"
+        assert user.processedClassLevel == "Senior"
+
         transaction.rollback()
 
 @pytest.mark.integration

--- a/tests/code/test_graduationManagement.py
+++ b/tests/code/test_graduationManagement.py
@@ -33,7 +33,7 @@ def test_setGraduationStatus():
             bnumber="B00888888",
             email="gradtoggle@berea.edu",
             isStudent=True,
-            rawClassLevel="Senior",
+            rawClassLevel="Junior",
             hasGraduated=False
         )
 
@@ -42,7 +42,7 @@ def test_setGraduationStatus():
         user = User.get_by_id("gradtoggle")
 
         assert user.hasGraduated is True
-        assert user.rawClassLevel == "Graduating"
+        assert user.rawClassLevel == "Junior"
         assert user.processedClassLevel == "Alumni"
 
         # Unmark as graduated
@@ -50,8 +50,8 @@ def test_setGraduationStatus():
         user = User.get_by_id("gradtoggle")
 
         assert user.hasGraduated is False
-        assert user.rawClassLevel == "Senior"
-        assert user.processedClassLevel == "Senior"
+        assert user.rawClassLevel == "Junior"
+        assert user.processedClassLevel == "Junior"
 
         transaction.rollback()
 

--- a/tests/code/test_users.py
+++ b/tests/code/test_users.py
@@ -492,3 +492,49 @@ def test_hasCurrentCeltsLabor():
         # Check if the new user has current Celts Labor
         assert newUser.hasCurrentCeltsLabor is False
         transaction.rollback()
+ 
+    
+@pytest.mark.integration
+def test_isCurrentlyEnrolled():
+    #testing the isCurrentlyEnrolled property of User
+    with mainDB.atomic() as transaction:
+        # Currently enrolled student
+        enrolledUser = User.create(
+            username="enrolleduser",
+            firstName="Enrolled",
+            lastName="Student",
+            bnumber="B10000004",
+            email="enrolled@berea.edu",
+            isStudent=True,
+            hasGraduated=False,
+            rawClassLevel="Junior"
+        )
+        assert enrolledUser.isCurrentlyEnrolled is True
+
+        # Alumni (graduated)
+        alumniUser = User.create(
+            username="alumniuser",
+            firstName="Alumni",
+            lastName="User",
+            bnumber="B10000005",
+            email="alumni@berea.edu",
+            isStudent=False,
+            hasGraduated=True,
+            rawClassLevel="Graduated"
+        )
+        assert alumniUser.isCurrentlyEnrolled is False
+
+        # Fall graduate (Graduating → Alumni)
+        fallGradUser = User.create(
+            username="fallgraduser",
+            firstName="Fall",
+            lastName="Grad",
+            bnumber="B10000006",
+            email="fall@berea.edu",
+            isStudent=False,
+            hasGraduated=False,
+            rawClassLevel="Graduating"
+        )
+        assert fallGradUser.isCurrentlyEnrolled is False
+
+        transaction.rollback()

--- a/tests/code/test_users.py
+++ b/tests/code/test_users.py
@@ -582,3 +582,60 @@ def test_isAlumni():
         assert seniorUser.isAlumni is False
 
         transaction.rollback()
+
+@pytest.mark.integration
+def test_processedClassLevel():
+    with mainDB.atomic() as transaction:
+        # Graduated user
+        graduatedUser = User.create(
+            username="procgrad",
+            firstName="Proc",
+            lastName="Grad",
+            bnumber="B10000007",
+            email="procgrad@berea.edu",
+            isStudent=False,
+            hasGraduated=True,
+            rawClassLevel="Graduated"
+        )
+        assert graduatedUser.processedClassLevel == "Alumni"
+
+        # Fall graduate marked as "Graduating"
+        graduatingUser = User.create(
+            username="procgraduating",
+            firstName="Proc",
+            lastName="Graduating",
+            bnumber="B10000008",
+            email="procgraduating@berea.edu",
+            isStudent=False,
+            hasGraduated=False,
+            rawClassLevel="Graduating"
+        )
+        assert graduatingUser.processedClassLevel == "Alumni"
+
+        # Current senior
+        seniorUser = User.create(
+            username="procsenior",
+            firstName="Proc",
+            lastName="Senior",
+            bnumber="B10000009",
+            email="procsenior@berea.edu",
+            isStudent=True,
+            hasGraduated=False,
+            rawClassLevel="Senior"
+        )
+        assert seniorUser.processedClassLevel == "Senior"
+
+        # Not enrolled user
+        notEnrolledUser = User.create(
+            username="procnotenrolled",
+            firstName="Proc",
+            lastName="None",
+            bnumber="B10000010",
+            email="procnone@berea.edu",
+            isStudent=False,
+            hasGraduated=False,
+            rawClassLevel=None
+        )
+        assert notEnrolledUser.processedClassLevel == "Not Enrolled"
+
+        transaction.rollback()

--- a/tests/code/test_users.py
+++ b/tests/code/test_users.py
@@ -538,3 +538,47 @@ def test_isCurrentlyEnrolled():
         assert fallGradUser.isCurrentlyEnrolled is False
 
         transaction.rollback()
+
+@pytest.mark.integration
+def test_isAlumni():
+    with mainDB.atomic() as transaction:
+        # User who has graduated
+        graduatedUser = User.create(
+            username="graduser",
+            firstName="Grad",
+            lastName="User",
+            bnumber="B10000001",
+            email="grad@berea.edu",
+            isStudent=False,
+            hasGraduated=True,
+            rawClassLevel="Graduated"
+        )
+        assert graduatedUser.isAlumni is True
+
+        # User marked as "Graduating" (Fall graduate)
+        graduatingUser = User.create(
+            username="graduatinguser",
+            firstName="Fall",
+            lastName="Grad",
+            bnumber="B10000002",
+            email="fallgrad@berea.edu",
+            isStudent=False,
+            hasGraduated=False,
+            rawClassLevel="Graduating"
+        )
+        assert graduatingUser.isAlumni is True
+
+        # Current senior graduating in spring
+        seniorUser = User.create(
+            username="senioruser",
+            firstName="Spring",
+            lastName="Senior",
+            bnumber="B10000003",
+            email="senior@berea.edu",
+            isStudent=True,
+            hasGraduated=False,
+            rawClassLevel="Senior"
+        )
+        assert seniorUser.isAlumni is False
+
+        transaction.rollback()


### PR DESCRIPTION
## Issue Description

Fixes #1649  
Graduated students do not show up in the graduation management page. The only graduated students that show up are the seniors that we explicitly check to say that they graduated. Other students who have graduated before we go check, do not show up in the list at all. We should have a designation for them the same way we have one for senior, junior, etc. And use that designation to display graduated students. Same thing for students that left before they graduated.


Fixes #1657  
Graduated or non-enrolled students don't have any designation on their profile, like Senior, Junior, Sophomore, Freshmen students do.

## Changes

- New functions to handle alumni and enrollment 
- Modified the display on the graduation management page, now students who graduated recently appear with the Alumni class level. 
- Ticked students become alumni automatically 
- Students who dropped out or transferred appear as non enrolled 

the page then (marked students who graduated last semester as seniors): 

<img width="1240" height="655" alt="image" src="https://github.com/user-attachments/assets/bd30d1c0-6f9c-4290-8831-bab2977acc9a" />

the page now:

<img width="1349" height="624" alt="image" src="https://github.com/user-attachments/assets/1d893d82-ae1b-4bfe-8973-39355c5d6f9e" />

The profile display for graduated students:

<img width="1171" height="265" alt="image" src="https://github.com/user-attachments/assets/9e5c171b-8500-444b-a28a-35189c77d571" />

The profile display for non-enrolled students:

<img width="1183" height="342" alt="image" src="https://github.com/user-attachments/assets/4ae86902-5c6b-43b4-a08f-cacc150df7b7" />


## Testing

-  database/reset_database.sh test  reset data base with test 
- tests/run_tests.sh -v  Run the tests 
- Use backup data database/reset_database.sh from-backup
- Then Flask run 
- Then go on the website 
- Click on admin
- Then go on the graduation management page 
- People marked as alumni, are people who recently graduated. When you untick the "include graduated students" toggle, they disappear from the list 
- When you click on Veronica's name, she becomes part of the alumni and disappear from the list unless you click on including graduated student. In case it is a mistake you can safely uncheck the box and she becomes a senior. 
- If another student is marked as alumni and they realize that it is a mistake, they can also untick the box and the person becomes a Senior instead.
- On the student profile search for coronad, she transferred last year and will appear as "Non'enrolled" on her profile.