### PR TITLE
Removed labor meetings from participation history

### DIFF
--- a/app/logic/events.py
+++ b/app/logic/events.py
@@ -380,7 +380,7 @@ def getParticipatedEventsForUser(user):
                                .join(Program, JOIN.LEFT_OUTER).switch()
                                .join(EventParticipant)
                                .where(EventParticipant.user == user,
-                                      Event.isAllVolunteerTraining == False, Event.deletionDate == None, checkIfLaborMeeting)
+                                      Event.isAllVolunteerTraining == False, Event.deletionDate == None, ~checkIfLaborMeeting)
                                .order_by(Event.startDate, Event.name))
 
     allVolunteer = (Event.select(Event, "")

--- a/app/logic/events.py
+++ b/app/logic/events.py
@@ -364,6 +364,16 @@ def getUpcomingEventsForUser(user, asOf=datetime.now(), program=None):
 
     return eventsList
 
+def excludeLaborMeeting():
+    eventName = fn.LOWER(Event.name)
+    eventDescription = fn.LOWER(Event.description)
+
+    return (
+        eventName.contains("labor meeting") |
+        eventName.contains("celts labor meeting") |
+        eventDescription.contains("labor meeting")
+    )
+
 def getParticipatedEventsForUser(user):
     """
         Get all the events a user has participated in.
@@ -373,17 +383,18 @@ def getParticipatedEventsForUser(user):
         :return: A list of Event objects
     """
 
+    excLaborMeeting = excludeLaborMeeting()
     participatedEvents = (Event.select(Event, Program.programName)
                                .join(Program, JOIN.LEFT_OUTER).switch()
                                .join(EventParticipant)
                                .where(EventParticipant.user == user,
-                                      Event.isAllVolunteerTraining == False, Event.deletionDate == None)
+                                      Event.isAllVolunteerTraining == False, Event.deletionDate == None, ~((Event.isLaborOnly == True) & excLaborMeeting), ~((Event.isTraining == True) & excLaborMeeting))
                                .order_by(Event.startDate, Event.name))
 
     allVolunteer = (Event.select(Event, "")
                          .join(EventParticipant)
                          .where(Event.isAllVolunteerTraining == True,
-                                EventParticipant.user == user))
+                                EventParticipant.user == user, ~((Event.isLaborOnly == True) & excLaborMeeting), ~((Event.isTraining == True) & excLaborMeeting)))
     union = participatedEvents.union_all(allVolunteer)
     unionParticipationWithVolunteer = list(union.select_from(union.c.id, union.c.programName, union.c.startDate, union.c.name).order_by(union.c.startDate, union.c.name).execute())
 

--- a/app/logic/events.py
+++ b/app/logic/events.py
@@ -364,16 +364,6 @@ def getUpcomingEventsForUser(user, asOf=datetime.now(), program=None):
 
     return eventsList
 
-def excludeLaborMeeting():
-    eventName = fn.LOWER(Event.name)
-    eventDescription = fn.LOWER(Event.description)
-
-    return (
-        eventName.contains("labor meeting") |
-        eventName.contains("celts labor meeting") |
-        eventDescription.contains("labor meeting")
-    )
-
 def getParticipatedEventsForUser(user):
     """
         Get all the events a user has participated in.
@@ -383,18 +373,20 @@ def getParticipatedEventsForUser(user):
         :return: A list of Event objects
     """
 
-    excLaborMeeting = excludeLaborMeeting()
+    eventName = fn.LOWER(Event.name)
+    checkIfLaborMeeting = eventName.contains("labor meeting")
+
     participatedEvents = (Event.select(Event, Program.programName)
                                .join(Program, JOIN.LEFT_OUTER).switch()
                                .join(EventParticipant)
                                .where(EventParticipant.user == user,
-                                      Event.isAllVolunteerTraining == False, Event.deletionDate == None, ~((Event.isLaborOnly == True) & excLaborMeeting), ~((Event.isTraining == True) & excLaborMeeting))
+                                      Event.isAllVolunteerTraining == False, Event.deletionDate == None, checkIfLaborMeeting)
                                .order_by(Event.startDate, Event.name))
 
     allVolunteer = (Event.select(Event, "")
                          .join(EventParticipant)
                          .where(Event.isAllVolunteerTraining == True,
-                                EventParticipant.user == user, ~((Event.isLaborOnly == True) & excLaborMeeting), ~((Event.isTraining == True) & excLaborMeeting)))
+                                EventParticipant.user == user))
     union = participatedEvents.union_all(allVolunteer)
     unionParticipationWithVolunteer = list(union.select_from(union.c.id, union.c.programName, union.c.startDate, union.c.name).order_by(union.c.startDate, union.c.name).execute())
 

--- a/app/logic/volunteerSpreadsheet.py
+++ b/app/logic/volunteerSpreadsheet.py
@@ -225,57 +225,6 @@ def calculateRetentionRate(fallDict, springDict):
 
     return retentionDict
 
-def getLaborMeetingAttendance(academicYear, toDateOnly=True):
-    """
-    This sheet tracks labor students attendance of labor meetings during academic year
-    """
-    columns = [
-        "Student First Name",
-        "Student Last Name",
-        "Student Email",
-        "Student B-Number",
-        "Program Name",
-        "Event Name",
-        "Term",
-        "Event Date",
-    ]
-
-    laborMeeting = (
-        fn.LOWER(Event.name).contains("labor meeting") |
-        fn.LOWER(fn.COALESCE(Event.description, "")).contains("labor meeting")
-    )
-
-    query = (EventParticipant
-             .select(
-                 User.firstName,
-                 User.lastName,
-                 fn.CONCAT(User.username, '@berea.edu').alias("email"),
-                 User.bnumber,
-                 Program.programName,
-                 Event.name,
-                 Term.description.alias("termDesc"),
-                 Event.startDate,
-             )
-             .join(User)
-             .switch(EventParticipant)
-             .join(Event)
-             .join(Program, JOIN.LEFT_OUTER)
-             .switch(Event)
-             .join(Term)
-             .where(
-                 Term.academicYear == academicYear,
-                 Event.deletionDate == None,
-                 Event.isCanceled == False,
-                 Event.isLaborOnly == True,
-                 laborMeeting,
-             )
-             .order_by(Term.termOrder, Event.startDate, Event.name, User.lastName, User.firstName))
-
-    if toDateOnly:
-        query = query.where(Event.startDate <= date.today())
-
-    return (columns, query.tuples())
-
 def makeDataXls(sheetName, sheetData, workbook, sheetDesc=None):
     # assumes the length of the column titles matches the length of the data
     (columnTitles, dataTuples) = sheetData
@@ -321,7 +270,6 @@ def createSpreadsheet(academicYear):
     makeDataXls("Unique Volunteers", getUniqueVolunteers(academicYear), workbook, sheetDesc=f"All students who participated in at least one service event during {academicYear}.")
     makeDataXls("Only All Volunteer Training", onlyCompletedAllVolunteer(academicYear), workbook, sheetDesc="Students who participated in an All Volunteer Training, but did not participate in any service events.")
     makeDataXls("Retention Rate By Semester", getRetentionRate(academicYear), workbook, sheetDesc="The percentage of students who participated in service events in the fall semester who also participated in a service event in the spring semester. Does not currently account for fall graduations.")
-    makeDataXls("Labor Meetings", getLaborMeetingAttendance(academicYear, toDateOnly=True), workbook, sheetDesc=f"Attendees for labor meetings during {academicYear}.")
 
     fallTerm = getFallTerm(academicYear)
     springTerm = getSpringTerm(academicYear)

--- a/app/logic/volunteerSpreadsheet.py
+++ b/app/logic/volunteerSpreadsheet.py
@@ -225,6 +225,56 @@ def calculateRetentionRate(fallDict, springDict):
 
     return retentionDict
 
+def getLaborMeetingAttendance(academicYear, toDateOnly=True):
+    """
+    This sheet tracks labor students attendance of labor meetings during academic year
+    """
+    columns = [
+        "Student First Name",
+        "Student Last Name",
+        "Student Email",
+        "Student B-Number",
+        "Program Name",
+        "Event Name",
+        "Term",
+        "Event Date",
+    ]
+
+    laborMeeting = (
+        fn.LOWER(Event.name).contains("labor meeting") |
+        fn.LOWER(fn.COALESCE(Event.description, "")).contains("labor meeting")
+    )
+
+    query = (EventParticipant
+             .select(
+                 User.firstName,
+                 User.lastName,
+                 fn.CONCAT(User.username, '@berea.edu').alias("email"),
+                 User.bnumber,
+                 Program.programName,
+                 Event.name,
+                 Term.description.alias("termDesc"),
+                 Event.startDate,
+             )
+             .join(User)
+             .switch(EventParticipant)
+             .join(Event)
+             .join(Program, JOIN.LEFT_OUTER)
+             .switch(Event)
+             .join(Term)
+             .where(
+                 Term.academicYear == academicYear,
+                 Event.deletionDate == None,
+                 Event.isCanceled == False,
+                 Event.isLaborOnly == True,
+                 laborMeeting,
+             )
+             .order_by(Term.termOrder, Event.startDate, Event.name, User.lastName, User.firstName))
+
+    if toDateOnly:
+        query = query.where(Event.startDate <= date.today())
+
+    return (columns, query.tuples())
 
 def makeDataXls(sheetName, sheetData, workbook, sheetDesc=None):
     # assumes the length of the column titles matches the length of the data
@@ -271,6 +321,7 @@ def createSpreadsheet(academicYear):
     makeDataXls("Unique Volunteers", getUniqueVolunteers(academicYear), workbook, sheetDesc=f"All students who participated in at least one service event during {academicYear}.")
     makeDataXls("Only All Volunteer Training", onlyCompletedAllVolunteer(academicYear), workbook, sheetDesc="Students who participated in an All Volunteer Training, but did not participate in any service events.")
     makeDataXls("Retention Rate By Semester", getRetentionRate(academicYear), workbook, sheetDesc="The percentage of students who participated in service events in the fall semester who also participated in a service event in the spring semester. Does not currently account for fall graduations.")
+    makeDataXls("Labor Meetings", getLaborMeetingAttendance(academicYear, toDateOnly=True), workbook, sheetDesc=f"Attendees for labor meetings during {academicYear}.")
 
     fallTerm = getFallTerm(academicYear)
     springTerm = getSpringTerm(academicYear)


### PR DESCRIPTION
Fixes #1683 

There was a request to remove labor meeting events from the Participation history. And also, those labor meetings should be tracked in reports for each academic year per each term. The problem with removing it from participation history was inconsistency in naming of labor meetings and also filtering: sometimes they are named "CELTS labor meeting" or "Labor meeting(date)", so it was confusing to remove Labor only events as there are trainings that are also filtered the exact same way.

## Changes

- Added a new function to exclude anything labeled labor meeting
- Got rid of labor meetings from participation history, while preserving trainings

## Testing

- Go to the user profile from backup data, such as Kai Craig
- Go to participation history
- Check if there are no labor meetings
- Download the report for AY 2025-2026, and find the column Labor Meetings
- Check their name, Kai Craig, as an attendee (confirming that there is data with labor meetings under their name)