### PR TITLE
solved issue service hours not being displayed in participation history

### DIFF
--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -233,7 +233,10 @@ def viewUsersProfile(username):
         managersProgramDict = getManagerProgramDict(g.current_user)
         managersList = [id[1] for id in managersProgramDict.items()]
         totalSustainedEngagements = getEngagementTotal(getCommunityEngagementByTerm(volunteer))
-        eventparticipant = list(EventParticipant.select(EventParticipant.hoursEarned).join(Event).where(EventParticipant.user == volunteer, EventParticipant.event == Event.id,).order_by(Event.id.asc()))
+        eventParticipant = list(EventParticipant.select(EventParticipant.hoursEarned)
+                                                .join(Event)
+                                                .where(EventParticipant.user == volunteer, EventParticipant.event == Event.id,)
+                                                .order_by(Event.id.asc()))
 
         return render_template ("/main/userProfile.html",
                                 username=username,
@@ -253,7 +256,7 @@ def viewUsersProfile(username):
                                 managersList = managersList,
                                 participatedInLabor = getCeltsLaborHistory(volunteer),
                                 totalSustainedEngagements = totalSustainedEngagements,
-                                eventparticipant = eventparticipant
+                                eventParticipant = eventParticipant
                             )
     abort(403)
 

--- a/app/controllers/main/routes.py
+++ b/app/controllers/main/routes.py
@@ -233,6 +233,7 @@ def viewUsersProfile(username):
         managersProgramDict = getManagerProgramDict(g.current_user)
         managersList = [id[1] for id in managersProgramDict.items()]
         totalSustainedEngagements = getEngagementTotal(getCommunityEngagementByTerm(volunteer))
+        eventparticipant = list(EventParticipant.select(EventParticipant.hoursEarned).join(Event).where(EventParticipant.user == volunteer, EventParticipant.event == Event.id,).order_by(Event.id.asc()))
 
         return render_template ("/main/userProfile.html",
                                 username=username,
@@ -252,6 +253,7 @@ def viewUsersProfile(username):
                                 managersList = managersList,
                                 participatedInLabor = getCeltsLaborHistory(volunteer),
                                 totalSustainedEngagements = totalSustainedEngagements,
+                                eventparticipant = eventparticipant
                             )
     abort(403)
 

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -168,20 +168,20 @@
                 <th scope="col">Program</th>
                 <th scope="col">Event Name</th>
                 <th scope="col">Participation Type</th>
-                <th scope="col">Event Date</th>
                 <th scope="col">Service Hours</th>
+                <th scope="col">Event Date</th>
               </thead>
               {% for event in participatedEvents %}
               <tr>
                 <td>{{event.programName}}</td>
                 <td><a href= '/event/{{event.id}}/view' class="link-primary">{{event.name}}</a></td>
                 <td>{{event.participatedType}}</td>
-                <td nowrap>{{event.startDate.strftime('%m/%d/%Y')}}</td>
                 {% if event.participatedType == 'Volunteer' %}
                   <td>{{eventParticipant[loop.index0].hoursEarned}}</td>
                 {% else %}
-                  <td>-</td>
+                  <td>N/A</td>
                 {% endif %}
+                <td nowrap>{{event.startDate.strftime('%m/%d/%Y')}}</td>
               </tr>
               {% endfor %}
               {% else %}

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -169,6 +169,7 @@
                 <th scope="col">Event Name</th>
                 <th scope="col">Participation Type</th>
                 <th scope="col">Event Date</th>
+                <th scope="col">Service Hours</th>
               </thead>
               {% for event in participatedEvents %}
               <tr>
@@ -176,6 +177,11 @@
                 <td><a href= '/event/{{event.id}}/view' class="link-primary">{{event.name}}</a></td>
                 <td>{{event.participatedType}}</td>
                 <td nowrap>{{event.startDate.strftime('%m/%d/%Y')}}</td>
+                {% if event.participatedType == 'Volunteer' %}
+                  <td>{{eventparticipant[loop.index0].hoursEarned}}</td>
+                {% else %}
+                  <td>-</td>
+                {% endif %}
               </tr>
               {% endfor %}
               {% else %}

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -178,7 +178,7 @@
                 <td>{{event.participatedType}}</td>
                 <td nowrap>{{event.startDate.strftime('%m/%d/%Y')}}</td>
                 {% if event.participatedType == 'Volunteer' %}
-                  <td>{{eventparticipant[loop.index0].hoursEarned}}</td>
+                  <td>{{eventParticipant[loop.index0].hoursEarned}}</td>
                 {% else %}
                   <td>-</td>
                 {% endif %}


### PR DESCRIPTION
## 

Fixes issue #<1742>
- there was an issue in celts where service hours were not being displayed in participation history, making it streneous for the user to find their hours and they had to go to the service transcript


## Changes

- added peewee query to find the hours for the specified event, by ascending order 
- 
<img width="1395" height="635" alt="image" src="https://github.com/user-attachments/assets/86d0f5e6-b8a2-4701-b4b4-39f5d64c46d5" />
<img width="1413" height="611" alt="image" src="https://github.com/user-attachments/assets/0d263097-ae21-4947-9a6c-fc3a3323e70e" />


## Testing

- reset the databse and ran it with no issues
-