### PR TITLE
Celts labor api

### DIFF
--- a/app/controllers/minor/routes.py
+++ b/app/controllers/minor/routes.py
@@ -29,6 +29,9 @@ def viewCceMinor(username):
     """
     Load minor management page with community engagements and summer experience
     """
+    if not (g.current_user.isAdmin or g.current_user.username == username or g.current_user.isCeltsStudentStaff):
+        return abort(403)
+
     sustainedEngagementByTerm = getCommunityEngagementByTerm(username)
 
     activeTab = request.args.get("tab", "sustainedCommunityEngagements")

--- a/app/logic/celtsLabor.py
+++ b/app/logic/celtsLabor.py
@@ -125,7 +125,7 @@ def getCeltsLaborHistory(volunteer):
                                               Term.isSummer)
                                       .join(Term, on=(CeltsLabor.term == Term.id))
                                       .where(CeltsLabor.user == volunteer)
-                                      .order_by(Term.id.asc()))
+                                      .order_by(Term.termOrder.asc()))
     termsByAcademicYear = {}
     for position in laborHistoryList:
         if position.term.isSummer:

--- a/app/logic/celtsLabor.py
+++ b/app/logic/celtsLabor.py
@@ -15,8 +15,10 @@ def getCeltsLaborFromLsf():
 
     """
     try: 
-        lsfUrl = f"{app.config['lsf_url'].strip('/')}/api/org/2084"
+        # lsfUrl = f"{app.config['lsf_url'].strip('/')}/api/org/2084"
+        lsfUrl = "http://127.0.0.1:8989/api/org/2084"
         response = requests.get(lsfUrl)
+        print("jinja", response.json())
         return response.json()
     except json.decoder.JSONDecodeError: 
         print(f'Response from {lsfUrl} was not JSON.\n' + response.text)
@@ -117,14 +119,37 @@ def refreshCeltsLaborRecords(laborDict):
 def getCeltsLaborHistory(volunteer):
     
     laborHistoryList = list(CeltsLabor.select(CeltsLabor.positionTitle, 
+                                              CeltsLabor.id,
                                               Term.description, 
                                               Term.academicYear, 
                                               Term.isSummer)
                                       .join(Term, on=(CeltsLabor.term == Term.id))
-                                      .where(CeltsLabor.user == volunteer))
-    
+                                      .where(CeltsLabor.user == volunteer)
+                                      .order_by(Term.id.asc()))
+    termsByAcademicYear = {}
+    for position in laborHistoryList:
+        if position.term.isSummer:
+            continue
+        academicYear = position.term.academicYear
+        description = position.term.description
+        if academicYear not in termsByAcademicYear:
+            termsByAcademicYear[academicYear] = {"Fall": False,"Spring": False}
+        if "Fall" in description:
+            termsByAcademicYear[academicYear]["Fall"] = True
+        elif "Spring" in description:
+            termsByAcademicYear[academicYear]["Spring"] = True
     laborHistoryDict= {}
-    for position in laborHistoryList: 
-        laborHistoryDict[position.positionTitle] = position.term.description if position.term.isSummer else position.term.academicYear
-
+    for position in laborHistoryList:
+        description = position.term.description
+        academicYear = position.term.academicYear
+        if position.term.isSummer:
+            positionTerm = description
+        else:
+            hasFall = termsByAcademicYear[academicYear]["Fall"]
+            hasSpring = termsByAcademicYear[academicYear]["Spring"]
+            if hasFall and hasSpring:
+                positionTerm = description
+            else:
+                positionTerm = f"AY {academicYear}"
+        laborHistoryDict[position.id] = (position.positionTitle,positionTerm)
     return laborHistoryDict

--- a/app/logic/celtsLabor.py
+++ b/app/logic/celtsLabor.py
@@ -15,10 +15,8 @@ def getCeltsLaborFromLsf():
 
     """
     try: 
-        # lsfUrl = f"{app.config['lsf_url'].strip('/')}/api/org/2084"
-        lsfUrl = "http://127.0.0.1:8989/api/org/2084"
+        lsfUrl = f"{app.config['lsf_url'].strip('/')}/api/org/2084"
         response = requests.get(lsfUrl)
-        print("jinja", response.json())
         return response.json()
     except json.decoder.JSONDecodeError: 
         print(f'Response from {lsfUrl} was not JSON.\n' + response.text)

--- a/app/logic/searchUsers.py
+++ b/app/logic/searchUsers.py
@@ -8,14 +8,13 @@ def searchUsers(query, category=None):
     '''
     # add wildcards to each piece of the query
     splitSearch = query.strip().split()
-    firstName = splitSearch[0] + "%"
-    lastName = " ".join(splitSearch[1:]) +"%"
-
-    if len(splitSearch) == 1: # search for query in first OR last name
-        searchWhere = (User.firstName ** firstName | User.lastName ** firstName | User.username ** splitSearch)
-    else:                     # search for first AND last name
-        searchWhere = (User.firstName ** firstName & User.lastName ** lastName)
-
+    fullSearch = " ".join(splitSearch) + "%"
+    searchWhere = (User.firstName ** fullSearch | User.lastName ** fullSearch | User.username ** fullSearch)
+    for splitIndex in range(1, len(splitSearch)):
+        firstName = " ".join(splitSearch[:splitIndex]) + "%"
+        lastName = " ".join(splitSearch[splitIndex:]) + "%"
+        searchWhere |= (User.firstName ** firstName & User.lastName ** lastName)
+    
     if category == "instructor":
         userWhere = (User.isFaculty | User.isStaff)
     elif category == "admin":

--- a/app/templates/main/userProfile.html
+++ b/app/templates/main/userProfile.html
@@ -282,8 +282,8 @@
             {% if participatedInLabor %}
             <div class="col-md-6">
               <h5>CELTS Labor History:</h5>
-              {% for program, term in participatedInLabor.items() %}
-                <p>{{term}}: {{program}}</p>
+              {% for positionTitle, term in participatedInLabor.values() %}
+                <p>{{term}}: {{positionTitle}}</p>
               {% endfor %}
             </div>
             {% endif %}

--- a/app/templates/sidebar.html
+++ b/app/templates/sidebar.html
@@ -105,7 +105,7 @@
           <select name="newuser" class="form-select" style="margin-bottom: 10px" onchange="this.form.submit()">>
             <option {{"selected" if g.current_user.username == config.default_user }} value="{{config.default_user}}">Default User: {{config.default_user}}</option>
             <option {{"selected" if g.current_user.username == "ramsayb2"}} value="ramsayb2">Admin: ramsayb2</option>
-            <option {{"selected" if g.current_user.username == "neillz"}} value="neillz">Student Staff: neillz</option>
+            <option {{"selected" if g.current_user.username == "velazquezdiaza"}} value="velazquezdiaza">Student Staff: velazquezdiaza</option>
             <option {{"selected" if g.current_user.username == "ayisie"}} value="ayisie">Student: ayisie</option>
             <option {{"selected" if g.current_user.username == "heggens"}} value="heggens">Faculty: heggens</option>
           </select>

--- a/tests/code/test_celtsLabor.py
+++ b/tests/code/test_celtsLabor.py
@@ -244,13 +244,24 @@ def test_getCeltsLaborHistory():
                           isAcademicYear = True)
 
 
-        testDataAyisieHistory = {"Bonner Manager": "Summer 2021"}
+        testDataAyisieHistory = [('Bonner Manager', 'Summer 2021')]
         getAyisieHistory = getCeltsLaborHistory(ayisie)
 
-        testDataMupotsalHistory = {"Habitat For Humanity Cord.": "2020-2021"}
+        testDataMupotsalHistory = [('Habitat For Humanity Cord.', 'AY 2020-2021')]
         getMupotsalHistory = getCeltsLaborHistory(mupotsal)
 
-        assert getAyisieHistory == testDataAyisieHistory
-        assert getMupotsalHistory == testDataMupotsalHistory
+        assert list(getAyisieHistory.values()) == testDataAyisieHistory
+        assert list(getMupotsalHistory.values()) == testDataMupotsalHistory
+
+        CeltsLabor.create(user = mupotsal, 
+                          positionTitle = "Bonner Manager", 
+                          term = Term.get_by_id(1), 
+                          isAcademicYear = True)
+
+        #this is to test if there are two different celts labor in a academic year it no longers show AY 2020-2021 instead shows Fall and Spring in ascending order
+        testDataMupotsalHistoryFallSpring = [('Bonner Manager', 'Fall 2020'), ('Habitat For Humanity Cord.', 'Spring 2021')]
+        getMupotsalHistory = getCeltsLaborHistory(mupotsal)
+
+        assert list(getMupotsalHistory.values()) == testDataMupotsalHistoryFallSpring
 
         transaction.rollback()


### PR DESCRIPTION
## Issue Description

Fixes issue #https://github.com/BCStudentSoftwareDevTeam/lsf/issues/553
- It appears that the feature that imports CELTS labor positions from LSF is not working. For example, user ramireza2 had a 2024-2025 position with CELTS.
- Normal students can access CCE Minor proposal page
- Student search not searching prefix searches like "Nyan Lin Zaw" or "Emma Mae Grooms"

## Changes

- The API from LSF works it is sending correctly what happened is within getCeltsLaborHistory if the student is working the same position title when the for loops run through the query it keeps replacing the same key within the dictionary with the same position even though the term changes. 
- This is fixed by first sorting through the terms as we want to catch the edge case of  the student having a different position in spring we can now show a separate fall and spring labor position and if they only have fall labor it is assumed as AY 2025-2026. 
- Then the second loop is we use the id as a key and a tuple of term description and position to make sure it doesn't have the same error as before.
- The terms are also in ascending order by termorder.
- For the search there is an ambiguity problem of what could be counted as first name and last name it can be "Emma Mae" and "Grooms" or the name can also be "Emma" and "Mae Grooms" so we fixed that ambiguity problem along with prefix problem in case we type "Emma M" it will still show as "Emma Mae Grooms" as an option.
- For the access problem every student can access it before now only the User themselves, User.isAdmin and User.isStudentStaff can do so.
- I also found out Neillz is no longer a Student Staff so I swithc it with another person who is a Student Staff and not a Celts Admin to fully find it capability.
- Fixed the test case for the getCeltsLaborHistory function with an added test case for a labor change in spring and its expected outcome.

Images:
Before: 

<img width="481" height="387" alt="image" src="https://github.com/user-attachments/assets/b10c8f80-e4ed-4725-9b87-728d9ffda59b" />

After:

<img width="840" height="223" alt="image" src="https://github.com/user-attachments/assets/64b34c18-edc5-47bf-bc9b-b87e8adf5302" />

Search Bar:

<img width="768" height="150" alt="image" src="https://github.com/user-attachments/assets/432e2d4f-0e0f-46c8-8c41-dd0cb5caa1d3" />

## Testing

- Check out the branch `git checkout CELTSLaborInput` and `git pull`
- Reset the Database to `database/reset_database.sh test` and run the test `tests/run_tests.sh`
- Then switch back to `database/reset_database.sh from-backup`

### Connecting LSF and CELTS
- Go to LSF and run the program make sure to flask run it and get the ip address of it for example : http://127.0.0.1:8989 paste that address into lsfURL in getCeltsLaborFromLsf. For me I commented out LsfUrl in the code and use this: lsfUrl = "http://127.0.0.1:8989/api/org/2084"

Code example:

`# lsfUrl = f"{app.config['lsf_url'].strip('/')}/api/org/2084"`
`lsfUrl = "http://127.0.0.1:8989/api/org/2084"`

- Then I go to LSF and in the lsf > app > config > secret_config.yaml I pasted the valid request ip as '127.0.0.1'. 

### Testing the connection:

-From your CELTS run python3 app/scripts/import_labor_from_lsf.py this will pull the labor data from LSF. Now any approved form in LSF of the student will be pulled and it should display on CELTS. For the edge case like having new spring labor go ahead and create and approve the labor status form. Then run the import_labor_from_lsf.py script. It will pull the updated one and you will see the changes.

### Testing the search bar
-Navigate to sidebar > student search  and search either of these names "Emma M" or " Nyan Li" it will show those names. 

### Testing CCEMinor portal
-Navigate to sidebar > student search  and search Cole Collins and go to his CCE Minor page. Copy the URL : http://127.0.0.1:8080/profile/collinsc2/cceMinor then switch to student ayisie and paste it. 
- It should deny for ayisie while display for celtsadmin and studentstaff. 