### PR TITLE
Student position is edited to display "current manager"

### DIFF
--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -285,7 +285,7 @@
             {% endif %}
             {% if volunteer.isCeltsStudentStaff %}
             <div class="col-md-6">
-                <h5>{{volunteer.firstName}} {{volunteer.lastName}} is the manager of:</h5>
+                <h5>{{volunteer.firstName}} {{volunteer.lastName}} is the current manager of:</h5>
                 <ul class="list-unstyled">
                 {% for program in programs %}
                   {% if program.id in permissionPrograms %}


### PR DESCRIPTION
## Issue Description

Fixes #1650

- The issue exist in My Profile > Search a student staff > expand CELTS Labor.

- There you will see the students' position as "student name is the manager of: ". That text should change to "student name is the current manager of: ".

## Changes

-  Added "current" into "is the manager of :" so that it is "is the current manager of :"

## Testing

- Checkout the branch `git checkout changeStudentPosition`
- Pull the code when you are in the branch `git pull`
- Run the application `flask run`
- Travel to the navigation bar > Student Search > Search Joyce Emeka-Ibe > Click CELTS Labor accordion to see the change.
<img width="503" height="107" alt="image" src="https://github.com/user-attachments/assets/6cd4e108-571f-403d-99b6-c3aabe0f3b14" />