### PR TITLE
Removed labor meetings from participation history

### DIFF
--- a/app/logic/events.py
+++ b/app/logic/events.py
@@ -398,6 +398,10 @@ def getParticipatedEventsForUser(user):
                       Used in testing, defaults to the current timestamp.
         :return: A list of Event objects
     """
+
+    eventName = fn.LOWER(Event.name)
+    checkIfLaborMeeting = eventName.contains("labor meeting")
+
     participatedEvents = (Event.select(Event, Program.programName, Case(None, (
                                ((Event.isLaborOnly | Event.name.contains("Labor")) & Event.isService, "Labor & Volunteer"),                                
                                ((Event.isLaborOnly | Event.name.contains("Labor")), "Labor"),
@@ -405,7 +409,7 @@ def getParticipatedEventsForUser(user):
                                .join(Program, JOIN.LEFT_OUTER).switch()
                                .join(EventParticipant)
                                .where(EventParticipant.user == user,
-                                      Event.isAllVolunteerTraining == False, Event.deletionDate == None)
+                                      Event.isAllVolunteerTraining == False, Event.deletionDate == None, ~checkIfLaborMeeting)
                                .order_by(Event.startDate, Event.name))
     allVolunteer = (Event.select(Event, "", Value("Volunteer").alias("participatedType"))
                          .join(EventParticipant)


### PR DESCRIPTION
Fixes #1683 

There was a request to remove labor meeting events from the Participation history. And also, those labor meetings should be tracked in reports for each academic year per each term. The problem with removing it from participation history was inconsistency in naming of labor meetings and also filtering: sometimes they are named "CELTS labor meeting" or "Labor meeting(date)", so it was confusing to remove Labor only events as there are trainings that are also filtered the exact same way.

## Changes

- Added a new function to exclude anything labeled labor meeting
- Got rid of labor meetings from participation history, while preserving trainings

## Testing

- Go to the user profile from backup data, such as Kai Craig
- Go to participation history
- Check if there are no labor meetings
- Download the report for AY 2025-2026, and find the column Labor Meetings
- Check their name, Kai Craig, as an attendee (confirming that there is data with labor meetings under their name)