### PR TITLE
Make Start Date appear

### DIFF
--- a/app/logic/events.py
+++ b/app/logic/events.py
@@ -120,7 +120,7 @@ def attemptSaveMultipleOfferings(eventData, attachmentFiles = None):
 
     # Create separate event data for each event in the series, inheriting from the original eventData
 
-    seriesData = sorted(eventData.get('seriesData'), key=lambda x: datetime.strptime(f"{x['eventDate']} {x['startTime']}",'%m/%d/%Y %H:%M'))
+    seriesData = sorted(eventData.get('seriesData'), key=lambda x: datetime.strptime(f"{x['eventDate']} {x['startTime']}",'%m/%d/%Y %H:%M')) # sorts the events in the series by date and time so that the events are created in order and the naming convention of Week 1, Week 2, etc. is consistent with the order of the events.
     isRepeating = bool(eventData.get('isRepeating'))
     with mainDB.atomic() as transaction:
         for index, event in enumerate(seriesData):

--- a/app/logic/events.py
+++ b/app/logic/events.py
@@ -120,7 +120,7 @@ def attemptSaveMultipleOfferings(eventData, attachmentFiles = None):
 
     # Create separate event data for each event in the series, inheriting from the original eventData
 
-    seriesData = sorted(eventData.get('seriesData'), key=lambda x: datetime.strptime(f"{x['eventDate']} {x['startTime']}",'%Y-%m-%d %H:%M'))
+    seriesData = sorted(eventData.get('seriesData'), key=lambda x: datetime.strptime(f"{x['eventDate']} {x['startTime']}",'%m/%d/%Y %H:%M'))
     isRepeating = bool(eventData.get('isRepeating'))
     with mainDB.atomic() as transaction:
         for index, event in enumerate(seriesData):

--- a/app/logic/events.py
+++ b/app/logic/events.py
@@ -119,7 +119,6 @@ def attemptSaveMultipleOfferings(eventData, attachmentFiles = None):
     seriesId = calculateNewSeriesId()
 
     # Create separate event data for each event in the series, inheriting from the original eventData
-    print("seriesData received:", eventData.get('seriesData'))
     seriesData = sorted(eventData.get('seriesData'), key=lambda x: datetime.strptime(x['eventDate'].split(' ')[0] + ' ' + x['startTime'], '%Y-%m-%d %H:%M'))
  # sorts the events in the series by date and time so that the events are created in order and the naming convention of Week 1, Week 2, etc. is consistent with the order of the events.
     isRepeating = bool(eventData.get('isRepeating'))

--- a/app/logic/events.py
+++ b/app/logic/events.py
@@ -119,8 +119,9 @@ def attemptSaveMultipleOfferings(eventData, attachmentFiles = None):
     seriesId = calculateNewSeriesId()
 
     # Create separate event data for each event in the series, inheriting from the original eventData
-
-    seriesData = sorted(eventData.get('seriesData'), key=lambda x: datetime.strptime(f"{x['eventDate']} {x['startTime']}",'%m/%d/%Y %H:%M')) # sorts the events in the series by date and time so that the events are created in order and the naming convention of Week 1, Week 2, etc. is consistent with the order of the events.
+    print("seriesData received:", eventData.get('seriesData'))
+    seriesData = sorted(eventData.get('seriesData'), key=lambda x: datetime.strptime(x['eventDate'].split(' ')[0] + ' ' + x['startTime'], '%Y-%m-%d %H:%M'))
+ # sorts the events in the series by date and time so that the events are created in order and the naming convention of Week 1, Week 2, etc. is consistent with the order of the events.
     isRepeating = bool(eventData.get('isRepeating'))
     with mainDB.atomic() as transaction:
         for index, event in enumerate(seriesData):

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -753,8 +753,10 @@ $("#cancelEvent").on('click', function (event) {
   $(".addMultipleOfferingEvent").click(function () {
     // Get the current value from the main location input
     let mainLocation = $("#inputEventLocation-main").val();
-    createOfferingModalRow({ eventLocation: mainLocation });
-  });
+    let existingRows = $("#multipleOfferingSlots .eventOffering").length;
+    let mainDate = existingRows === 0 ? $("#startDatePicker-mainOnly").val() : null;
+    createOfferingModalRow({ eventLocation: mainLocation, eventDate: mainDate });
+});
 
   var minDate = new Date('10/25/1999')
   $("#startDatePicker-main").datepicker("option", "minDate", minDate)

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -755,7 +755,9 @@ $("#cancelEvent").on('click', function (event) {
     let mainLocation = $("#inputEventLocation-main").val();
     let existingRows = $("#multipleOfferingSlots .eventOffering").length;
     let mainDate = existingRows === 0 ? $("#startDatePicker-mainOnly").val() : null;
-    createOfferingModalRow({ eventLocation: mainLocation, eventDate: mainDate });
+    let mainTime = $("#startTime-main").val();
+    let endTime = $("#endTime-main").val();
+    createOfferingModalRow({ eventLocation: mainLocation, eventDate: mainDate, startTime: mainTime, endTime: endTime });
 });
 
   var minDate = new Date('10/25/1999')

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -687,6 +687,8 @@ $("#cancelEvent").on('click', function (event) {
       $("#repeatingEventsNamePicker").val($("#inputEventName").val());
       $("#repeatingEventsLocationPicker").val($("#inputEventLocation-main").val());
       $("#repeatingEventsStartDate").val($("#startDatePicker-mainOnly").val());
+      $("#repeatingEventsStartTime").val($("#startTime-main").val());
+      $("#repeatingEventsEndTime").val($("#endTime-main").val());
       $('.addMultipleOfferingEvent').hide();
       $("#repeatingEventsDiv").removeClass('d-none');
       $("#multipleOfferingSlots").children().remove();
@@ -879,8 +881,3 @@ $("#cancelEvent").on('click', function (event) {
 
   setCharacterLimit($("#inputCharacters"), "#remainingCharacters"); 
   });
-
-
-
-
-

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -405,8 +405,7 @@ function loadOfferingsToModal() {
 
 function loadRepeatingOfferingToModal(offering){
   var seriesTable = $("#generatedEventsTable");
-  var eventDate = new Date(offering.date || offering.eventDate).toLocaleDateString();
-  
+  var eventDate = offering.date || offering.eventDate;  
 
   seriesTable.append(
     "<tr class='eventOffering'>" +
@@ -751,7 +750,7 @@ $("#cancelEvent").on('click', function (event) {
   /*cloning the div with ID multipleOfferingEvent and cloning, changing the ID of each clone going up by 1. This also changes 
   the ID of the deleteMultipleOffering so that when the trash icon is clicked, that specific row will be deleted*/
   $(".addMultipleOfferingEvent").click(function () {
-    // Get the current value from the main location input
+    // Get the current value from the main location input and the date input
     let mainLocation = $("#inputEventLocation-main").val();
     let existingRows = $("#multipleOfferingSlots .eventOffering").length;
     let mainDate = existingRows === 0 ? $("#startDatePicker-mainOnly").val() : null;

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -686,6 +686,7 @@ $("#cancelEvent").on('click', function (event) {
     if ($(this).is(':checked')) {
       $("#repeatingEventsNamePicker").val($("#inputEventName").val());
       $("#repeatingEventsLocationPicker").val($("#inputEventLocation-main").val());
+      $("#repeatingEventsStartDate").val($("#startDatePicker-mainOnly").val());
       $('.addMultipleOfferingEvent').hide();
       $("#repeatingEventsDiv").removeClass('d-none');
       $("#multipleOfferingSlots").children().remove();

--- a/app/static/js/createEvents.js
+++ b/app/static/js/createEvents.js
@@ -405,7 +405,7 @@ function loadOfferingsToModal() {
 
 function loadRepeatingOfferingToModal(offering){
   var seriesTable = $("#generatedEventsTable");
-  var eventDate = offering.date || offering.eventDate;  
+  var eventDate = formatDate(offering.date || offering.eventDate);  
 
   seriesTable.append(
     "<tr class='eventOffering'>" +

--- a/tests/code/test_bonner.py
+++ b/tests/code/test_bonner.py
@@ -113,7 +113,7 @@ def test_addBonnerCohortToRsvpLog():
             BonnerCohort.create(user="neillz", year=currentYear)
             BonnerCohort.create(user="khatts", year=currentYear)
                
-            testDate = datetime.strptime("2025-01-19 05:00","%Y-%m-%d %H:%M")
+            testDate = datetime.strptime("01/19/2025 05:00","%m/%d/%Y %H:%M")
             
             # Create a test event associated with a Bonner Scholars program
             programEvent = Program.create(id = 15,

--- a/tests/code/test_event_list.py
+++ b/tests/code/test_event_list.py
@@ -77,7 +77,7 @@ def test_getVolunteerOpportunities(training_events):
 @pytest.mark.integration
 def test_getUpcomingVolunteerOpportunitiesCount():
     with mainDB.atomic() as transaction: 
-        testDate = datetime.strptime("2021-08-01 05:00","%Y-%m-%d %H:%M")
+        testDate = datetime.strptime("08/01/2021 05:00","%m/%d/%Y %H:%M")
         currentTestTerm = Term.get_by_id(5)
 
         # In case any events are put in term 5 in testData, put them into the past.

--- a/tests/code/test_events.py
+++ b/tests/code/test_events.py
@@ -772,7 +772,7 @@ def test_deleteEvent():
 @pytest.mark.integration
 def test_upcomingEvents():
     with mainDB.atomic() as transaction:
-        testDate = datetime.strptime("2021-08-01 05:00","%Y-%m-%d %H:%M")
+        testDate = datetime.strptime("08/01/2021 05:00","%m/%d/%Y %H:%M")
         dayBeforeTestDate = testDate - timedelta(days=1)
 
         # Create a user to run the tests with
@@ -1329,7 +1329,7 @@ def test_inviteCohortsToEvent():
         with app.app_context():
             g.current_user = "heggens"
             
-            testDate = datetime.strptime("2025-08-01 05:00","%Y-%m-%d %H:%M")
+            testDate = datetime.strptime("08/01/2025 05:00","%m/%d/%Y %H:%M")
             programEvent = Program.create(id = 13,
                                         programName = "Bonner Scholars",
                                         isBonnerScholars = True,
@@ -1362,7 +1362,7 @@ def test_updateEventCohorts():
         with app.app_context():
             g.current_user = "heggens"
             
-            testDate = datetime.strptime("2025-10-01 05:00","%Y-%m-%d %H:%M")
+            testDate = datetime.strptime("10/01/2025 05:00","%m/%d/%Y %H:%M")
             programEvent = Program.create(id = 13,
                                           programName = "Bonner Scholars",
                                           isBonnerScholars = True,


### PR DESCRIPTION
## Issue Description

Fixes #1594 
- When doing the usability study, in reference to task " Create an Event that Repeats Three Weeks in a Series", participants often faced a problem in which the start date created on the main page (after picking an Event type within "Create Event"), when they turned on the toggle ("This is a series of Events") the start date would disappear and didnt transfer to the series. The start date selected outside of the modal should transfer into the modal and should still be editable.

## Changes

- Only js file, made it so that the event is carried into the box, same as the name and location.
- Carried the date into the occurrence events 
- Carried the time too

## Testing

- Go to create an event 
- Select the program 
- Fill out name, location, and date 
- Click that it is a series of events 
- toggle the weekly repetition 
- You should see the name you previously inputted appear as the start date. 