### PR TITLE
Fixed rendering error in the 'On Transcript' column for StudentStaff

### DIFF
--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -208,7 +208,9 @@
                 <th scope="col">Training</th>
                 {% if g.current_user.isCeltsAdmin or g.current_user.isCeltsStudentStaff%}
                   <th scope="col">Eligibility</th>
-                  <th scope="col">On Transcript</th>
+                  {% if g.current_user.isCeltsAdmin%}
+                    <th scope="col">On Transcript</th>
+                    {% endif %}
                 {% endif %}
 
               </tr>
@@ -244,7 +246,7 @@
                     {% endif %}
                     </td>
                    
-                    {% if g.current_user.isCeltsAdmin or g.current_user.isCeltsStudentStaff %}
+                    {% if g.current_user.isCeltsAdmin %}
                         <td class="onTranscript">
                           <input class="form-check-input onTranscriptCheckbox ms-5" name="onTranscriptCheckbox" id="onTranscriptCheckbox" type="checkbox" data-programid="{{row.program.id}}"
                           data-username="{{volunteer.username}}" {% if row.isNotBanned %}checked disabled{% endif %} {% if row.onTranscript %} checked {% endif %}/>

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -244,7 +244,7 @@
                     {% endif %}
                     </td>
                    
-                    {% if g.current_user.isCeltsAdmin %}
+                    {% if g.current_user.isCeltsAdmin or g.current_user.isCeltsStudentStaff %}
                         <td class="onTranscript">
                           <input class="form-check-input onTranscriptCheckbox ms-5" name="onTranscriptCheckbox" id="onTranscriptCheckbox" type="checkbox" data-programid="{{row.program.id}}"
                           data-username="{{volunteer.username}}" {% if row.isNotBanned %}checked disabled{% endif %} {% if row.onTranscript %} checked {% endif %}/>


### PR DESCRIPTION
## Issue Description

Fixes #1441
- The table wasn't displaying the buttons in the "On Transcript" column for the student staff; however, it still showed the header and caused the missing space.
- For all the other types of users, it was displaying information correctly.

## Changes

- We revoked access to the student staff to see the transcript buttons.
- Transcript buttons are only viewable to staff and admins.

## Testing

- Checked that it's working with every single user and checked that the buttons were working correctly in each case.