### PR TITLE
1597 edit event btn

### DIFF
--- a/app/templates/events/eventList.html
+++ b/app/templates/events/eventList.html
@@ -141,7 +141,11 @@
                 <button class="btn {{btn_class}}" onclick="showEmailModal({{event.id}}, 'Unknown', {{ selectedTerm }}, {{ isPastStart }}, '{{defaultTemplate}}')">
                   <span class="bi bi-envelope-fill"> {{btn_text}}</span>
                 </button>
+
+                <a class="btn btn-outline-secondary ms-2" href="eventTempletes "> <span class="bi bi-pencil-fill"> Edit Event</span> </a>
+
               </td>
+              
             {% else %}
               <td>
               {% if event.id in rsvpedEventsID %}

--- a/app/templates/events/eventList.html
+++ b/app/templates/events/eventList.html
@@ -141,9 +141,8 @@
                 <button class="btn {{btn_class}}" onclick="showEmailModal({{event.id}}, 'Unknown', {{ selectedTerm }}, {{ isPastStart }}, '{{defaultTemplate}}')">
                   <span class="bi bi-envelope-fill"> {{btn_text}}</span>
                 </button>
-
-                <a class="btn btn-outline-secondary ms-2" href="eventTempletes "> <span class="bi bi-pencil-fill"> Edit Event</span> </a>
-
+                
+                <a class="btn btn-primary ms-2"href="/event/{{ event.id }}/edit"><span class="bi bi-pencil-fill"></span> Edit Event </a>
               </td>
               
             {% else %}


### PR DESCRIPTION
## Issue Description
During the usability study, participants had a hard time figuring out how to edit the events they had created. They would often try to go back to "create events" to figure out how to edit it because they didn't recognize the event name link as a path to editing the event in "Events List". To accommodate this, an edit event button should be added next to the invite button so they can reach the editing/customizing event information page.

Fixes #1597
- Edit event button should be added next to the invite button. 

## Changes

- Added edit button next to the invite button.
- Only made changes in the event.html file.

**Before**:

<img width="1425" height="356" alt="image" src="https://github.com/user-attachments/assets/16a6a6c5-8835-4042-8735-58de1d67ab08" />

**After:** 

<img width="1878" height="481" alt="image" src="https://github.com/user-attachments/assets/582f8bfd-1bd3-48a9-a779-ce7c3a021c94" />

<img width="1476" height="507" alt="image" src="https://github.com/user-attachments/assets/a64347ca-9eaa-4a68-8043-30dd4a3efcbc" />


## Testing
- Switch to 1597Edit_event_btn branch 
- Go in as an admin, Create an event
- After creating an event, go to the events list page, view the event you create and you should be able to see the "Edit Event" button. 