### PR TITLE
1670 Change Title in Bonner Management Accordion

### DIFF
--- a/app/templates/admin/bonnerManagement.html
+++ b/app/templates/admin/bonnerManagement.html
@@ -82,7 +82,7 @@
   <div class="accordion-item">
     <h3 class="accordion-header" id="headingTwo">
       {% set focus = "open" if visibleAccordion == "events" else "collapsed" %}
-      <button class="accordion-button {{focus}} " type="button" data-bs-toggle="collapse" data-bs-target="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo"> {{g.current_term.description}} Events </button>
+      <button class="accordion-button {{focus}} " type="button" data-bs-toggle="collapse" data-bs-target="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo"> {{g.current_term.description}} Bonner Events </button>
     </h3>
     {% set show = "show" if visibleAccordion == "events" else "" %}
     <div id="collapseTwo" class="accordion-collapse collapse {{show}}" aria-labelledby="headingTwo" data-bs-parent="#bonnerManagement">


### PR DESCRIPTION
## Issue Description

Fixes #1670  
Updated the language in the Bonner Management accordion (second tab) to better reflect the content by renaming “Fall 2025 events” to “Fall 2025 Bonner Events.”

## Changes
Updated accordion tab label from “Fall 2025 events” to “Fall 2025 Bonner Events”



## Testing
-Switch to branch 1632_Bonne_rAccordion
-Navigate to the Bonner Management page
-Expand the accordion and verified the second tab displays:
“Fall 2025 Bonner Events”
<img width="716" height="263" alt="Screenshot 2026-01-28 181307" src="https://github.com/user-attachments/assets/50e73b3a-3ed8-49b1-9843-96d052b41fa9" />
