### PR TITLE
Fixing the List of Summer Terms on the Request Summer Proposal page 

### DIFF
--- a/app/controllers/minor/routes.py
+++ b/app/controllers/minor/routes.py
@@ -117,13 +117,16 @@ def createSummerExperienceRequest(username):
         createSummerExperience(username, request.form)
         flash("Proposal successfully created.", "success")
         return redirect(url_for('minor.viewCceMinor', username=username, tab="manageProposals"))
+
+    student   = User.get_by_id(username)
+    year_name = User.rawClassLevel
     
     summerTerms = selectSurroundingTerms(g.current_term, summerOnly=True)
 
     return render_template("minor/summerExperience.html",
                             selectableTerms = summerTerms,
                             contentAreas = [],
-                            user = User.get_by_id(username),
+                            user = student,
                             )
 
 @minor_bp.route('/cceMinor/<username>/getEngagementInformation/<type>/<term>/<id>', methods=['GET'])

--- a/app/logic/utils.py
+++ b/app/logic/utils.py
@@ -36,6 +36,42 @@ def selectSurroundingTerms(currentTerm, prevTerms=2, summerOnly=False):
 
     return surroundingTerms
 
+def selectAllSummerTerms(currentTerm, student):
+    """
+    Selects all summer terms for CCE Minor. 
+    """
+    year_name = student.rawClassLevel
+    timeOrder = currentTerm.timeOrder
+
+    match year_name: 
+        case "Freshman":    year = 1, 
+        case "Sophomore":   year = 2, 
+        case "Junior":      year = 3, 
+        case "Senior":      year = 4
+    
+    match timeOrder[1]: 
+        case 1: timeOfTheYear = "Fall"
+        case 2: timeOfTheYear = "Spring"
+        case 3: timeOfTheYear = "Summer"
+
+    if student.hasGraduated: 
+        return []
+    elif timeOfTheYear == "Fall" and year == 1:
+        firstSummer = currentTerm.year + 1
+        lastSummer = currentTerm.year + 3
+    else: 
+        firstSummer = currentTerm.year 
+        lastSummer = currentTerm.year + (4 - year) 
+        # because we do not know whether the student came to Berea in the Fall or in the Spring, 
+        # we have an extra summer in the list just in case. 
+    
+    surroundingTerms = (Term.select()
+                            .where(Term.year >= firstSummer, Term.year <= lastSummer)
+                            .order_by(Term.termOrder)
+                            .where(Term.isSummer))
+
+    return surroundingTerms
+
 def getStartofCurrentAcademicYear(currentTerm):
     if ("Summer" in currentTerm.description) or ("Spring" in currentTerm.description):
         fallTerm = Term.select().where(Term.year==currentTerm.year-1, Term.description == f"Fall {currentTerm.year-1}").get()

--- a/setup.sh
+++ b/setup.sh
@@ -42,3 +42,8 @@ export FLASK_APP=run.py
 export APP_ENV=development
 export FLASK_RUN_PORT=8080
 export FLASK_RUN_HOST=0.0.0.0   # To allow external routing to the application for development
+
+
+
+
+


### PR DESCRIPTION
## Issue Description

Fixes issue #1747 
- If you request summer experience on a CCE Minor Profile page, you don't have enough Summer terms to choose from 

## Changes

- There are now more Summer Terms options for the CCE Minor Proposal Form
- The options reflect the academic year of a student (for example, if they are a freshman, they will 4 options, but if they are not, they will have less).

## Testing

1. Go to Admin > Minor Management
2. Choose different students on the CCE Minor Progress list/table
3. Click on the Request Summer Proposal button
4. Click on the Summer Year dropdown
5. Make sure that the displayed years match the Student's academic year