### PR TITLE
Transcript

### DIFF
--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -546,9 +546,11 @@ def serviceTranscript(username):
     slCourses = getSlCourseTranscript(username)
     totalHours = getTotalHours(username)
     allEventTranscript = getProgramTranscript(username)
+    zeroHourEvents = getZeroHourEvents(username)
     startDate = getStartYear(username)
     return render_template('main/serviceTranscript.html',
                             allEventTranscript = allEventTranscript,
+                            zeroHourEvents = zeroHourEvents,
                             slCourses = slCourses.objects(),
                             totalHours = totalHours,
                             startDate = startDate,

--- a/app/logic/transcript.py
+++ b/app/logic/transcript.py
@@ -42,6 +42,24 @@ def getProgramTranscript(username):
             
     return dict(transcriptData)
 
+def getZeroHourEvents(username):
+    """
+    Returns a list of events with zero hours earned for the given user,
+    excluding deleted and canceled events.
+    """
+    zeroHourEvents = (Event.select(Event, Program, Term)
+                      .join(EventParticipant)
+                      .switch(Event)
+                      .join(Program)
+                      .switch(Event)
+                      .join(Term)
+                      .where(EventParticipant.user == username,
+                             EventParticipant.hoursEarned == 0,
+                             Event.deletionDate == None,
+                             Event.isCanceled == False))
+    
+    return list(zeroHourEvents)
+
 def getSlCourseTranscript(username):
     """
     Returns a SLCourse query object containing all the training events for

--- a/app/logic/transcript.py
+++ b/app/logic/transcript.py
@@ -56,7 +56,8 @@ def getZeroHourEvents(username):
                       .where(EventParticipant.user == username,
                              EventParticipant.hoursEarned == 0,
                              Event.deletionDate == None,
-                             Event.isCanceled == False))
+                             Event.isCanceled == False)
+                      .order_by(Event.term))
     
     return list(zeroHourEvents)
 

--- a/app/templates/main/serviceTranscript.html
+++ b/app/templates/main/serviceTranscript.html
@@ -109,6 +109,29 @@
             </div>
           {% endif %}
         {% endfor %}
+
+        {% if zeroHourEvents %}
+          {% set ns = namespace(filtered=[]) %}
+          {% for event in zeroHourEvents %}
+            {% if event.program.programName != "Bonner Scholars" %}
+              {% set _ = ns.filtered.append(event) %}
+            {% endif %}
+          {% endfor %}
+
+          {% if ns.filtered %}
+            <div class="mb-4 p-3" style="page-break-inside: avoid;">
+              <h6 class="fw-bold" style="color: #005c90">Events with No Hours Earned</h6>
+              {% for event in ns.filtered %}
+                <div class="mb-2">
+                  <small class="text-muted">
+                    {{ event.term.description }} — {{ event.name }} - 0 hour(s)
+                  </small>
+                </div>
+              {% endfor %}
+            </div>
+          {% endif %}
+        {% endif %}
+
       {% else %}
         <div class="text-center py-4">
           <h6 class="text-muted">No Volunteer Record</h6>

--- a/app/templates/main/serviceTranscript.html
+++ b/app/templates/main/serviceTranscript.html
@@ -124,7 +124,7 @@
               {% for event in ns.filtered %}
                 <div class="mb-2">
                   <small class="text-muted">
-                    {{ event.term.description }} — {{ event.name }} - 0 hour(s)
+                    {{ event.term.description }} — {{ event.name }} - 0 hour
                   </small>
                   {% if event.program.programName != "CELTS Sponsored Events" %}
                     <p class="text-muted small mb-2">{{ event.program.description }}</p>

--- a/app/templates/main/serviceTranscript.html
+++ b/app/templates/main/serviceTranscript.html
@@ -126,6 +126,10 @@
                   <small class="text-muted">
                     {{ event.term.description }} — {{ event.name }} - 0 hour(s)
                   </small>
+                  {% if event.program.programName != "CELTS Sponsored Events" %}
+                    <p class="text-muted small mb-2">{{ event.program.description }}</p>
+                    <a class="d-print-none small" href="{{ event.program.url }}" target="_blank">More Information</a>
+                  {% endif %}
                 </div>
               {% endfor %}
             </div>

--- a/tests/code/test_transcripts.py
+++ b/tests/code/test_transcripts.py
@@ -179,6 +179,39 @@ def testingProgram():
     assert not emptyProgramDict
 
 @pytest.mark.integration
+def testingZeroHourEvents():
+    username = "namet"
+    adminName = "ramsayb2"
+
+    with mainDB.atomic() as transaction:
+        zeroHourEvent = Event.create(name = "Test Zero Hour Event",
+                                     term = 1,
+                                     description = "Event for testing zero hours",
+                                     timeStart = "18:00:00",
+                                     timeEnd = "21:00:00",
+                                     location = "The testing lab",
+                                     isRsvpRequired = 0,
+                                     isPrerequisiteForProgram = 0,
+                                     isTraining = 0,
+                                     isService = 0,
+                                     startDate = "2021-12-12",
+                                     recurringId = None,
+                                     program = 9)
+
+        EventParticipant.create(user = username,
+                                event = zeroHourEvent,
+                                attended = True,
+                                hoursEarned = 0)
+
+        zeroHourEvents = getZeroHourEvents(username)
+        emptyZeroHourEvents = getZeroHourEvents(adminName)
+
+        assert emptyZeroHourEvents == []
+        assert zeroHourEvent in zeroHourEvents
+
+        transaction.rollback()
+
+@pytest.mark.integration
 def testingTotalHours():
 
     totalHours = getTotalHours("namet")


### PR DESCRIPTION
## Issue Description

Fixes #1538 
- When a volunteer is marked as attended for an event but earns 0 total hours, it should still display as an event they attended on their transcript that will display that they earned 0 hours.
-Once this feature is added, check the service transcript to not affect the total hours or service/event hours as it should not be affected by an event they attended but earned 0 hours.

## Changes

- Added a new function to get the attended events with no hours earned then added that to the front-end display

Before 

<img width="473" height="449" alt="image" src="https://github.com/user-attachments/assets/4b3d859d-49ba-45a4-b813-3e08923695a8" />

After

<img width="455" height="442" alt="image" src="https://github.com/user-attachments/assets/f886801e-9f38-4ded-9906-d832b344b9ec" />


## Testing

- Create a new past event 
- Add a student of your choice to that event 
- Go to the student's profile
- click on the service transcript button 