### PR TITLE
1597 edit event btn

### DIFF
--- a/app/templates/events/eventList.html
+++ b/app/templates/events/eventList.html
@@ -113,7 +113,7 @@
             {% endif %}
             {% if user.isCeltsAdmin or user.isProgramManagerFor(event.program)%}
               {% set link_class = 'link-secondary' if event.isPastStart else 'link-primary' %}
-                <td><a href="/event/{{event.id}}/edit" class="{{link_class}}">{{event.name}}</a></td>
+                <td><a href="/event/{{event.id}}/view" class="{{link_class}}">{{event.name}}</a></td>
             {% else %}
               <td><a href="/event/{{event.id}}/view" class="link-primary">{{event.name}}</a></td>
             {% endif %}
@@ -141,12 +141,14 @@
                 <button class="btn {{btn_class}}" onclick="showEmailModal({{event.id}}, 'Unknown', {{ selectedTerm }}, {{ isPastStart }}, '{{defaultTemplate}}')">
                   <span class="bi bi-envelope-fill"> {{btn_text}}</span>
                 </button>
-                
-                <a class="btn btn-primary ms-2"href="/event/{{ event.id }}/edit"><span class="bi bi-pencil-fill"></span> Edit Event </a>
-              </td>
-              
+                <a class="btn {{btn_class}} ms-2" href="/event/{{ event.id }}/view"><span class="bi bi-pencil-fill"></span> Edit Event</a>
+              </td>  
             {% else %}
               <td>
+              {% if user.isProgramManagerFor(event.program) %}
+                {% set btn_class = 'btn-secondary' if event.isPastStart or event.isCanceled else 'btn-primary' %}
+                <a class="btn {{btn_class}}" href="/event/{{ event.id }}/view"><span class="bi bi-pencil-fill"></span> Edit Event</a>
+              {% endif %}
               {% if event.id in rsvpedEventsID %}
                 <button type="button" class="btn btn-danger" onclick="removeRsvpForEvent({{event.id}})">Remove RSVP</button>
               {% elif (not event.isPastStart) and (event.isRsvpRequired) and (not event.isCanceled) %}

--- a/app/templates/events/eventList.html
+++ b/app/templates/events/eventList.html
@@ -129,7 +129,7 @@
                 <td class="text-dark">{{event.location}}</td>
               {% endif %}
             {% if user.isCeltsAdmin or user.isProgramManagerFor(event.program)%}
-              <td td style="white-space: nowrap;">
+              <td style="white-space: nowrap;">
                 {% if event.isPastStart %}
                   {% set isPastStart = "true" %}
                 {% else %}

--- a/app/templates/events/eventList.html
+++ b/app/templates/events/eventList.html
@@ -128,8 +128,8 @@
                 <td nowrap>{{event.timeStart.strftime('%-I:%M %p')}} - {{event.timeEnd.strftime('%-I:%M %p')}}</td>
                 <td class="text-dark">{{event.location}}</td>
               {% endif %}
-            {% if user.isAdmin %}
-              <td>
+            {% if user.isCeltsAdmin or user.isProgramManagerFor(event.program)%}
+              <td td style="white-space: nowrap;">
                 {% if event.isPastStart %}
                   {% set isPastStart = "true" %}
                 {% else %}
@@ -141,13 +141,13 @@
                 <button class="btn {{btn_class}}" onclick="showEmailModal({{event.id}}, 'Unknown', {{ selectedTerm }}, {{ isPastStart }}, '{{defaultTemplate}}')">
                   <span class="bi bi-envelope-fill"> {{btn_text}}</span>
                 </button>
-                <a class="btn {{btn_class}} ms-2" href="/event/{{ event.id }}/view"><span class="bi bi-pencil-fill"></span> Edit Event</a>
+                <a class="btn {{btn_class}} ms-2" href="/event/{{ event.id }}/edit"><span class="bi bi-pencil-fill"></span> Edit Event</a>
               </td>  
             {% else %}
               <td>
               {% if user.isProgramManagerFor(event.program) %}
                 {% set btn_class = 'btn-secondary' if event.isPastStart or event.isCanceled else 'btn-primary' %}
-                <a class="btn {{btn_class}}" href="/event/{{ event.id }}/view"><span class="bi bi-pencil-fill"></span> Edit Event</a>
+                <a class="btn {{btn_class}}" href="/event/{{ event.id }}/edit"><span class="bi bi-pencil-fill"></span> Edit Event</a>
               {% endif %}
               {% if event.id in rsvpedEventsID %}
                 <button type="button" class="btn btn-danger" onclick="removeRsvpForEvent({{event.id}})">Remove RSVP</button>


### PR DESCRIPTION
## Update events edit button functionality 

Fixes #1597 
- During the usability study, participants had a hard time figuring out how to edit the events they had created. They would often try to go back to "create events" to figure out how to edit it because they didn't recognize the event name link as a path to editing the event in "Events List". To accommodate this, an edit event button should be added next to the invite button so they can reach the editing/customizing event information page.
## Changes

- Added an Edit button next to the invite button.
- Added user's conditions which were missing from the previous PR.
- Change the URL to the right location which is Edit button.
- The admin can view and edit button for every event; other users can only view and edit the edit button for their specific events. 






## Testing

- As admin, go to events list page, create an event if there is not any, should be able to see the current events available with both invite and edit event button.
<img width="1904" height="776" alt="image" src="https://github.com/user-attachments/assets/095dcafd-d5b8-4222-9256-d40399318017" />


- Other users, navigate to the event list page, create an event, should be able to see the events and edit button available for Program managers, otherwise, it will only show the event. 
<img width="1809" height="830" alt="image" src="https://github.com/user-attachments/assets/4f7e0490-b38e-4402-9238-e0c75a19952a" />

