### PR TITLE
Participationtypes

### DIFF
--- a/app/logic/events.py
+++ b/app/logic/events.py
@@ -1,5 +1,5 @@
 from flask import  url_for, g, session
-from peewee import DoesNotExist, fn, JOIN
+from peewee import DoesNotExist, fn, JOIN, Case, Value
 from dateutil import parser
 from datetime import timedelta, date, datetime
 from dateutil.relativedelta import relativedelta
@@ -398,21 +398,21 @@ def getParticipatedEventsForUser(user):
                       Used in testing, defaults to the current timestamp.
         :return: A list of Event objects
     """
-
-    participatedEvents = (Event.select(Event, Program.programName)
+    participatedEvents = (Event.select(Event, Program.programName, Case(None, (
+                               ((Event.isLaborOnly | Event.name.contains("Labor")) & Event.isService, "Labor & Volunteer"),                                
+                               ((Event.isLaborOnly | Event.name.contains("Labor")), "Labor"),
+                               (Event.isService, "Volunteer")), "Attendee").alias("participatedType"))
                                .join(Program, JOIN.LEFT_OUTER).switch()
                                .join(EventParticipant)
                                .where(EventParticipant.user == user,
                                       Event.isAllVolunteerTraining == False, Event.deletionDate == None)
                                .order_by(Event.startDate, Event.name))
-
-    allVolunteer = (Event.select(Event, "")
+    allVolunteer = (Event.select(Event, "", Value("Volunteer").alias("participatedType"))
                          .join(EventParticipant)
                          .where(Event.isAllVolunteerTraining == True,
                                 EventParticipant.user == user))
     union = participatedEvents.union_all(allVolunteer)
-    unionParticipationWithVolunteer = list(union.select_from(union.c.id, union.c.programName, union.c.startDate, union.c.name).order_by(union.c.startDate, union.c.name).execute())
-
+    unionParticipationWithVolunteer = list(union.select_from(union.c.id, union.c.programName, union.c.startDate, union.c.name, union.c.participatedType).order_by(union.c.startDate, union.c.name).execute())
     return unionParticipationWithVolunteer
 
 def validateNewEventData(data):

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -167,12 +167,14 @@
               <thead>
                 <th scope="col">Program</th>
                 <th scope="col">Event Name</th>
+                <th scope="col">Participation Type</th>
                 <th scope="col">Event Date</th>
               </thead>
               {% for event in participatedEvents %}
               <tr>
                 <td>{{event.programName}}</td>
                 <td><a href= '/event/{{event.id}}/view' class="link-primary">{{event.name}}</a></td>
+                <td>{{event.participatedType}}</td>
                 <td nowrap>{{event.startDate.strftime('%m/%d/%Y')}}</td>
               </tr>
               {% endfor %}

--- a/tests/code/test_events.py
+++ b/tests/code/test_events.py
@@ -1024,7 +1024,7 @@ def test_calculateNewSeriesId():
     assert calculateNewSeriesId() == maxSeriesId
 
 @pytest.mark.integration
-def test_getParticipatedEventsForUser_participated_types():
+def test_getParticipatedEventsForUser_participatedTypes():
     with mainDB.atomic() as transaction:
         user = User.create(
             username='usrtst2',

--- a/tests/code/test_events.py
+++ b/tests/code/test_events.py
@@ -1024,6 +1024,85 @@ def test_calculateNewSeriesId():
     assert calculateNewSeriesId() == maxSeriesId
 
 @pytest.mark.integration
+def test_getParticipatedEventsForUser_participated_types():
+    with mainDB.atomic() as transaction:
+        user = User.create(
+            username='usrtst2',
+            firstName='Test',
+            lastName='User',
+            bnumber='03522493',
+            email='user2@berea.edu',
+            isStudent=True
+        )
+
+        program = Program.create(
+            id=14,
+            programName="BOO",
+            isBonnerScholars=False,
+            contactEmail="test@email",
+            contactName="testName"
+        )
+
+        laborEvent = Event.create(
+            name="Labor shift",
+            term=2,
+            description="Labor event",
+            timeStart="18:00:00",
+            timeEnd="21:00:00",
+            location="The moon",
+            startDate="2021-12-12",
+            isAllVolunteerTraining=False,
+            isLaborOnly=True,
+            isService=False,
+            program=program
+        )
+
+        volunteerEvent = Event.create(
+            name="Volunteer event",
+            term=2,
+            description="Volunteer event",
+            timeStart="18:00:00",
+            timeEnd="21:00:00",
+            location="The moon",
+            startDate="2021-12-13",
+            isAllVolunteerTraining=False,
+            isLaborOnly=False,
+            isService=True,
+            program=program
+        )
+
+        laborVolunteerEvent = Event.create(
+            name="Labor volunteer event",
+            term=2,
+            description="Labor and volunteer event",
+            timeStart="18:00:00",
+            timeEnd="21:00:00",
+            location="The moon",
+            startDate="2021-12-14",
+            isAllVolunteerTraining=False,
+            isLaborOnly=True,
+            isService=True,
+            program=program
+        )
+
+        EventParticipant.create(user=user, event=laborEvent)
+        EventParticipant.create(user=user, event=volunteerEvent)
+        EventParticipant.create(user=user, event=laborVolunteerEvent)
+
+        result = getParticipatedEventsForUser(user)
+
+        participatedTypes = {
+            event.name: event.participatedType for event in result
+        }
+
+        assert participatedTypes["Labor shift"] == "Labor"
+        assert participatedTypes["Volunteer event"] == "Volunteer"
+        assert participatedTypes["Labor volunteer event"] == "Labor & Volunteer"
+
+        transaction.rollback()
+
+
+@pytest.mark.integration
 def test_getPreviousRecurringEventData():
     with mainDB.atomic() as transaction:
 

--- a/tests/code/test_events.py
+++ b/tests/code/test_events.py
@@ -1085,6 +1085,21 @@ def test_getParticipatedEventsForUser_participated_types():
             program=program
         )
 
+        allVolunteerTrainingEvent = Event.create(
+            name="All Volunteer Training",
+            term=2,
+            description="All volunteer training event",
+            timeStart="18:00:00",
+            timeEnd="21:00:00",
+            location="The moon",
+            startDate="2021-12-15",
+            isAllVolunteerTraining=True,
+            isLaborOnly=False,
+            isService=False,
+            program=program
+        )
+
+        EventParticipant.create(user=user, event=allVolunteerTrainingEvent)
         EventParticipant.create(user=user, event=laborEvent)
         EventParticipant.create(user=user, event=volunteerEvent)
         EventParticipant.create(user=user, event=laborVolunteerEvent)
@@ -1098,6 +1113,7 @@ def test_getParticipatedEventsForUser_participated_types():
         assert participatedTypes["Labor shift"] == "Labor"
         assert participatedTypes["Volunteer event"] == "Volunteer"
         assert participatedTypes["Labor volunteer event"] == "Labor & Volunteer"
+        assert participatedTypes["All Volunteer Training"] == "Volunteer"
 
         transaction.rollback()
 


### PR DESCRIPTION
## Issue Description

Fixes #1631
- In participation history accordion on the user's page, there should be a participation type: volunteer, labor, attendee

## Changes

- Added participation type table in Sidebar > Search Student > User profile > participation History drop down

 <img width="1369" height="590" alt="image" src="https://github.com/user-attachments/assets/0744f992-b2f0-4408-8d9b-29c9c806f5db" />

- Refactored the getParticipatedEventsForUser(user) function to also add the column of event participant type and if the event is for volunteer the student participation type is volunteer, if the event is labor only it is labor else it is attendees.

- Added test case for getParticipatedEventsForUser function and checked the returned participation types.

- Rationale: This implementation can only be accurate if the eventParticiapant table has a new column which is participant type and we would need a script to populate it. However, this implementation is to give an approximation before the full implementation. 

## Testing

- Switch to the participationType - `git checkout participationType`
- Pull the changes - `git pull` & `git fetch origin`
- Reset the test database - `database/reset_database.sh test`
- Test the case - `tests/run_tests.sh`
- Then reset the database - `database/reset_database.sh from-backup`
- Run the application - `flask run`
- Go to Sidebar > Search Student > User profile > participation History drop down to see the changes