### PR TITLE
training message

### DIFF
--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -493,9 +493,7 @@ def volunteerRegister():
     program = event.program
     user = g.current_user
 
-    isAdded = checkUserRsvp(user, event)
     isEligible = isEligibleForProgram(program, user)
-    listOfRequirements = unattendedRequiredEvents(program, user)
 
     personAdded = False
     if isEligible:
@@ -506,7 +504,6 @@ def volunteerRegister():
             flash(f"RSVP Failed due to an unknown error.", "danger")
     else:
         flash(f"Cannot RSVP. Contact CELTS administrators: {app.config['celts_admin_contact']}.", "danger")
-
 
     if 'from' in request.form:
         if request.form['from'] == 'ajax':

--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -500,10 +500,7 @@ def volunteerRegister():
     personAdded = False
     if isEligible:
         personAdded = addPersonToEvent(user, event)
-        if personAdded and listOfRequirements:
-            reqListToString = ', '.join(listOfRequirements)
-            flash(f"{user.firstName} {user.lastName} successfully registered. However, the following training may be required: {reqListToString}.", "success")
-        elif personAdded:
+        if personAdded:
             flash("Successfully registered for event!","success")
         else:
             flash(f"RSVP Failed due to an unknown error.", "danger")


### PR DESCRIPTION
## Issue Description

Fixes #1432 
- When you RSVP for an event you get a flash message with a million different trainings that really shouldn't be necessary. They need to be removed.

## Changes

- Changed the routes flash message and removed unused variables 

## Testing

- Create a new event that requires an RSVP (while you are logged in as admin)
- Then log in as a student 
- Go to events list 
- RSVP for that event, you should see the new flash message without the trainings.