### PR TITLE
Labor attendance report 1626

### DIFF
--- a/app/logic/volunteerSpreadsheet.py
+++ b/app/logic/volunteerSpreadsheet.py
@@ -226,28 +226,8 @@ def calculateRetentionRate(fallDict, springDict):
 
     return retentionDict
 
-def laborAttendanceByTerm(academicYear):
-#     """Get labor students and their meeting attendance count for each term"""
-#     base = getBaseQuery(academicYear)
-
-#     query = (base.select(
-#         fn.CONCAT(User.firstName, ' ', User.lastName).alias('fullName'), 
-#         User.bnumber, 
-#         fn.CONCAT(EventParticipant.user_id, '@berea.edu').alias('email'),
-#         Term.description, 
-#         fn.COUNT(EventParticipant.event_id).alias('meetingsAttended'), 
-#     )
-#     .where(Event.isLaborOnly == True)
-#     .group_by(EventParticipant.user_id, Term.description)
-#     .order_by(User.lastName, User.firstName, Term.description)
-#     )
-
-#     columns = ("Full Name", "B-Number", "Email", "Term", "Meetings Attended")
-#     results = list(query.tuples())
-#     return (columns, results)
-
-
-    query = (
+def laborAttendanceByTerm(academicYear): 
+    laborQuery = (
         CeltsLabor
         .select(
             fn.CONCAT(User.firstName, ' ', User.lastName).alias('fullName'),
@@ -260,32 +240,62 @@ def laborAttendanceByTerm(academicYear):
         .switch(CeltsLabor)
         .join(
             EventParticipant,
-            JOIN.FULL,
+            JOIN.LEFT_OUTER,
             on=(CeltsLabor.user == EventParticipant.user)
         )
         .join(
             Event,
             JOIN.LEFT_OUTER,
-            on=(EventParticipant.event_id == Event.id)
+            on=(
+                (EventParticipant.event == Event.id) &
+                (Event.isLaborOnly == True) &
+                (Event.deletionDate.is_null()) &
+                (Event.isCanceled == False)
+            )
         )
         .join(
             Term,
-            on=(Event.term == Term.id)
+            JOIN.LEFT_OUTER,
+            on=(
+                (Event.term == Term.id) &
+                (Term.academicYear == academicYear)
+            )
         )
+        .group_by(CeltsLabor.user, Term.description)
+    )
+
+    nonLaborQuery = (
+        EventParticipant
+        .select(
+            fn.CONCAT(User.firstName, ' ', User.lastName).alias('fullName'),
+            User.bnumber,
+            fn.CONCAT(User.username, '@berea.edu').alias('email'),
+            Term.description,
+            fn.COUNT(EventParticipant.event_id).alias('meetingsAttended')
+        )
+        .join(User)
+        .switch(EventParticipant)
+        .join(
+            Event,
+            on=(
+                (EventParticipant.event == Event.id) &
+                (Event.isLaborOnly == True) &
+                (Event.deletionDate.is_null()) &
+                (Event.isCanceled == False)
+            )
+        )
+        .join(Term, on=(Event.term == Term.id))
         .where(
             Term.academicYear == academicYear,
-            Event.isLaborOnly == True,
-            Event.deletionDate.is_null(True),
-            Event.isCanceled == False
+            User.username.not_in(CeltsLabor.select(CeltsLabor.user_id))
         )
-        .group_by(User.id, Term.description)
-        .order_by(User.lastName, User.firstName, Term.description)
+        .group_by(EventParticipant.user, Term.description)
     )
-    
-    columns = ("Full Name", "B-Number", "Email", "Term", "Meetings Attended")
-    results = list(query.tuples())
-    return (columns, results)
 
+    query = laborQuery.union(nonLaborQuery)
+    columns = ("Full Name", "B-Number", "Email", "Term", "Meetings Attended")
+
+    return (columns, query.tuples())
 
 
 def makeDataXls(sheetName, sheetData, workbook, sheetDesc=None):
@@ -333,7 +343,7 @@ def createSpreadsheet(academicYear):
     makeDataXls("Unique Volunteers", getUniqueVolunteers(academicYear), workbook, sheetDesc=f"All students who participated in at least one service event during {academicYear}.")
     makeDataXls("Only All Volunteer Training", onlyCompletedAllVolunteer(academicYear), workbook, sheetDesc="Students who participated in an All Volunteer Training, but did not participate in any service events.")
     makeDataXls("Retention Rate By Semester", getRetentionRate(academicYear), workbook, sheetDesc="The percentage of students who participated in service events in the fall semester who also participated in a service event in the spring semester. Does not currently account for fall graduations.")
-    makeDataXls("Labor Attendance By Term", laborAttendanceByTerm(academicYear), workbook, sheetDesc="Labor students and the number of labor events attended for each term in the academic year.")
+    makeDataXls("Labor Attendance By Term", laborAttendanceByTerm(academicYear), workbook, sheetDesc="Reports the number of labor-only events attended per term for each labor student, including those with zero attendance, and non-labor attendees.")
 
     fallTerm = getFallTerm(academicYear)
     springTerm = getSpringTerm(academicYear)

--- a/app/logic/volunteerSpreadsheet.py
+++ b/app/logic/volunteerSpreadsheet.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from datetime import date, datetime,time
 from app import app
 from app.models import mainDB
+from app.models.celtsLabor import CeltsLabor
 from app.models.eventParticipant import EventParticipant
 from app.models.user import User
 from app.models.program import Program
@@ -226,24 +227,60 @@ def calculateRetentionRate(fallDict, springDict):
     return retentionDict
 
 def laborAttendanceByTerm(academicYear):
-    """Get labor students and their meeting attendance count for each term"""
-    base = getBaseQuery(academicYear)
+#     """Get labor students and their meeting attendance count for each term"""
+#     base = getBaseQuery(academicYear)
 
-    query = (base.select(
-        fn.CONCAT(User.firstName, ' ', User.lastName).alias('fullName'), 
-        User.bnumber, 
-        fn.CONCAT(EventParticipant.user_id, '@berea.edu').alias('email'),
-        Term.description, 
-        fn.COUNT(EventParticipant.event_id.distinct()).alias('meetingsAttended'), 
-    )
-    .where(Event.isLaborOnly == True)
-    .group_by(EventParticipant.user_id, Term.description)
-    .order_by(User.lastName, User.firstName, Term.description)
-    )
+#     query = (base.select(
+#         fn.CONCAT(User.firstName, ' ', User.lastName).alias('fullName'), 
+#         User.bnumber, 
+#         fn.CONCAT(EventParticipant.user_id, '@berea.edu').alias('email'),
+#         Term.description, 
+#         fn.COUNT(EventParticipant.event_id).alias('meetingsAttended'), 
+#     )
+#     .where(Event.isLaborOnly == True)
+#     .group_by(EventParticipant.user_id, Term.description)
+#     .order_by(User.lastName, User.firstName, Term.description)
+#     )
 
-    columns = ("Full Name", "B-Number", "Email", "Term", "Meetings Attended")
-    results = list(query.tuples())
-    return (columns, results)
+#     columns = ("Full Name", "B-Number", "Email", "Term", "Meetings Attended")
+#     results = list(query.tuples())
+#     return (columns, results)
+
+
+    query = (
+        CeltsLabor
+        .select(
+            fn.CONCAT(User.firstName, ' ', User.lastName).alias('fullName'),
+            User.bnumber,
+            fn.CONCAT(User.username, '@berea.edu').alias('email'),
+            Term.description,
+            fn.COUNT(EventParticipant.event_id).alias('meetingsAttended')
+        )
+        .join(User)
+        .switch(CeltsLabor)
+        .join(
+            EventParticipant,
+            JOIN.FULL,
+            on=(CeltsLabor.user == EventParticipant.user)
+        )
+        .join(
+            Event,
+            JOIN.LEFT_OUTER,
+            on=(EventParticipant.event_id == Event.id)
+        )
+        .join(
+            Term,
+            on=(Event.term == Term.id)
+        )
+        .where(
+            Term.academicYear == academicYear,
+            Event.isLaborOnly == True,
+            Event.deletionDate.is_null(True),
+            Event.isCanceled == False
+        )
+        .group_by(User.id, Term.description)
+        .order_by(User.lastName, User.firstName, Term.description)
+    )
 
 
 
@@ -292,7 +329,7 @@ def createSpreadsheet(academicYear):
     makeDataXls("Unique Volunteers", getUniqueVolunteers(academicYear), workbook, sheetDesc=f"All students who participated in at least one service event during {academicYear}.")
     makeDataXls("Only All Volunteer Training", onlyCompletedAllVolunteer(academicYear), workbook, sheetDesc="Students who participated in an All Volunteer Training, but did not participate in any service events.")
     makeDataXls("Retention Rate By Semester", getRetentionRate(academicYear), workbook, sheetDesc="The percentage of students who participated in service events in the fall semester who also participated in a service event in the spring semester. Does not currently account for fall graduations.")
-    makeDataXls("Labor Attendance By Term", laborAttendanceByTerm(academicYear), workbook, sheetDesc="Labor students and the number of labor meetings attended for each term in the academic year.")
+    makeDataXls("Labor Attendance By Term", laborAttendanceByTerm(academicYear), workbook, sheetDesc="Labor students and the number of labor events attended for each term in the academic year.")
 
     fallTerm = getFallTerm(academicYear)
     springTerm = getSpringTerm(academicYear)

--- a/app/logic/volunteerSpreadsheet.py
+++ b/app/logic/volunteerSpreadsheet.py
@@ -241,7 +241,7 @@ def laborAttendanceByTerm(term):
     CLTerm = Term.alias()
     laborMembers = (
         CeltsLabor
-        .select(CeltsLabor.user_id)
+        .select(fn.DISTINCT(CeltsLabor.user_id))
         .join(CLTerm, on=(CeltsLabor.term == CLTerm.id))
         .where(
             (CeltsLabor.term == term) |

--- a/app/logic/volunteerSpreadsheet.py
+++ b/app/logic/volunteerSpreadsheet.py
@@ -243,7 +243,6 @@ def laborAttendanceByTerm(academicYear):
 
     columns = ("Full Name", "B-Number", "Email", "Term", "Meetings Attended")
     results = list(query.tuples())
-    # return (columns,query.tuples())
     return (columns, results)
 
 

--- a/app/logic/volunteerSpreadsheet.py
+++ b/app/logic/volunteerSpreadsheet.py
@@ -265,7 +265,7 @@ def laborAttendanceByTerm(term):
             fn.CONCAT(User.firstName, ' ', User.lastName).alias('fullName'),
             User.bnumber,
             fn.CONCAT(User.username, '@berea.edu').alias('email'),
-            fn.COUNT(EventParticipant.event_id).alias('meetingsAttended')
+            fn.COUNT(fn.DISTINCT(EventParticipant.event_id)).alias('meetingsAttended')
         )
         .join(User)
         .switch(EventParticipant)

--- a/app/logic/volunteerSpreadsheet.py
+++ b/app/logic/volunteerSpreadsheet.py
@@ -234,7 +234,7 @@ def laborAttendanceByTerm(academicYear):
         User.bnumber, 
         fn.CONCAT(EventParticipant.user_id, '@berea.edu').alias('email'),
         Term.description, 
-        fn.COUNT(EventParticipant.event_id).alias('meetingsAttended'), 
+        fn.COUNT(EventParticipant.event_id.distinct()).alias('meetingsAttended'), 
     )
     .where(Event.isLaborOnly == True)
     .group_by(EventParticipant.user_id, Term.description)

--- a/app/logic/volunteerSpreadsheet.py
+++ b/app/logic/volunteerSpreadsheet.py
@@ -227,73 +227,50 @@ def calculateRetentionRate(fallDict, springDict):
     return retentionDict
 
 def laborAttendanceByTerm(term):
-    laborQuery = ( #so that all Celts Labor students appear even if they didn't attend anything 
+    fullName = fn.CONCAT(User.firstName, ' ', User.lastName).alias('fullName')
+    email = fn.CONCAT(User.username, '@berea.edu').alias('email')
+    meetingsAttended = fn.COUNT(fn.DISTINCT(Event.id)).alias('meetingsAttended')
+
+    validEvent = (
+        (EventParticipant.event == Event.id) &
+        (Event.term == term) &
+        (Event.isLaborOnly == True) &
+        (Event.deletionDate.is_null()) &
+        (Event.isCanceled == False))
+
+    CLTerm = Term.alias()
+    laborMembers = (
         CeltsLabor
-        .select(
-            fn.CONCAT(User.firstName, ' ', User.lastName).alias('fullName'),
-            User.bnumber,
-            fn.CONCAT(User.username, '@berea.edu').alias('email'),
-            fn.COUNT(fn.DISTINCT(Event.id)).alias('meetingsAttended')
-        )
+        .select(CeltsLabor.user_id)
+        .join(CLTerm, on=(CeltsLabor.term == CLTerm.id))
+        .where(
+            (CeltsLabor.term == term) |
+            ((CLTerm.academicYear == term.academicYear) & (CeltsLabor.isAcademicYear == True))
+        ))
+
+    laborQuery = (
+        CeltsLabor
+        .select(fullName, User.bnumber, email, meetingsAttended)
         .join(User)
         .switch(CeltsLabor)
-        .join(
-            EventParticipant,
-            JOIN.LEFT_OUTER,
-            on=(CeltsLabor.user == EventParticipant.user)
-        )
-        .join(
-            Event,
-            JOIN.LEFT_OUTER,
-            on=(
-                (EventParticipant.event == Event.id) &
-                (Event.term == term) &
-                (Event.isLaborOnly == True) &
-                (Event.deletionDate.is_null()) &
-                (Event.isCanceled == False)
-            )
-        )
-        .where(
-            (CeltsLabor.term == term)
-        )
-        .group_by(CeltsLabor.user)
-    )
+        .join(EventParticipant, JOIN.LEFT_OUTER, on=(CeltsLabor.user == EventParticipant.user))
+        .join(Event, JOIN.LEFT_OUTER,on=validEvent)
+        .where(CeltsLabor.user.in_(laborMembers))
+        .group_by(CeltsLabor.user))
 
-    nonLaborQuery = ( #so that non-labor attendees who are not in CeltsLabor also appear 
+    nonLaborQuery = (
         EventParticipant
-        .select(
-            fn.CONCAT(User.firstName, ' ', User.lastName).alias('fullName'),
-            User.bnumber,
-            fn.CONCAT(User.username, '@berea.edu').alias('email'),
-            fn.COUNT(fn.DISTINCT(EventParticipant.event_id)).alias('meetingsAttended')
-        )
+        .select(fullName, User.bnumber, email, meetingsAttended)
         .join(User)
         .switch(EventParticipant)
-        .join(
-            Event,
-            on=(
-                (EventParticipant.event == Event.id) &
-                (Event.term == term) &
-                (Event.isLaborOnly == True) &
-                (Event.deletionDate.is_null()) &
-                (Event.isCanceled == False)
-            )
-        )
-        .join(
-            CeltsLabor,
-            JOIN.LEFT_OUTER,
-            on=(EventParticipant.user == CeltsLabor.user) &
-                (CeltsLabor.term == term) 
-        )
-        .where(CeltsLabor.user.is_null())
-        .group_by(EventParticipant.user)
-    )
+        .join(Event,on=validEvent)
+        .where(EventParticipant.user.not_in(laborMembers))
+        .group_by(EventParticipant.user))
 
     query = laborQuery.union(nonLaborQuery).order_by(SQL('fullName'))
     columns = ("Full Name", "B-Number", "Email", "Meetings Attended")
 
-    return (columns, query.tuples()) 
-
+    return (columns, query.tuples())
 
 def makeDataXls(sheetName, sheetData, workbook, sheetDesc=None):
     # assumes the length of the column titles matches the length of the data

--- a/app/logic/volunteerSpreadsheet.py
+++ b/app/logic/volunteerSpreadsheet.py
@@ -232,12 +232,12 @@ def laborAttendanceByTerm(academicYear):
     query = (base.select(
         fn.CONCAT(User.firstName, ' ', User.lastName).alias('fullName'), 
         User.bnumber, 
-        fn.CONCAT(User.username, '@berea.edu').alias('email'),
+        fn.CONCAT(EventParticipant.user_id, '@berea.edu').alias('email'),
         Term.description, 
         fn.COUNT(EventParticipant.event_id).alias('meetingsAttended'), 
     )
     .where(Event.isLaborOnly == True)
-    .group_by(User.username, Term.description)
+    .group_by(EventParticipant.user_id, Term.description)
     .order_by(User.lastName, Term.description)
     )
 

--- a/app/logic/volunteerSpreadsheet.py
+++ b/app/logic/volunteerSpreadsheet.py
@@ -243,8 +243,6 @@ def laborAttendanceByTerm(academicYear):
 
     columns = ("Full Name", "B-Number", "Email", "Term", "Meetings Attended")
     results = list(query.tuples())
-    print("Row count:", len(results))
-    print("Results:", results)
     # return (columns,query.tuples())
     return (columns, results)
 

--- a/app/logic/volunteerSpreadsheet.py
+++ b/app/logic/volunteerSpreadsheet.py
@@ -295,6 +295,7 @@ def createSpreadsheet(academicYear):
     makeDataXls("Unique Volunteers", getUniqueVolunteers(academicYear), workbook, sheetDesc=f"All students who participated in at least one service event during {academicYear}.")
     makeDataXls("Only All Volunteer Training", onlyCompletedAllVolunteer(academicYear), workbook, sheetDesc="Students who participated in an All Volunteer Training, but did not participate in any service events.")
     makeDataXls("Retention Rate By Semester", getRetentionRate(academicYear), workbook, sheetDesc="The percentage of students who participated in service events in the fall semester who also participated in a service event in the spring semester. Does not currently account for fall graduations.")
+    makeDataXls("Labor Attendance By Term", laborAttendanceByTerm(academicYear), workbook, sheetDesc="Labor students and the number of labor meetings attended for each term in the academic year.")
 
     fallTerm = getFallTerm(academicYear)
     springTerm = getSpringTerm(academicYear)

--- a/app/logic/volunteerSpreadsheet.py
+++ b/app/logic/volunteerSpreadsheet.py
@@ -1,5 +1,4 @@
 from os import major
-from openpyxl import workbook
 import xlsxwriter 
 from peewee import fn, Case, JOIN, SQL, Select
 from collections import defaultdict
@@ -234,7 +233,7 @@ def laborAttendanceByTerm(term):
             fn.CONCAT(User.firstName, ' ', User.lastName).alias('fullName'),
             User.bnumber,
             fn.CONCAT(User.username, '@berea.edu').alias('email'),
-            fn.COUNT(EventParticipant.event_id).alias('meetingsAttended')
+            fn.COUNT(Event.id).alias('meetingsAttended')
         )
         .join(User)
         .switch(CeltsLabor)

--- a/app/logic/volunteerSpreadsheet.py
+++ b/app/logic/volunteerSpreadsheet.py
@@ -342,8 +342,6 @@ def createSpreadsheet(academicYear):
     makeDataXls(f"Labor Attendance {fallTerm.description}", laborAttendanceByTerm(fallTerm), workbook,sheetDesc=f"Number of labor-only events attended in {fallTerm.description} for each labor student and non-labor attendees, including zero attendance (for labor students).")
     makeDataXls(f"Labor Attendance {springTerm.description}", laborAttendanceByTerm(springTerm), workbook, sheetDesc=f"Number of labor-only events attended in {springTerm.description} for each labor student and non-labor attendees, including zero attendance (for labor students).")
     
-    fallTerm = getFallTerm(academicYear)
-    springTerm = getSpringTerm(academicYear)
     makeDataXls(fallTerm.description, getAllTermData(fallTerm), workbook, sheetDesc= "All event participation for the term, excluding deleted or canceled events.")
     makeDataXls(springTerm.description, getAllTermData(springTerm), workbook, sheetDesc="All event participation for the term, excluding deleted or canceled events.")
 

--- a/app/logic/volunteerSpreadsheet.py
+++ b/app/logic/volunteerSpreadsheet.py
@@ -238,7 +238,7 @@ def laborAttendanceByTerm(academicYear):
     )
     .where(Event.isLaborOnly == True)
     .group_by(EventParticipant.user_id, Term.description)
-    .order_by(User.lastName, Term.description)
+    .order_by(User.lastName, User.firstName, Term.description)
     )
 
     columns = ("Full Name", "B-Number", "Email", "Term", "Meetings Attended")

--- a/app/logic/volunteerSpreadsheet.py
+++ b/app/logic/volunteerSpreadsheet.py
@@ -233,7 +233,7 @@ def laborAttendanceByTerm(term):
             fn.CONCAT(User.firstName, ' ', User.lastName).alias('fullName'),
             User.bnumber,
             fn.CONCAT(User.username, '@berea.edu').alias('email'),
-            fn.COUNT(Event.id).alias('meetingsAttended')
+            fn.COUNT(fn.DISTINCT(Event.id)).alias('meetingsAttended')
         )
         .join(User)
         .switch(CeltsLabor)
@@ -252,6 +252,9 @@ def laborAttendanceByTerm(term):
                 (Event.deletionDate.is_null()) &
                 (Event.isCanceled == False)
             )
+        )
+        .where(
+            (CeltsLabor.term == term)
         )
         .group_by(CeltsLabor.user)
     )
@@ -279,7 +282,8 @@ def laborAttendanceByTerm(term):
         .join(
             CeltsLabor,
             JOIN.LEFT_OUTER,
-            on=(EventParticipant.user == CeltsLabor.user)
+            on=(EventParticipant.user == CeltsLabor.user) &
+                (CeltsLabor.term == term) 
         )
         .where(CeltsLabor.user.is_null())
         .group_by(EventParticipant.user)

--- a/app/logic/volunteerSpreadsheet.py
+++ b/app/logic/volunteerSpreadsheet.py
@@ -225,6 +225,30 @@ def calculateRetentionRate(fallDict, springDict):
 
     return retentionDict
 
+def laborAttendanceByTerm(academicYear):
+    """Get labor students and their meeting attendance count for each term"""
+    base = getBaseQuery(academicYear)
+
+    query = (base.select(
+        fn.CONCAT(User.firstName, ' ', User.lastName).alias('fullName'), 
+        User.bnumber, 
+        fn.CONCAT(User.username, '@berea.edu').alias('email'),
+        Term.description, 
+        fn.COUNT(EventParticipant.event_id).alias('meetingsAttended'), 
+    )
+    .where(Event.isLaborOnly == True)
+    .group_by(User.username, Term.description)
+    .order_by(User.lastName, Term.description)
+    )
+
+    columns = ("Full Name", "B-Number", "Email", "Term", "Meetings Attended")
+    results = list(query.tuples())
+    print("Row count:", len(results))
+    print("Results:", results)
+    # return (columns,query.tuples())
+    return (columns, results)
+
+
 
 def makeDataXls(sheetName, sheetData, workbook, sheetDesc=None):
     # assumes the length of the column titles matches the length of the data

--- a/app/logic/volunteerSpreadsheet.py
+++ b/app/logic/volunteerSpreadsheet.py
@@ -281,6 +281,10 @@ def laborAttendanceByTerm(academicYear):
         .group_by(User.id, Term.description)
         .order_by(User.lastName, User.firstName, Term.description)
     )
+    
+    columns = ("Full Name", "B-Number", "Email", "Term", "Meetings Attended")
+    results = list(query.tuples())
+    return (columns, results)
 
 
 

--- a/app/logic/volunteerSpreadsheet.py
+++ b/app/logic/volunteerSpreadsheet.py
@@ -1,4 +1,5 @@
 from os import major
+from openpyxl import workbook
 import xlsxwriter 
 from peewee import fn, Case, JOIN, SQL, Select
 from collections import defaultdict
@@ -226,14 +227,13 @@ def calculateRetentionRate(fallDict, springDict):
 
     return retentionDict
 
-def laborAttendanceByTerm(academicYear): 
-    laborQuery = (
+def laborAttendanceByTerm(term):
+    laborQuery = ( #so that all Celts Labor students appear even if they didn't attend anything 
         CeltsLabor
         .select(
             fn.CONCAT(User.firstName, ' ', User.lastName).alias('fullName'),
             User.bnumber,
             fn.CONCAT(User.username, '@berea.edu').alias('email'),
-            Term.description,
             fn.COUNT(EventParticipant.event_id).alias('meetingsAttended')
         )
         .join(User)
@@ -248,29 +248,21 @@ def laborAttendanceByTerm(academicYear):
             JOIN.LEFT_OUTER,
             on=(
                 (EventParticipant.event == Event.id) &
+                (Event.term == term) &
                 (Event.isLaborOnly == True) &
                 (Event.deletionDate.is_null()) &
                 (Event.isCanceled == False)
             )
         )
-        .join(
-            Term,
-            JOIN.LEFT_OUTER,
-            on=(
-                (Event.term == Term.id) &
-                (Term.academicYear == academicYear)
-            )
-        )
-        .group_by(CeltsLabor.user, Term.description)
+        .group_by(CeltsLabor.user)
     )
 
-    nonLaborQuery = (
+    nonLaborQuery = ( #so that non-labor attendees who are not in CeltsLabor also appear 
         EventParticipant
         .select(
             fn.CONCAT(User.firstName, ' ', User.lastName).alias('fullName'),
             User.bnumber,
             fn.CONCAT(User.username, '@berea.edu').alias('email'),
-            Term.description,
             fn.COUNT(EventParticipant.event_id).alias('meetingsAttended')
         )
         .join(User)
@@ -279,23 +271,25 @@ def laborAttendanceByTerm(academicYear):
             Event,
             on=(
                 (EventParticipant.event == Event.id) &
+                (Event.term == term) &
                 (Event.isLaborOnly == True) &
                 (Event.deletionDate.is_null()) &
                 (Event.isCanceled == False)
             )
         )
-        .join(Term, on=(Event.term == Term.id))
-        .where(
-            Term.academicYear == academicYear,
-            User.username.not_in(CeltsLabor.select(CeltsLabor.user_id))
+        .join(
+            CeltsLabor,
+            JOIN.LEFT_OUTER,
+            on=(EventParticipant.user == CeltsLabor.user)
         )
-        .group_by(EventParticipant.user, Term.description)
+        .where(CeltsLabor.user.is_null())
+        .group_by(EventParticipant.user)
     )
 
-    query = laborQuery.union(nonLaborQuery)
-    columns = ("Full Name", "B-Number", "Email", "Term", "Meetings Attended")
+    query = laborQuery.union(nonLaborQuery).order_by(SQL('fullName'))
+    columns = ("Full Name", "B-Number", "Email", "Meetings Attended")
 
-    return (columns, query.tuples())
+    return (columns, query.tuples()) 
 
 
 def makeDataXls(sheetName, sheetData, workbook, sheetDesc=None):
@@ -343,8 +337,12 @@ def createSpreadsheet(academicYear):
     makeDataXls("Unique Volunteers", getUniqueVolunteers(academicYear), workbook, sheetDesc=f"All students who participated in at least one service event during {academicYear}.")
     makeDataXls("Only All Volunteer Training", onlyCompletedAllVolunteer(academicYear), workbook, sheetDesc="Students who participated in an All Volunteer Training, but did not participate in any service events.")
     makeDataXls("Retention Rate By Semester", getRetentionRate(academicYear), workbook, sheetDesc="The percentage of students who participated in service events in the fall semester who also participated in a service event in the spring semester. Does not currently account for fall graduations.")
-    makeDataXls("Labor Attendance By Term", laborAttendanceByTerm(academicYear), workbook, sheetDesc="Reports the number of labor-only events attended per term for each labor student, including those with zero attendance, and non-labor attendees.")
-
+    
+    fallTerm = getFallTerm(academicYear)
+    springTerm = getSpringTerm(academicYear)
+    makeDataXls(f"Labor Attendance {fallTerm.description}", laborAttendanceByTerm(fallTerm), workbook,sheetDesc=f"Number of labor-only events attended in {fallTerm.description} for each labor student and non-labor attendees, including zero attendance (for labor students).")
+    makeDataXls(f"Labor Attendance {springTerm.description}", laborAttendanceByTerm(springTerm), workbook, sheetDesc=f"Number of labor-only events attended in {springTerm.description} for each labor student and non-labor attendees, including zero attendance (for labor students).")
+    
     fallTerm = getFallTerm(academicYear)
     springTerm = getSpringTerm(academicYear)
     makeDataXls(fallTerm.description, getAllTermData(fallTerm), workbook, sheetDesc= "All event participation for the term, excluding deleted or canceled events.")

--- a/tests/code/test_spreadsheet.py
+++ b/tests/code/test_spreadsheet.py
@@ -65,10 +65,10 @@ def fixture_info():
             isService=True
         )
 
-        labor1 = CeltsLabor.create(user=user1, term=term1, positionTitle="test position 1")
-        labor2 = CeltsLabor.create(user=user2, term=term1, positionTitle="test position 2")
-        labor3 = CeltsLabor.create(user=user1, term=term2, positionTitle="test position 3")
-        labor4 = CeltsLabor.create(user=user2, term=term2, positionTitle="test position 4")
+        labor1 = CeltsLabor.create(user=user1, term=term1, positionTitle="test position 1", isAcademicYear=True)
+        labor2 = CeltsLabor.create(user=user2, term=term1, positionTitle="test position 2", isAcademicYear=True)
+        labor3 = CeltsLabor.create(user=user1, term=term2, positionTitle="test position 3", isAcademicYear=True)
+        labor4 = CeltsLabor.create(user=user2, term=term2, positionTitle="test position 4", isAcademicYear=True)
 
         eventparticipant1 = EventParticipant.create(event=event1, user=user1, hoursEarned=5)
         eventparticipant2 = EventParticipant.create(event=event1, user=user2, hoursEarned=3)
@@ -699,13 +699,20 @@ def test_laborAttendanceByTerm(fixture_info):
     columns, results = laborAttendanceByTerm(fixture_info['term1'])
     results = list(results)
 
-    assert columns == ["Full Name", "B-Number", "Email", "Meetings Attended"]
+    assert columns == ("Full Name", "B-Number", "Email", "Meetings Attended")
 
     assert len(results) == 2
     assert ("John Doe", "B774377", "doej@berea.edu", 1) in results
     assert ("Jane Doe", "B888828", "doej2@berea.edu", 1) in results
 
     columns, results = laborAttendanceByTerm(fixture_info['term2'])
+    results = list(results)
+
+    assert len(results) == 2
+    assert ("John Doe", "B774377", "doej@berea.edu", 0) in results
+    assert ("Jane Doe", "B888828", "doej2@berea.edu", 0) in results
+
+    columns, results = laborAttendanceByTerm(fixture_info['term3'])
     results = list(results)
 
     assert len(results) == 2

--- a/tests/code/test_spreadsheet.py
+++ b/tests/code/test_spreadsheet.py
@@ -683,5 +683,42 @@ def test_getUniqueVolunteers(fixture_info):
         ("Test Tester", "testt@berea.edu", "B55555"),
     ])
 
+@pytest.mark.integration
+def test_laborAttendanceByTerm(fixture_info):
+    # No labor events yet so should return empty results
+    columns, results = laborAttendanceByTerm("2023-2024-test")
+    assert columns == ("Full Name", "B-Number", "Email", "Term", "Meetings Attended")
+    assert results == []
 
+    # Create a labor-only program and events
+    laborProgram = Program.create(programName='Labor')
+    laborEvent1 = Event.create(
+        name='Labor Meeting 1',
+        term=fixture_info['term1'],
+        program=laborProgram,
+        startDate=date(2023, 9, 5),
+        isCanceled=False,
+        deletionDate=None,
+        isLaborOnly=True,
+    )
+    laborEvent2 = Event.create(
+        name='Labor Meeting 2',
+        term=fixture_info['term1'],
+        program=laborProgram,
+        startDate=date(2023, 9, 12),
+        isCanceled=False,
+        deletionDate=None,
+        isLaborOnly=True,
+    )
 
+    EventParticipant.create(event=laborEvent1, user=fixture_info['user1'], hoursEarned=1)
+    EventParticipant.create(event=laborEvent2, user=fixture_info['user1'], hoursEarned=1)
+    EventParticipant.create(event=laborEvent1, user=fixture_info['user2'], hoursEarned=1)
+
+    columns, results = laborAttendanceByTerm("2023-2024-test")
+    assert columns == ("Full Name", "B-Number", "Email", "Term", "Meetings Attended")
+
+    # user1 (Doe, John) attended 2 meetings, user2 (Doe, Jane) attended 1
+    assert len(results) == 2
+    assert ("John Doe", "B774377", "doej@berea.edu", "Fall 2023", 2) in results
+    assert ("Jane Doe", "B888828", "doej2@berea.edu", "Fall 2023", 1) in results

--- a/tests/code/test_spreadsheet.py
+++ b/tests/code/test_spreadsheet.py
@@ -4,6 +4,7 @@ from app.models import mainDB
 from app.models.user import User
 from app.models.term import Term
 from app.models.eventParticipant import EventParticipant
+from app.models.celtsLabor import CeltsLabor
 from app.logic.volunteerSpreadsheet import *
 from app.models.program import Program
 from app.models.event import Event
@@ -32,7 +33,7 @@ def fixture_info():
             startDate=date(2023, 9, 1),
             isCanceled=False,
             deletionDate=None,
-            isService=True, 
+            isService=True,
             isLaborOnly=True
         )
         event2 = Event.create(
@@ -42,7 +43,7 @@ def fixture_info():
             startDate=date(2023, 9, 10),
             isCanceled=False,
             deletionDate=None,
-            isService=True, 
+            isService=True,
             isLaborOnly=True
         )
         event3 = Event.create(
@@ -64,6 +65,10 @@ def fixture_info():
             isService=True
         )
 
+        labor1 = CeltsLabor.create(user=user1, term=term1, positionTitle="test position 1")
+        labor2 = CeltsLabor.create(user=user2, term=term1, positionTitle="test position 2")
+        labor3 = CeltsLabor.create(user=user1, term=term2, positionTitle="test position 3")
+        labor4 = CeltsLabor.create(user=user2, term=term2, positionTitle="test position 4")
 
         eventparticipant1 = EventParticipant.create(event=event1, user=user1, hoursEarned=5)
         eventparticipant2 = EventParticipant.create(event=event1, user=user2, hoursEarned=3)
@@ -88,6 +93,10 @@ def fixture_info():
             'eventparticipant1': eventparticipant1,
             'eventparticipant2': eventparticipant2,
             'eventparticipant4': eventparticipant4,
+            'labor1': labor1,
+            'labor2': labor2,
+            'labor3': labor3,
+            'labor4': labor4
         }
 
         transaction.rollback()
@@ -687,14 +696,44 @@ def test_getUniqueVolunteers(fixture_info):
 
 @pytest.mark.integration
 def test_laborAttendanceByTerm(fixture_info):
-    EventParticipant.create(event=fixture_info["event2"], user=fixture_info['user1'], hoursEarned=1)
-    EventParticipant.create(event=fixture_info["event2"], user=fixture_info['user2'], hoursEarned=1)
-    EventParticipant.create(event=fixture_info["event1"], user=fixture_info['user3'], hoursEarned=1)
+    columns, results = laborAttendanceByTerm(fixture_info['term1'])
+    results = list(results)
 
-    columns, results = laborAttendanceByTerm("2023-2024-test")
-    assert columns == ("Full Name", "B-Number", "Email", "Term", "Meetings Attended")
+    assert columns == ("Full Name", "B-Number", "Email", "Meetings Attended")
+
+    assert len(results) == 2
+    assert ("John Doe", "B774377", "doej@berea.edu", 1) in results
+    assert ("Jane Doe", "B888828", "doej2@berea.edu", 1) in results
+
+    columns, results = laborAttendanceByTerm(fixture_info['term2'])
+    results = list(results)
+
+    assert len(results) == 2
+    assert ("John Doe", "B774377", "doej@berea.edu", 0) in results
+    assert ("Jane Doe", "B888828", "doej2@berea.edu", 0) in results
+
+    EventParticipant.create(event=fixture_info['event2'], user=fixture_info['user1'], hoursEarned=1)
+
+    columns, results = laborAttendanceByTerm(fixture_info['term1'])
+    results = list(results)
+
+    assert len(results) == 2
+    assert ("John Doe", "B774377", "doej@berea.edu", 2) in results
+    assert ("Jane Doe", "B888828", "doej2@berea.edu", 1) in results
+
+    EventParticipant.create(event=fixture_info['event1'], user=fixture_info['user3'], hoursEarned=1)
+
+    columns, results = laborAttendanceByTerm(fixture_info['term1'])
+    results = list(results)
 
     assert len(results) == 3
-    assert ("John Doe", "B774377", "doej@berea.edu", "Fall 2023", 2) in results
-    assert ("Jane Doe", "B888828", "doej2@berea.edu", "Fall 2023", 2) in results
-    assert ("Bob Builder", "B00700932", "builderb@berea.edu", "Fall 2023", 1) in results
+    assert ("John Doe", "B774377", "doej@berea.edu", 2) in results
+    assert ("Jane Doe", "B888828", "doej2@berea.edu", 1) in results
+    assert ("Bob Builder", "B00700932", "builderb@berea.edu", 1) in results
+
+    EventParticipant.create(event=fixture_info['event3'], user=fixture_info['user1'], hoursEarned=2)
+
+    columns, results = laborAttendanceByTerm(fixture_info['term1'])
+    results = list(results)
+
+    assert ("John Doe", "B774377", "doej@berea.edu", 2) in results

--- a/tests/code/test_spreadsheet.py
+++ b/tests/code/test_spreadsheet.py
@@ -32,7 +32,8 @@ def fixture_info():
             startDate=date(2023, 9, 1),
             isCanceled=False,
             deletionDate=None,
-            isService=True
+            isService=True, 
+            isLaborOnly=True
         )
         event2 = Event.create(
             name='Event2',
@@ -41,7 +42,8 @@ def fixture_info():
             startDate=date(2023, 9, 10),
             isCanceled=False,
             deletionDate=None,
-            isService=True
+            isService=True, 
+            isLaborOnly=True
         )
         event3 = Event.create(
             name='Event3',
@@ -685,40 +687,13 @@ def test_getUniqueVolunteers(fixture_info):
 
 @pytest.mark.integration
 def test_laborAttendanceByTerm(fixture_info):
-    # No labor events yet so should return empty results
-    columns, results = laborAttendanceByTerm("2023-2024-test")
-    assert columns == ("Full Name", "B-Number", "Email", "Term", "Meetings Attended")
-    assert results == []
-
-    # Create a labor-only program and events
-    laborProgram = Program.create(programName='Labor')
-    laborEvent1 = Event.create(
-        name='Labor Meeting 1',
-        term=fixture_info['term1'],
-        program=laborProgram,
-        startDate=date(2023, 9, 5),
-        isCanceled=False,
-        deletionDate=None,
-        isLaborOnly=True,
-    )
-    laborEvent2 = Event.create(
-        name='Labor Meeting 2',
-        term=fixture_info['term1'],
-        program=laborProgram,
-        startDate=date(2023, 9, 12),
-        isCanceled=False,
-        deletionDate=None,
-        isLaborOnly=True,
-    )
-
-    EventParticipant.create(event=laborEvent1, user=fixture_info['user1'], hoursEarned=1)
-    EventParticipant.create(event=laborEvent2, user=fixture_info['user1'], hoursEarned=1)
-    EventParticipant.create(event=laborEvent1, user=fixture_info['user2'], hoursEarned=1)
+    EventParticipant.create(event=fixture_info["event1"], user=fixture_info['user1'], hoursEarned=1)
+    EventParticipant.create(event=fixture_info["event2"], user=fixture_info['user1'], hoursEarned=1)
+    EventParticipant.create(event=fixture_info["event1"], user=fixture_info['user2'], hoursEarned=1)
 
     columns, results = laborAttendanceByTerm("2023-2024-test")
     assert columns == ("Full Name", "B-Number", "Email", "Term", "Meetings Attended")
 
-    # user1 (Doe, John) attended 2 meetings, user2 (Doe, Jane) attended 1
     assert len(results) == 2
-    assert ("John Doe", "B774377", "doej@berea.edu", "Fall 2023", 2) in results
-    assert ("Jane Doe", "B888828", "doej2@berea.edu", "Fall 2023", 1) in results
+    assert ("John Doe", "B774377", "doej@berea.edu", "Fall 2023", 3) in results
+    assert ("Jane Doe", "B888828", "doej2@berea.edu", "Fall 2023", 2) in results

--- a/tests/code/test_spreadsheet.py
+++ b/tests/code/test_spreadsheet.py
@@ -687,13 +687,14 @@ def test_getUniqueVolunteers(fixture_info):
 
 @pytest.mark.integration
 def test_laborAttendanceByTerm(fixture_info):
-    EventParticipant.create(event=fixture_info["event1"], user=fixture_info['user1'], hoursEarned=1)
     EventParticipant.create(event=fixture_info["event2"], user=fixture_info['user1'], hoursEarned=1)
-    EventParticipant.create(event=fixture_info["event1"], user=fixture_info['user2'], hoursEarned=1)
+    EventParticipant.create(event=fixture_info["event2"], user=fixture_info['user2'], hoursEarned=1)
+    EventParticipant.create(event=fixture_info["event1"], user=fixture_info['user3'], hoursEarned=1)
 
     columns, results = laborAttendanceByTerm("2023-2024-test")
     assert columns == ("Full Name", "B-Number", "Email", "Term", "Meetings Attended")
 
-    assert len(results) == 2
-    assert ("John Doe", "B774377", "doej@berea.edu", "Fall 2023", 3) in results
+    assert len(results) == 3
+    assert ("John Doe", "B774377", "doej@berea.edu", "Fall 2023", 2) in results
     assert ("Jane Doe", "B888828", "doej2@berea.edu", "Fall 2023", 2) in results
+    assert ("Bob Builder", "B00700932", "builderb@berea.edu", "Fall 2023", 1) in results

--- a/tests/code/test_spreadsheet.py
+++ b/tests/code/test_spreadsheet.py
@@ -699,7 +699,7 @@ def test_laborAttendanceByTerm(fixture_info):
     columns, results = laborAttendanceByTerm(fixture_info['term1'])
     results = list(results)
 
-    assert columns == ("Full Name", "B-Number", "Email", "Meetings Attended")
+    assert columns == ["Full Name", "B-Number", "Email", "Meetings Attended"]
 
     assert len(results) == 2
     assert ("John Doe", "B774377", "doej@berea.edu", 1) in results


### PR DESCRIPTION
## Issue Description

Fixes #1626
- We should have a sheet in the Reports downloads that shows labor attendance for the academic year. The report should have a list of labor students and the number of labor meetings that they attended for each term in the academic year.

## Changes

- Implemented `laborAttendanceByTerm(term)` function to query labor students and count their meeting attendance by term
- Added "Labor Attendance By Term". There are two sheets: one for Fall term and one for Spring term (for the academic year)
- added the test function `test_laborAttendanceByTerm` in `test_spreadsheet.py `
 
This is how the spreadsheet looks like: 
<img width="1047" height="802" alt="image" src="https://github.com/user-attachments/assets/2144390c-c8d6-4986-96a7-0a2e82ad25e4" />


## Testing

- run `database/reset_database.sh test` and then `tests/run_tests.sh` or if you want to test the laborAttendanceByTerm function specifically, you can run `pytest tests/code/test_spreadsheet.py::test_laborAttendanceByTerm -v`
- after it passed, run `database/reset_database.sh from-backup` and then `flask run`
- Once you are in the Celts app, go to event list choose Fall 2024, and then choose a couple of events there, such as these events
<img width="1532" height="652" alt="image" src="https://github.com/user-attachments/assets/8f9ee676-2488-4c7d-8a36-c8e104a0924f" />

- And for each, click on the event,  turn on the toggle "This event is for labor only" , and then click "save"
<img width="1521" height="937" alt="image" src="https://github.com/user-attachments/assets/e4dd1d8e-103b-40a4-9296-58248110b0e5" />

- And then do the same for Spring 2025. 

- Then go to admin --> report --> select academic year 2024 - 2025 --> download the spreadsheet, open it, and you should see a sheet called "Labor Attendance By Term" with the reporting, one for Fall and one for Spring term. 

 