### PR TITLE
Added and Delete Note Buttons

### DIFF
--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -387,6 +387,7 @@ def addNote():
         flash("Failed to add profile note", "danger")
         return "Failed to add profile note", 500
 
+    
 @main_bp.route('/<username>/deleteNote', methods=['POST'])
 def deleteNote(username):
     """

--- a/app/models/note.py
+++ b/app/models/note.py
@@ -4,6 +4,6 @@ from app.models.user import User
 class Note(baseModel):
     createdBy = ForeignKeyField(User)
     createdOn = DateTimeField()
-    noteContent = CharField()
+    noteContent = TextField()
     isPrivate = BooleanField(default=False)
     noteType = CharField(null=True)

--- a/app/static/js/userProfile.js
+++ b/app/static/js/userProfile.js
@@ -191,9 +191,9 @@ $(document).ready(function(){
 
     $("#addBonnerNoteButton").click(function() {
         bonnerNoteOn()
-        $("#addNoteTextArea").val('')                   // clear the text
-        $("#notesSaveButton").data('mode', 'add')       // set mode to add
-        $("#notesSaveButton").data('noteid', null)      // clear any stored noteid
+        $("#addNoteTextArea").val('')                   
+        $("#notesSaveButton").data('mode', 'add')       
+        $("#notesSaveButton").data('noteid', null)      
         $("#noteModal").modal("toggle");
     });
 
@@ -244,27 +244,26 @@ $(document).ready(function(){
     });
   });
   $(".editNoteButton").click(function() {
-    console.log("joyce", this)
     let noteText = $(this).data('notetext')
     let visibility = $(this).data('visibility')
     let isBonner = $(this).data('bonner')
     let noteid = $(this).data('noteid')
     
-    // Pre-fill the modal with the existing note data
+    
     $("#addNoteTextArea").val(noteText)
     $("#noteDropdown").val(visibility)
 
-    // Show/hide bonner fields based on note type
+   
     if (isBonner === 'yes') {
         bonnerNoteOn()
     } else {
         bonnerNoteOff()
     }
-    // Save the noteid so the form knows which note to delete later
+    
     $("#notesSaveButton").data('noteid', $(this).data('noteid'))
     $("#notesSaveButton").data('mode', 'edit')
 
-    // Open the modal
+   
     $("#noteModal").modal("toggle")
 });
     $.ajax({

--- a/app/static/js/userProfile.js
+++ b/app/static/js/userProfile.js
@@ -191,6 +191,9 @@ $(document).ready(function(){
 
     $("#addBonnerNoteButton").click(function() {
         bonnerNoteOn()
+        $("#addNoteTextArea").val('')                   // clear the text
+        $("#notesSaveButton").data('mode', 'add')       // set mode to add
+        $("#notesSaveButton").data('noteid', null)      // clear any stored noteid
         $("#noteModal").modal("toggle");
     });
 
@@ -199,6 +202,17 @@ $(document).ready(function(){
     event.preventDefault()
     let username = $("#notesSaveButton").data('username')
     let isBonner = $("#bonnerInput").is(":checked")
+    let mode = $("#notesSaveButton").data('mode')
+    let noteid = $("#notesSaveButton").data('noteid')
+
+    // If we're editing, delete the old note first
+    if (mode === 'edit') {
+        $.ajax({
+            method: "POST",
+            url: "/" + username + "/deleteNote",
+            data: { "id": noteid }
+        })
+    }
     $.ajax({
       method: "POST",
       url:  "/profile/addNote",
@@ -229,9 +243,30 @@ $(document).ready(function(){
       }
     });
   });
-    $(".editNoteButton").click(function() {
-    let username = $(this).data('username')
+  $(".editNoteButton").click(function() {
+    console.log("joyce", this)
+    let noteText = $(this).data('notetext')
+    let visibility = $(this).data('visibility')
+    let isBonner = $(this).data('bonner')
     let noteid = $(this).data('noteid')
+    
+    // Pre-fill the modal with the existing note data
+    $("#addNoteTextArea").val(noteText)
+    $("#noteDropdown").val(visibility)
+
+    // Show/hide bonner fields based on note type
+    if (isBonner === 'yes') {
+        bonnerNoteOn()
+    } else {
+        bonnerNoteOff()
+    }
+    // Save the noteid so the form knows which note to delete later
+    $("#notesSaveButton").data('noteid', $(this).data('noteid'))
+    $("#notesSaveButton").data('mode', 'edit')
+
+    // Open the modal
+    $("#noteModal").modal("toggle")
+});
     $.ajax({
       method: "POST",
       url:  "/" + username + "/editNote",
@@ -366,8 +401,8 @@ $(document).ready(function(){
       typingTimer = setTimeout(saveDiet, saveInterval);
     });
   });
+ // end document.ready()
 
-}); // end document.ready()
 
 // Update program manager status
 function updateManagers(el, volunteerUsername ) {

--- a/app/static/js/userProfile.js
+++ b/app/static/js/userProfile.js
@@ -229,7 +229,18 @@ $(document).ready(function(){
       }
     });
   });
-
+    $(".editNoteButton").click(function() {
+    let username = $(this).data('username')
+    let noteid = $(this).data('noteid')
+    $.ajax({
+      method: "POST",
+      url:  "/" + username + "/editNote",
+      data: {"id": noteid},
+      success: function(response) {
+        reloadWithAccordion("notes")
+      }
+    });
+  });
   /*
     * Background Check Functionality
     */

--- a/app/static/js/userProfile.js
+++ b/app/static/js/userProfile.js
@@ -235,6 +235,13 @@ $(document).ready(function(){
   });
 
   $(".deleteNoteButton").click(function() {
+    $("#confirmDeleteNote").data('username', $(this).data('username'))
+    $("#confirmDeleteNote").data('noteid', $(this).data('noteid'))
+    $("#deleteNoteWarning").modal("show")
+  
+  });
+
+  $("#confirmDeleteNote").click(function() { 
     let username = $(this).data('username')
     let noteid = $(this).data('noteid')
     $.ajax({
@@ -242,10 +249,12 @@ $(document).ready(function(){
       url:  "/" + username + "/deleteNote",
       data: {"id": noteid},
       success: function(response) {
+         msgFlash("Successfully deleted note", "success", 1300, true)
         reloadWithAccordion("notes")
       }
     });
   });
+  
   $(".editNoteButton").click(function() {
     let noteText = $(this).data('notetext')
     let visibility = $(this).data('visibility')

--- a/app/static/js/userProfile.js
+++ b/app/static/js/userProfile.js
@@ -176,6 +176,9 @@ $(document).ready(function(){
 
     $("#addNoteButton").click(function() {
         bonnerNoteOff()
+        $("#addNoteTextArea").val('')
+        $("#notesSaveButton").data('mode', 'add') 
+        $("#notesSaveButton").data('noteid', null) 
         $("#noteModal").modal("toggle")
     });
 

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -423,12 +423,12 @@
                     {% else %}
                       {{ "Bonner Scholar " if row.isBonnerNote else "Everyone"}}
                     {% endif %}
-                  <td>
+                  <td class ="text-nowrap">
                     {% if (g.current_user == row.note.createdBy) or g.current_user.isCeltsAdmin%}
-                     <button type="button" class="btn btn-sm btn-primary editNoteButton"data-noteid="{{ row.id }}"data-notetext="{{ row.note.noteContent }}"data-username="{{ volunteer.username }}"data-visibility="{{ row.viewTier }}"data-bonner="{{ 'yes' if row.isBonnerNote else 'no' }}">Edit</button>
+                     <button type="button" class="btn btn-sm btn-primary me-1 editNoteButton"data-noteid="{{ row.id }}"data-notetext="{{ row.note.noteContent }}"data-username="{{ volunteer.username }}"data-visibility="{{ row.viewTier }}"data-bonner="{{ 'yes' if row.isBonnerNote else 'no' }}">Edit</button>
                      <button type="button" class="btn btn-sm btn-danger deleteNoteButton" data-noteid="{{ row.id}}" data-username="{{volunteer.username}}">Delete</button>
                     {% else %}
-                      <button type="button" class="btn btn-sm btn-primary" disabled>Edit</button>
+                      <button type="button" class="btn btn-sm btn-primary me-1" disabled>Edit</button>
                       <button type="button" class="btn btn-sm btn-danger" disabled>Delete</button>
                     {% endif %}
                   </td>

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -597,6 +597,28 @@
 </div>
 <!-- ################# Add Notes Modal ################ -->
 
+
+<!-- ################# Delete Note Warning Modal ################ -->
+<div class="modal fade" id="deleteNoteWarning" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Delete Note</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p>This action is irreversible.</p>
+                <p>By deleting this note, all information regarding this note will be removed.</p>
+            </div>
+            <div class="modal-footer justify-content-between">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-danger" id="confirmDeleteNote">Delete Note</button>
+            </div>
+        </div>
+    </div>
+</div>
+<!-- ################# Delete Note Warning Modal ################ -->
+
 <!-- ################# Ban or Unban Modal ################ -->
 <div class="modal fade" id="banModal" tabindex="-1" aria-labelledby="banVolunteerModalLabel" aria-hidden="true" style="width:-60px;">
   <form onsubmit="return validate();">

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -494,7 +494,19 @@
               {% if bonnerNotes|length %}
               <dl class="bonnerNotes">
                 {% for row in profileNotes|selectattr("isBonnerNote") %}
-                    <dt>{{row.note.noteContent}}</dd>
+                    <dt>{{row.note.noteContent}}
+                      <span class="float-end">
+                        <i class="bi bi-pencil text-primary editNoteButton me-2" 
+                          data-notetext="{{row.note.noteContent}}"
+                          data-visibility="{{row.note.visibility}}"
+                          data-bonner="yes"
+                          data-noteid="{{row.note.id}}"
+                          data-username="{{volunteer.username}}"
+                          style="cursor:pointer"></i>
+                       <i class="bi bi-trash text-danger deleteNoteButton"
+                          data-noteid="{{row.note.id}}"
+                          data-username="{{volunteer.username}}"
+                          style="cursor:pointer"></i>
                     <dd class='text-muted'>{{row.note.createdBy.fullName}} <span class="float-end">{{row.note.createdOn.strftime('%m/%d/%Y')}}</span></dt>
                 {% endfor %}
               </dl>

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -618,6 +618,7 @@
     </div>
 </div>
 <!-- ################# Delete Note Warning Modal ################ -->
+ 
 
 <!-- ################# Ban or Unban Modal ################ -->
 <div class="modal fade" id="banModal" tabindex="-1" aria-labelledby="banVolunteerModalLabel" aria-hidden="true" style="width:-60px;">

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -452,7 +452,7 @@
         {% endif %}
         <br>
         <br>
-        <button type="button" name="button" class="btn btn-primary" id="addNoteButton">Add Note</button>
+        <button type="button" name="button" class="btn btn-primary" id="addNoteButton">Add Bonner Note</button>
       </div>
     </div>
   </div>

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -423,14 +423,13 @@
                     {% else %}
                       {{ "Bonner Scholar " if row.isBonnerNote else "Everyone"}}
                     {% endif %}
-                  </td>
-                  <tr>
+                  <td>
                     {% if (g.current_user == row.note.createdBy) or g.current_user.isCeltsAdmin%}
-                      <button type="button" class="btn btn-sm btn-danger editNoteButton float-end" data-noteid="{{row.id}}" data-username="{{volunteer.username}}">Edit</button>
-                      <button type="button" class="btn btn-sm btn-danger deleteNoteButton float-end" data-noteid="{{row.id}}" data-username="{{volunteer.username}}">Delete</button>
+                     <button type="button" class="btn btn-sm btn-primary editNoteButton"data-noteid="{{ row.id }}"data-notetext="{{ row.note.noteContent }}"data-username="{{ volunteer.username }}"data-visibility="{{ row.viewTier }}"data-bonner="{{ 'yes' if row.isBonnerNote else 'no' }}">Edit</button>
+                     <button type="button" class="btn btn-sm btn-danger deleteNoteButton" data-noteid="{{ row.id}}" data-username="{{volunteer.username}}">Delete</button>
                     {% else %}
-                      <button type="button" class="btn btn-sm btn-danger editNoteButton float-end disabled" data-noteid="{{row.id}}" data-username="{{volunteer.username}}">Edit</button>
-                      <button type="button" class="btn btn-sm btn-danger deleteNoteButton float-end disabled" data-noteid="{{row.id}}" data-username="{{volunteer.username}}">Delete</button>
+                      <button type="button" class="btn btn-sm btn-primary" disabled>Edit</button>
+                      <button type="button" class="btn btn-sm btn-danger" disabled>Delete</button>
                     {% endif %}
                   </td>
                 </tr>
@@ -565,7 +564,7 @@
             <div class="form-group input-group-x form-outline ui-widget">
               <textarea required name="noteTextbox" rows="8" cols="80" type="input" id="addNoteTextArea" class="form-control" placeholder="This will add a note to a user's profile." ></textarea>
             </div>
-          </div>
+          </div> 
         </div>
         <div class="modal-footer justify-content-between">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -424,10 +424,12 @@
                       {{ "Bonner Scholar " if row.isBonnerNote else "Everyone"}}
                     {% endif %}
                   </td>
-                  <td>
+                  <tr>
                     {% if (g.current_user == row.note.createdBy) or g.current_user.isCeltsAdmin%}
+                      <button type="button" class="btn btn-sm btn-danger editNoteButton float-end" data-noteid="{{row.id}}" data-username="{{volunteer.username}}">Edit</button>
                       <button type="button" class="btn btn-sm btn-danger deleteNoteButton float-end" data-noteid="{{row.id}}" data-username="{{volunteer.username}}">Delete</button>
                     {% else %}
+                      <button type="button" class="btn btn-sm btn-danger editNoteButton float-end disabled" data-noteid="{{row.id}}" data-username="{{volunteer.username}}">Edit</button>
                       <button type="button" class="btn btn-sm btn-danger deleteNoteButton float-end disabled" data-noteid="{{row.id}}" data-username="{{volunteer.username}}">Delete</button>
                     {% endif %}
                   </td>

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -452,7 +452,7 @@
         {% endif %}
         <br>
         <br>
-        <button type="button" name="button" class="btn btn-primary" id="addNoteButton">Add Bonner Note</button>
+        <button type="button" name="button" class="btn btn-primary" id="addNoteButton">Add Note</button>
       </div>
     </div>
   </div>
@@ -513,7 +513,7 @@
               {% else %}
                 <p class='ps-1'>No one has left a Bonner note.</p>
               {% endif %}
-                <button type="button" name="button" class="btn btn-primary" id="addBonnerNoteButton">Add Note</button>
+                <button type="button" name="button" class="btn btn-primary" id="addBonnerNoteButton">Add Bonner Note</button>
             </div>
             {# Bonner Requirements #}
             <div class="col-md-6">

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -544,7 +544,7 @@
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title">Add Notes</h5>
+          <h5 class="modal-title">Notes</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
 

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -513,7 +513,7 @@
               {% else %}
                 <p class='ps-1'>No one has left a Bonner note.</p>
               {% endif %}
-                <button type="button" name="button" class="btn btn-primary" id="addBonnerNoteButton">Add Bonner Note</button>
+                <button type="button" name="button" class="btn btn-primary" id="addBonnerNoteButton">Add Note</button>
             </div>
             {# Bonner Requirements #}
             <div class="col-md-6">

--- a/database/prod-backup.sql
+++ b/database/prod-backup.sql
@@ -954,7 +954,7 @@ CREATE TABLE `note` (
   `id` int NOT NULL AUTO_INCREMENT,
   `createdBy_id` varchar(255) NOT NULL,
   `createdOn` datetime NOT NULL,
-  `noteContent` varchar(255) NOT NULL,
+  `noteContent` TEXT NOT NULL,
   `isPrivate` tinyint(1) NOT NULL,
   `noteType` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),


### PR DESCRIPTION
## Issue Description

Fixes #1630
- Add issue description
This update allows users to edit an existing note using the same modal that is used to add a new note.
When a user clicks Edit, the modal now opens with the note’s:
Text already filled in
<img width="1145" height="610" alt="Screenshot 2026-02-18 at 3 26 47 PM" src="https://github.com/user-attachments/assets/b6b616ff-4b1f-4c7c-afa3-8b6571d93cf3" />

## Changes
Added logic so clicking Edit opens the modal with the note’s current information.
Fixed the edit button’s data-* attributes so they match the correct model fields.
If editing, the old note is deleted.
The updated version is saved as a new note.
<img width="476" height="493" alt="Screenshot 2026-02-18 at 3 26 58 PM" src="https://github.com/user-attachments/assets/6ec691a5-4ab7-41a2-ad69-48bef5d18a67" />

Note Editing
Go to My Profile under Event List.
Create a note and save
Click Edit on the existing note.
Confirm the updated text appears correctly.
Click save.
Confirm the updated note appears  correctly.