### PR TITLE
Paging issue

### DIFF
--- a/app/static/js/volunteerDetails.js
+++ b/app/static/js/volunteerDetails.js
@@ -21,6 +21,19 @@ $(document).ready(function () {
 	$(".displayCheckbox").on('change', function () {
 		getCheckBoxes()
 	})
+	$.fn.dataTable.ext.search.push(function (settings, data, dataIndex) {
+		if (settings.nTable.id !== 'volunteerInformationTableToPrint') {
+			return true;
+		}
+
+		const status = data[3].toLowerCase(); // Volunteer Status column
+
+		if (status === 'attended' && !$('#attendedSelect').is(':checked')) return false;
+		if (status === 'rsvp' && !$('#rsvpSelect').is(':checked')) return false;
+		if (status === 'waitlist' && !$('#waitlistSelect').is(':checked')) return false;
+
+		return true;
+	});
 	function hideDuplicateVolunteers() {
 		let allEntries = $(".volunteerInfoEntries")
 		let shownUsers = []

--- a/app/static/js/volunteerDetails.js
+++ b/app/static/js/volunteerDetails.js
@@ -35,10 +35,11 @@ $(document).ready(function () {
 		return true;
 	});
 	function hideDuplicateVolunteers() {
-		let allEntries = $(".volunteerInfoEntries")
-		let shownUsers = []
-		for (let i = 0; i < allEntries.length; i++) {
-			let currentEntry = $(allEntries[i])
+		let allEntries = $("#volunteerInformationCardToPrint .volunteerInfoEntries");
+		let shownUsers = [];
+		allEntries.each(function () {
+        let currentEntry = $(this);
+        let user = currentEntry.data("user");
 			if (currentEntry.is(":visible")) {
 				if (shownUsers.includes(currentEntry.data("user"))) {
 					currentEntry.hide()
@@ -46,7 +47,7 @@ $(document).ready(function () {
 					shownUsers.push(currentEntry.data("user"))
 				}
 			}
-		}
+		});
 	}
 	function getCheckBoxes() {
 		$(".displayCheckbox").each(function () {

--- a/app/static/js/volunteerDetails.js
+++ b/app/static/js/volunteerDetails.js
@@ -53,14 +53,14 @@ $(document).ready(function () {
 		$(".displayCheckbox").each(function () {
 			let checkboxId = this.id;
 			if ($('#' + checkboxId).is(':checked')) {
-				$("." + checkboxId).show()
+				$("#volunteerInformationCardToPrint ." + checkboxId).show();
 			} else {
-				$("." + checkboxId).hide()
+				$("#volunteerInformationCardToPrint ." + checkboxId).hide();
 			}
-		})
+			});
 		hideDuplicateVolunteers()
-
 	}
+	
 	function sortVolunteers() {
 		let sortedTable = $("#volunteerInformationTableToPrint_wrapper");
 		let entriesTable = sortedTable.find(".volunteerInfoEntries");

--- a/app/static/js/volunteerDetails.js
+++ b/app/static/js/volunteerDetails.js
@@ -85,7 +85,7 @@ $(document).ready(function () {
 		entriesCards.appendTo(sortedCards);
 	};
 
-	var volunteerInfoTable= $('#volunteerInformationTableToPrint').DataTable({ stripeClasses: []});
+	var volunteerInfoTable = $('#volunteerInformationTableToPrint').DataTable({pageLength: 10,order: [[0, 'asc']]});
 	getCheckBoxes()
 	hideDuplicateVolunteers()
 	sortVolunteers()

--- a/app/static/js/volunteerDetails.js
+++ b/app/static/js/volunteerDetails.js
@@ -78,10 +78,10 @@ $(document).ready(function () {
 			$(e).addClass(i % 2 ? 'custom-odd' : 'custom-even')
 		})
 	}
+	var volunteerInfoTable= $('#volunteerInformationTableToPrint').DataTable({ stripeClasses: []});
 	getCheckBoxes()
 	hideDuplicateVolunteers()
 	sortVolunteers()
-	var volunteerInfoTable= $('#volunteerInformationTableToPrint').DataTable({ stripeClasses: []});
 	volunteerInfoTable.on('draw.dt', function (){
 		getCheckBoxes()
 		stripeVolunteerInfoTable()

--- a/app/static/js/volunteerDetails.js
+++ b/app/static/js/volunteerDetails.js
@@ -25,13 +25,10 @@ $(document).ready(function () {
 		if (settings.nTable.id !== 'volunteerInformationTableToPrint') {
 			return true;
 		}
-
-		const status = data[3].toLowerCase(); // Volunteer Status column
-
+		const status = data[3].toLowerCase(); 
 		if (status === 'attended' && !$('#attendedSelect').is(':checked')) return false;
 		if (status === 'rsvp' && !$('#rsvpSelect').is(':checked')) return false;
 		if (status === 'waitlist' && !$('#waitlistSelect').is(':checked')) return false;
-
 		return true;
 	});
 	function hideDuplicateVolunteers() {
@@ -59,6 +56,8 @@ $(document).ready(function () {
 			}
 			});
 		hideDuplicateVolunteers()
+		volunteerInfoTable.page('first').draw(false);
+
 	}
 	
 	function sortVolunteers() {
@@ -66,17 +65,6 @@ $(document).ready(function () {
 		let entriesTable = sortedTable.find(".volunteerInfoEntries");
 	
 		entriesTable.sort(function (a, b) {
-			let textA = a.getElementsByClassName('nameSelect')[0].innerText
-			let textB = b.getElementsByClassName('nameSelect')[0].innerText
-			return textA.localeCompare(textB);
-		});
-	
-		entriesTable.appendTo(sortedTable);
-
-		let sortedCards = $("#volunteerInformationCardToPrint .sort-here");
-		let entriesCards = sortedCards.find(".volunteerInfoEntries");
-	
-		entriesCards.sort(function (a, b) {
 			let textA = a.getElementsByClassName('nameSelect')[0].innerText
 			let textB = b.getElementsByClassName('nameSelect')[0].innerText
 			return textA.localeCompare(textB);

--- a/app/static/js/volunteerDetails.js
+++ b/app/static/js/volunteerDetails.js
@@ -41,10 +41,10 @@ $(document).ready(function () {
         let currentEntry = $(this);
         let user = currentEntry.data("user");
 			if (currentEntry.is(":visible")) {
-				if (shownUsers.includes(currentEntry.data("user"))) {
+				if (shownUsers.includes(user)) {
 					currentEntry.hide()
 				} else {
-					shownUsers.push(currentEntry.data("user"))
+					shownUsers.push(user);
 				}
 			}
 		});

--- a/app/static/js/volunteerDetails.js
+++ b/app/static/js/volunteerDetails.js
@@ -1,103 +1,118 @@
 $(document).ready(function () {
-    var userdata = $('.volunteerInfoEntries');
-    var users = userdata.map((index,row) => {
-        return $(row).data('user');
+	var userdata = $('.volunteerInfoEntries');
+	var users = userdata.map((index,row) => {
+		return $(row).data('user');
     }).get();
-    users = new Set(users);
-    users = [... users]
-    $("#tableCardToggle").on('click', function () {
-        $("#volunteerInformationCardToPrint").toggle()
-        $("#volunteerInformationTableToPrint_wrapper").toggle()
-        if ($("#tableCardToggle").text() == "Card View") {
-            $("#tableCardToggle").text("Table View")
-            $(".bNumberSelect").toggle()
-        } else {
-            $("#tableCardToggle").text("Card View")
-            $(".bNumberSelect").toggle()
-        }
-        hideDuplicateVolunteers()
-    })
-    $(".displayCheckbox").on('change', function () {
-        getCheckBoxes()
-    })
-    $.fn.dataTable.ext.search.push(function (settings, data, dataIndex) {
-        if (settings.nTable.id !== 'volunteerInformationTableToPrint') {
-            return true;
-        }
-        const status = data[3].toLowerCase(); // Volunteer Status column
-        if (status === 'attended' && !$('#attendedSelect').is(':checked')) return false;
-        if (status === 'rsvp' && !$('#rsvpSelect').is(':checked')) return false;
-        if (status === 'waitlist' && !$('#waitlistSelect').is(':checked')) return false;
-        return true;
-    });
+	users = new Set(users);
+	users = [... users]
+	$("#tableCardToggle").on('click', function () {
+		$("#volunteerInformationCardToPrint").toggle()
+		$("#volunteerInformationTableToPrint_wrapper").toggle()
 
-    function hideDuplicateVolunteers() {
-        let allEntries = $("#volunteerInformationCardToPrint .volunteerInfoEntries");
-        let shownUsers = []
-        allEntries.each(function () {
+		if ($("#tableCardToggle").text() == "Card View") {
+			$("#tableCardToggle").text("Table View")
+			$(".bNumberSelect").toggle()
+		} else {
+			$("#tableCardToggle").text("Card View")
+			$(".bNumberSelect").toggle()
+		}
+		hideDuplicateVolunteers()
+	})
+	$(".displayCheckbox").on('change', function () {
+		getCheckBoxes()
+	})
+	$.fn.dataTable.ext.search.push(function (settings, data, dataIndex) {
+		if (settings.nTable.id !== 'volunteerInformationTableToPrint') {
+			return true;
+		}
+
+		const status = data[3].toLowerCase(); // Volunteer Status column
+
+		if (status === 'attended' && !$('#attendedSelect').is(':checked')) return false;
+		if (status === 'rsvp' && !$('#rsvpSelect').is(':checked')) return false;
+		if (status === 'waitlist' && !$('#waitlistSelect').is(':checked')) return false;
+
+		return true;
+	});
+	function hideDuplicateVolunteers() {
+		let allEntries = $("#volunteerInformationCardToPrint .volunteerInfoEntries");
+		let shownUsers = [];
+		allEntries.each(function () {
         let currentEntry = $(this);
         let user = currentEntry.data("user");
-        if (currentEntry.is(":visible")) {
-            if (shownUsers.includes(user)) {
-                currentEntry.hide();
-            } else {
-                shownUsers.push(user);
-            }
-        }
-    });
-}
-    function getCheckBoxes() {
-        $(".displayCheckbox").each(function () {
-            let checkboxId = this.id;
-            if ($('#' + checkboxId).is(':checked')) {
-            $("#volunteerInformationCardToPrint ." + checkboxId).show();
-            } else {
-            $("#volunteerInformationCardToPrint ." + checkboxId).hide();
-            }
-        });
-        hideDuplicateVolunteers();
-        volunteerInfoTable.page('first').draw(false);
-        }
-    function sortVolunteers() {
-        let sortedCards = $("#volunteerInformationCardToPrint .sort-here");
-        let entriesCards = sortedCards.find(".volunteerInfoEntries");
-   
-        entriesCards.sort(function (a, b) {
-            let textA = a.getElementsByClassName('nameSelect')[0].innerText
-            let textB = b.getElementsByClassName('nameSelect')[0].innerText
-            return textA.localeCompare(textB);
-        });
-   
-        entriesCards.appendTo(sortedCards);
-    };
+			if (currentEntry.is(":visible")) {
+				if (shownUsers.includes(user)) {
+					currentEntry.hide()
+				} else {
+					shownUsers.push(user);
+				}
+			}
+		});
+	}
+	function getCheckBoxes() {
+		$(".displayCheckbox").each(function () {
+			let checkboxId = this.id;
+			if ($('#' + checkboxId).is(':checked')) {
+				$("#volunteerInformationCardToPrint ." + checkboxId).show();
+			} else {
+				$("#volunteerInformationCardToPrint ." + checkboxId).hide();
+			}
+			});
+		hideDuplicateVolunteers()
+	}
+	
+	function sortVolunteers() {
+		let sortedTable = $("#volunteerInformationTableToPrint_wrapper");
+		let entriesTable = sortedTable.find(".volunteerInfoEntries");
+	
+		entriesTable.sort(function (a, b) {
+			let textA = a.getElementsByClassName('nameSelect')[0].innerText
+			let textB = b.getElementsByClassName('nameSelect')[0].innerText
+			return textA.localeCompare(textB);
+		});
+	
+		entriesTable.appendTo(sortedTable);
 
-    var volunteerInfoTable = $('#volunteerInformationTableToPrint').DataTable({pageLength: 10, order: [[0, 'asc']]});
-    getCheckBoxes()
-    hideDuplicateVolunteers()
-    sortVolunteers()
-    for(let i = 0; i < users.length; i++){
-        $('#volunteerUsernames').append(`<input type="hidden" name="username" value=${users[i]}>`)
-    }
+		let sortedCards = $("#volunteerInformationCardToPrint .sort-here");
+		let entriesCards = sortedCards.find(".volunteerInfoEntries");
+	
+		entriesCards.sort(function (a, b) {
+			let textA = a.getElementsByClassName('nameSelect')[0].innerText
+			let textB = b.getElementsByClassName('nameSelect')[0].innerText
+			return textA.localeCompare(textB);
+		});
+	
+		entriesCards.appendTo(sortedCards);
+	};
+
+	var volunteerInfoTable = $('#volunteerInformationTableToPrint').DataTable({pageLength: 10,order: [[0, 'asc']]});
+	getCheckBoxes()
+	hideDuplicateVolunteers()
+	sortVolunteers()
+	for(let i = 0; i < users.length; i++){
+		$('#volunteerUsernames').append(`<input type="hidden" name="username" value=${users[i]}>`)
+	}
 $("#travelFormItem").on("click", function(){
-            $("#volunteerUsernames").submit()
+			$("#volunteerUsernames").submit()
 })
 $("#volutneerListItem").on("click", function(){
-    let contentToPrint;
-            let tableContent = $("#volunteerInformationTableToPrint_wrapper");
-            let cardContent = $("#volunteerInformationCardToPrint");
-            if ($('#tableCardToggle').text() == 'Card View') {
-                contentToPrint = tableContent;
-            } else {
-                contentToPrint = cardContent;
-            }
-            contentToPrint.siblings().addClass('d-print-none');
-            contentToPrint.removeClass('d-print-none');
-            $(".always-print").removeClass('d-print-none');
-            let getTableLength = volunteerInfoTable.page.len();
-            let getTablePage = volunteerInfoTable.page();
-            volunteerInfoTable.page.len(-1).draw();
-            window.print();
-            volunteerInfoTable.page.len(getTableLength).draw();
-            volunteerInfoTable.page(getTablePage).draw('page');
+	let contentToPrint;
+			let tableContent = $("#volunteerInformationTableToPrint_wrapper");
+			let cardContent = $("#volunteerInformationCardToPrint");
+			if ($('#tableCardToggle').text() == 'Card View') {
+				contentToPrint = tableContent;
+			} else {
+				contentToPrint = cardContent;
+			}
+			contentToPrint.siblings().addClass('d-print-none');
+			contentToPrint.removeClass('d-print-none');
+			$(".always-print").removeClass('d-print-none');
+			let getTableLength = volunteerInfoTable.page.len();
+			let getTablePage = volunteerInfoTable.page();
+			volunteerInfoTable.page.len(-1).draw();
+			window.print();
+			volunteerInfoTable.page.len(getTableLength).draw();
+			volunteerInfoTable.page(getTablePage).draw('page');
 })
+
 });

--- a/app/static/js/volunteerDetails.js
+++ b/app/static/js/volunteerDetails.js
@@ -47,7 +47,6 @@ $(document).ready(function () {
 				}
 			}
 		}
-		stripeVolunteerInfoTable()
 	}
 	function getCheckBoxes() {
 		$(".displayCheckbox").each(function () {
@@ -91,9 +90,7 @@ $(document).ready(function () {
 	sortVolunteers()
 	volunteerInfoTable.on('draw.dt', function (){
 		getCheckBoxes()
-		stripeVolunteerInfoTable()
 	});
-	stripeVolunteerInfoTable()
 	for(let i = 0; i < users.length; i++){
 		$('#volunteerUsernames').append(`<input type="hidden" name="username" value=${users[i]}>`)
 	}

--- a/app/static/js/volunteerDetails.js
+++ b/app/static/js/volunteerDetails.js
@@ -1,118 +1,103 @@
 $(document).ready(function () {
-	var userdata = $('.volunteerInfoEntries');
-	var users = userdata.map((index,row) => {
-		return $(row).data('user');
+    var userdata = $('.volunteerInfoEntries');
+    var users = userdata.map((index,row) => {
+        return $(row).data('user');
     }).get();
-	users = new Set(users);
-	users = [... users]
-	$("#tableCardToggle").on('click', function () {
-		$("#volunteerInformationCardToPrint").toggle()
-		$("#volunteerInformationTableToPrint_wrapper").toggle()
+    users = new Set(users);
+    users = [... users]
+    $("#tableCardToggle").on('click', function () {
+        $("#volunteerInformationCardToPrint").toggle()
+        $("#volunteerInformationTableToPrint_wrapper").toggle()
+        if ($("#tableCardToggle").text() == "Card View") {
+            $("#tableCardToggle").text("Table View")
+            $(".bNumberSelect").toggle()
+        } else {
+            $("#tableCardToggle").text("Card View")
+            $(".bNumberSelect").toggle()
+        }
+        hideDuplicateVolunteers()
+    })
+    $(".displayCheckbox").on('change', function () {
+        getCheckBoxes()
+    })
+    $.fn.dataTable.ext.search.push(function (settings, data, dataIndex) {
+        if (settings.nTable.id !== 'volunteerInformationTableToPrint') {
+            return true;
+        }
+        const status = data[3].toLowerCase(); // Volunteer Status column
+        if (status === 'attended' && !$('#attendedSelect').is(':checked')) return false;
+        if (status === 'rsvp' && !$('#rsvpSelect').is(':checked')) return false;
+        if (status === 'waitlist' && !$('#waitlistSelect').is(':checked')) return false;
+        return true;
+    });
 
-		if ($("#tableCardToggle").text() == "Card View") {
-			$("#tableCardToggle").text("Table View")
-			$(".bNumberSelect").toggle()
-		} else {
-			$("#tableCardToggle").text("Card View")
-			$(".bNumberSelect").toggle()
-		}
-		hideDuplicateVolunteers()
-	})
-	$(".displayCheckbox").on('change', function () {
-		getCheckBoxes()
-	})
-	$.fn.dataTable.ext.search.push(function (settings, data, dataIndex) {
-		if (settings.nTable.id !== 'volunteerInformationTableToPrint') {
-			return true;
-		}
-
-		const status = data[3].toLowerCase(); // Volunteer Status column
-
-		if (status === 'attended' && !$('#attendedSelect').is(':checked')) return false;
-		if (status === 'rsvp' && !$('#rsvpSelect').is(':checked')) return false;
-		if (status === 'waitlist' && !$('#waitlistSelect').is(':checked')) return false;
-
-		return true;
-	});
-	function hideDuplicateVolunteers() {
-		let allEntries = $("#volunteerInformationCardToPrint .volunteerInfoEntries");
-		let shownUsers = [];
-		allEntries.each(function () {
+    function hideDuplicateVolunteers() {
+        let allEntries = $("#volunteerInformationCardToPrint .volunteerInfoEntries");
+        let shownUsers = []
+        allEntries.each(function () {
         let currentEntry = $(this);
         let user = currentEntry.data("user");
-			if (currentEntry.is(":visible")) {
-				if (shownUsers.includes(user)) {
-					currentEntry.hide()
-				} else {
-					shownUsers.push(user);
-				}
-			}
-		});
-	}
-	function getCheckBoxes() {
-		$(".displayCheckbox").each(function () {
-			let checkboxId = this.id;
-			if ($('#' + checkboxId).is(':checked')) {
-				$("#volunteerInformationCardToPrint ." + checkboxId).show();
-			} else {
-				$("#volunteerInformationCardToPrint ." + checkboxId).hide();
-			}
-			});
-		hideDuplicateVolunteers()
-	}
-	
-	function sortVolunteers() {
-		let sortedTable = $("#volunteerInformationTableToPrint_wrapper");
-		let entriesTable = sortedTable.find(".volunteerInfoEntries");
-	
-		entriesTable.sort(function (a, b) {
-			let textA = a.getElementsByClassName('nameSelect')[0].innerText
-			let textB = b.getElementsByClassName('nameSelect')[0].innerText
-			return textA.localeCompare(textB);
-		});
-	
-		entriesTable.appendTo(sortedTable);
+        if (currentEntry.is(":visible")) {
+            if (shownUsers.includes(user)) {
+                currentEntry.hide();
+            } else {
+                shownUsers.push(user);
+            }
+        }
+    });
+}
+    function getCheckBoxes() {
+        $(".displayCheckbox").each(function () {
+            let checkboxId = this.id;
+            if ($('#' + checkboxId).is(':checked')) {
+            $("#volunteerInformationCardToPrint ." + checkboxId).show();
+            } else {
+            $("#volunteerInformationCardToPrint ." + checkboxId).hide();
+            }
+        });
+        hideDuplicateVolunteers();
+        volunteerInfoTable.page('first').draw(false);
+        }
+    function sortVolunteers() {
+        let sortedCards = $("#volunteerInformationCardToPrint .sort-here");
+        let entriesCards = sortedCards.find(".volunteerInfoEntries");
+   
+        entriesCards.sort(function (a, b) {
+            let textA = a.getElementsByClassName('nameSelect')[0].innerText
+            let textB = b.getElementsByClassName('nameSelect')[0].innerText
+            return textA.localeCompare(textB);
+        });
+   
+        entriesCards.appendTo(sortedCards);
+    };
 
-		let sortedCards = $("#volunteerInformationCardToPrint .sort-here");
-		let entriesCards = sortedCards.find(".volunteerInfoEntries");
-	
-		entriesCards.sort(function (a, b) {
-			let textA = a.getElementsByClassName('nameSelect')[0].innerText
-			let textB = b.getElementsByClassName('nameSelect')[0].innerText
-			return textA.localeCompare(textB);
-		});
-	
-		entriesCards.appendTo(sortedCards);
-	};
-
-	var volunteerInfoTable = $('#volunteerInformationTableToPrint').DataTable({pageLength: 10,order: [[0, 'asc']]});
-	getCheckBoxes()
-	hideDuplicateVolunteers()
-	sortVolunteers()
-	for(let i = 0; i < users.length; i++){
-		$('#volunteerUsernames').append(`<input type="hidden" name="username" value=${users[i]}>`)
-	}
+    var volunteerInfoTable = $('#volunteerInformationTableToPrint').DataTable({pageLength: 10, order: [[0, 'asc']]});
+    getCheckBoxes()
+    hideDuplicateVolunteers()
+    sortVolunteers()
+    for(let i = 0; i < users.length; i++){
+        $('#volunteerUsernames').append(`<input type="hidden" name="username" value=${users[i]}>`)
+    }
 $("#travelFormItem").on("click", function(){
-			$("#volunteerUsernames").submit()
+            $("#volunteerUsernames").submit()
 })
 $("#volutneerListItem").on("click", function(){
-	let contentToPrint;
-			let tableContent = $("#volunteerInformationTableToPrint_wrapper");
-			let cardContent = $("#volunteerInformationCardToPrint");
-			if ($('#tableCardToggle').text() == 'Card View') {
-				contentToPrint = tableContent;
-			} else {
-				contentToPrint = cardContent;
-			}
-			contentToPrint.siblings().addClass('d-print-none');
-			contentToPrint.removeClass('d-print-none');
-			$(".always-print").removeClass('d-print-none');
-			let getTableLength = volunteerInfoTable.page.len();
-			let getTablePage = volunteerInfoTable.page();
-			volunteerInfoTable.page.len(-1).draw();
-			window.print();
-			volunteerInfoTable.page.len(getTableLength).draw();
-			volunteerInfoTable.page(getTablePage).draw('page');
+    let contentToPrint;
+            let tableContent = $("#volunteerInformationTableToPrint_wrapper");
+            let cardContent = $("#volunteerInformationCardToPrint");
+            if ($('#tableCardToggle').text() == 'Card View') {
+                contentToPrint = tableContent;
+            } else {
+                contentToPrint = cardContent;
+            }
+            contentToPrint.siblings().addClass('d-print-none');
+            contentToPrint.removeClass('d-print-none');
+            $(".always-print").removeClass('d-print-none');
+            let getTableLength = volunteerInfoTable.page.len();
+            let getTablePage = volunteerInfoTable.page();
+            volunteerInfoTable.page.len(-1).draw();
+            window.print();
+            volunteerInfoTable.page.len(getTableLength).draw();
+            volunteerInfoTable.page(getTablePage).draw('page');
 })
-
 });

--- a/app/static/js/volunteerDetails.js
+++ b/app/static/js/volunteerDetails.js
@@ -85,12 +85,6 @@ $(document).ready(function () {
 		entriesCards.appendTo(sortedCards);
 	};
 
-	function stripeVolunteerInfoTable() {
-		$('#volunteerInformationTableToPrint .volunteerInfoEntries').removeClass('custom-odd custom-even')
-		$('#volunteerInformationTableToPrint .volunteerInfoEntries:visible').each(function (i,e) {
-			$(e).addClass(i % 2 ? 'custom-odd' : 'custom-even')
-		})
-	}
 	var volunteerInfoTable= $('#volunteerInformationTableToPrint').DataTable({ stripeClasses: []});
 	getCheckBoxes()
 	hideDuplicateVolunteers()

--- a/app/static/js/volunteerDetails.js
+++ b/app/static/js/volunteerDetails.js
@@ -88,9 +88,6 @@ $(document).ready(function () {
 	getCheckBoxes()
 	hideDuplicateVolunteers()
 	sortVolunteers()
-	volunteerInfoTable.on('draw.dt', function (){
-		getCheckBoxes()
-	});
 	for(let i = 0; i < users.length; i++){
 		$('#volunteerUsernames').append(`<input type="hidden" name="username" value=${users[i]}>`)
 	}

--- a/app/templates/events/volunteerDetails.html
+++ b/app/templates/events/volunteerDetails.html
@@ -59,15 +59,13 @@
 {% macro printParticipants(type, attended, rsvp, waitlist) %}
     {% set combinedParticipants = attended + rsvp + waitlist %}
     {% for p in combinedParticipants | unique %}
-      {% if p in rsvp %}
-          {{createTable(p, 'rsvp') if type == 'table' else createCard(p, 'rsvp') }}
-      {% endif %}
-      {% if p in attended%}
-          {{createTable(p, 'attended') if type == 'table' else createCard(p, 'attended') }}
-      {% endif %}
-      {% if p in waitlist %}
-          {{createTable(p, 'waitlist') if type == 'table' else createCard(p, 'waitlist') }}
-      {% endif %}
+        {% if p in attended %}
+            {{ createTable(p, 'attended') if type == 'table' else createCard(p, 'attended') }}
+        {% elif p in rsvp %}
+            {{ createTable(p, 'rsvp') if type == 'table' else createCard(p, 'rsvp') }}
+        {% elif p in waitlist %}
+            {{ createTable(p, 'waitlist') if type == 'table' else createCard(p, 'waitlist') }}
+        {% endif %}
     {% endfor %}
 {% endmacro %}
 

--- a/app/templates/events/volunteerDetails.html
+++ b/app/templates/events/volunteerDetails.html
@@ -63,12 +63,20 @@
         {% set username = p.user.username %}
         {% if username not in seen %}
             {% set _ = seen.append(username) %}
+            {% set status = none %}
             {% if p in attended %}
-                {{ createTable(p, 'attended') if type == 'table' else createCard(p, 'attended') }}
+                {% set status = 'attended'%}
             {% elif p in rsvp %}
-                {{ createTable(p, 'rsvp') if type == 'table' else createCard(p, 'rsvp') }}
+                {% set status = 'rsvp'%}
             {% elif p in waitlist %}
-                {{ createTable(p, 'waitlist') if type == 'table' else createCard(p, 'waitlist') }}
+                {% set status = 'waitlist'%}
+            {% endif %}
+            {% if status %}
+                {% if type == 'card' %}
+                    {{ createCard(p, status) }}
+                {% elif type == 'table' %}
+                    {{ createTable(p, status) }}
+                {% endif %}
             {% endif %}
         {% endif %}
     {% endfor %}

--- a/app/templates/events/volunteerDetails.html
+++ b/app/templates/events/volunteerDetails.html
@@ -57,14 +57,19 @@
 {% endmacro %}
 
 {% macro printParticipants(type, attended, rsvp, waitlist) %}
+    {% set seen = [] %}
     {% set combinedParticipants = attended + rsvp + waitlist %}
-    {% for p in combinedParticipants | unique %}
-        {% if p in attended %}
-            {{ createTable(p, 'attended') if type == 'table' else createCard(p, 'attended') }}
-        {% elif p in rsvp %}
-            {{ createTable(p, 'rsvp') if type == 'table' else createCard(p, 'rsvp') }}
-        {% elif p in waitlist %}
-            {{ createTable(p, 'waitlist') if type == 'table' else createCard(p, 'waitlist') }}
+    {% for p in combinedParticipants %}
+        {% set username = p.user.username %}
+        {% if username not in seen %}
+            {% set _ = seen.append(username) %}
+            {% if p in attended %}
+                {{ createTable(p, 'attended') if type == 'table' else createCard(p, 'attended') }}
+            {% elif p in rsvp %}
+                {{ createTable(p, 'rsvp') if type == 'table' else createCard(p, 'rsvp') }}
+            {% elif p in waitlist %}
+                {{ createTable(p, 'waitlist') if type == 'table' else createCard(p, 'waitlist') }}
+            {% endif %}
         {% endif %}
     {% endfor %}
 {% endmacro %}


### PR DESCRIPTION
## Paging issue

Fixes #1656 

- Arrange the flow of the list in volunteer details when RSVP is unchecked. Here, for instance, Joyce's details appear on the third page, as she is the only person listed. So logically, she should be appearing on the first page. Which means whenever these checkmarks are done the page should reconsolidate the data and repopulate them to fit the filter that is there like 50-100.

## Changes

- Changed mainly the JavaScript file 
- Now we are not anymore manually hiding table rows when checkboxes were unchecked but we use the DataTables custom filtering
- Removed Duplicate DataTable Initialization

Now joyce appears on the first page when RSVP unchecked
<img width="1594" height="813" alt="image" src="https://github.com/user-attachments/assets/451a483f-24a4-4391-84be-fa0b332d39b1" />

## Testing

- Go to events page
- Change to the fall 2025 term
- go to Bonner Scholars tab 
- Click on the only event there 
- Click on volunteer details
- You can check and uncheck the RSVP box 