### PR TITLE
Changed wording of Manage Proposals to My Proposals if the user is a student.

### DIFF
--- a/app/templates/minor/profile.html
+++ b/app/templates/minor/profile.html
@@ -32,7 +32,7 @@
         </li>
         <li class="col-md-3 col-12 nav-item" role="presentation">
           <button class="nav-link {{ 'active' if activeTab == 'manageProposals' else '' }}" id="manageProposals"
-            data-bs-toggle="pill" data-bs-target="#pills-manageProposals" type="button" role="tab" aria-controls="pills-manageProposals" aria-selected="{{'true' if activeTab == 'manageProposals' else 'false'}}">{{ 'My Proposals' if g.current_user.isStudent else 'Manage Proposals' }}</button>
+            data-bs-toggle="pill" data-bs-target="#pills-manageProposals" type="button" role="tab" aria-controls="pills-manageProposals" aria-selected="{{'true' if activeTab == 'manageProposals' else 'false'}}">{{ 'My Proposals' if g.current_user.isStudent and g.current_user == user else 'Manage Proposals' }}</button>
         </li>
       </ul>
     </div>

--- a/app/templates/minor/profile.html
+++ b/app/templates/minor/profile.html
@@ -32,7 +32,7 @@
         </li>
         <li class="col-md-3 col-12 nav-item" role="presentation">
           <button class="nav-link {{ 'active' if activeTab == 'manageProposals' else '' }}" id="manageProposals"
-            data-bs-toggle="pill" data-bs-target="#pills-manageProposals" type="button" role="tab" aria-controls="pills-manageProposals" aria-selected="{{'true' if activeTab == 'manageProposals' else 'false'}}">{{ 'My Proposals' if g.current_user.isStudent and g.current_user == user else 'Manage Proposals' }}</button>
+            data-bs-toggle="pill" data-bs-target="#pills-manageProposals" type="button" role="tab" aria-controls="pills-manageProposals" aria-selected="{{'true' if activeTab == 'manageProposals' else 'false'}}">{{ 'My Proposals' if g.current_user == user else 'Manage Proposals' }}</button>
         </li>
       </ul>
     </div>

--- a/app/templates/minor/profile.html
+++ b/app/templates/minor/profile.html
@@ -32,7 +32,7 @@
         </li>
         <li class="col-md-3 col-12 nav-item" role="presentation">
           <button class="nav-link {{ 'active' if activeTab == 'manageProposals' else '' }}" id="manageProposals"
-            data-bs-toggle="pill" data-bs-target="#pills-manageProposals" type="button" role="tab" aria-controls="pills-manageProposals" aria-selected="{{'true' if activeTab == 'manageProposals' else 'false'}}">Manage Proposals</button>
+            data-bs-toggle="pill" data-bs-target="#pills-manageProposals" type="button" role="tab" aria-controls="pills-manageProposals" aria-selected="{{'true' if activeTab == 'manageProposals' else 'false'}}">{{ 'My Proposals' if g.current_user.isStudent else 'Manage Proposals' }}</button>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## Issue Description

Fixes issue #1749 
- Student navigating in their CCE Minor Profile should have My Proposals instead of Manage Proposal within the two tabs. This is to improve clarity. Wording for admin can remain unchanged.

## Changes

- Added Jinja code in the profile.html Manage Proposals tab that changes the text to "My Proposals" if the user is a student. Otherwise, the text will read "Manage Proposals" (it should remain this way for admins). 

## Testing

- To test for students:
  - In My Profile, click on the Community & Civic Engagement Minor tab.
  - Toggle on the "Are you interested in the CCE Minor?".
  - Reload the page.
  - Click the newly appeared Manage CCE Minor button next to the View Service Transcript button.
  - Check the second tab to see if it says My Proposals.
- To test for Admin:
  - Click on the Admin button on the sidebar
  - Select Minor Management
  - Click on the name of a student highlighted in blue.
  - On the new page, check to see if the second tab says Manage Proposals.